### PR TITLE
Fixed permissions issue

### DIFF
--- a/.devcontainer/features/local_provider_dev/install.sh
+++ b/.devcontainer/features/local_provider_dev/install.sh
@@ -8,6 +8,9 @@ cp terraform.rc /go/bin/
 # install tfplugindocs
 go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest
 
+# install mockgen
+go install github.com/golang/mock/mockgen@latest
+
 # fix permissions issue running as vscode and not root
 sudo chmod -R 777 /go/pkg/mod
 mkdir /workspaces/ && mkdir /workspaces/terraform-provider-power-platform/ 
@@ -16,6 +19,3 @@ sudo chown -R vscode /workspaces/terraform-provider-power-platform/
 # install mkdocs
 sudo apt update && sudo apt install -y python3-pip
 pip3 install mkdocs
-
-# install mockgen
-go install github.com/golang/mock/mockgen@latest


### PR DESCRIPTION
running `go install` again as root was undoing the `chmod`.  Moved the go install commands together and made sure that chmod happened afterwards.

Fixes #57 