### PR TITLE
adding headers support to api calls

### DIFF
--- a/internal/powerplatform/api/api_bapi.go
+++ b/internal/powerplatform/api/api_bapi.go
@@ -2,6 +2,7 @@ package powerplatform
 
 import (
 	"context"
+	"net/http"
 
 	common "github.com/microsoft/terraform-provider-power-platform/internal/powerplatform/common"
 )
@@ -28,10 +29,10 @@ func (client *BapiClientApi) GetConfig() *common.ProviderConfig {
 	return client.baseApi.Config
 }
 
-func (client *BapiClientApi) Execute(ctx context.Context, method string, url string, body interface{}, acceptableStatusCodes []int, responseObj interface{}) (*ApiHttpResponse, error) {
+func (client *BapiClientApi) Execute(ctx context.Context, method string, url string, headers http.Header, body interface{}, acceptableStatusCodes []int, responseObj interface{}) (*ApiHttpResponse, error) {
 	token, err := client.baseApi.InitializeBase(ctx, client.auth)
 	if err != nil {
 		return nil, err
 	}
-	return client.baseApi.ExecuteBase(ctx, token, method, url, body, acceptableStatusCodes, responseObj)
+	return client.baseApi.ExecuteBase(ctx, token, method, url, headers, body, acceptableStatusCodes, responseObj)
 }

--- a/internal/powerplatform/api/api_base.go
+++ b/internal/powerplatform/api/api_base.go
@@ -29,7 +29,7 @@ func NewApiClientBase(config *common.ProviderConfig, baseAuth *AuthBase) *ApiCli
 	}
 }
 
-func (client *ApiClientBase) ExecuteBase(ctx context.Context, token, method string, url string, body interface{}, acceptableStatusCodes []int, responseObj interface{}) (*ApiHttpResponse, error) {
+func (client *ApiClientBase) ExecuteBase(ctx context.Context, token, method string, url string, headers http.Header, body interface{}, acceptableStatusCodes []int, responseObj interface{}) (*ApiHttpResponse, error) {
 	var bodyBuffer io.Reader = nil
 	if body != nil {
 		bodyBytes, err := json.Marshal(body)
@@ -43,7 +43,7 @@ func (client *ApiClientBase) ExecuteBase(ctx context.Context, token, method stri
 	if err != nil {
 		return nil, err
 	}
-	apiResponse, err := client.doRequest(token, request)
+	apiResponse, err := client.doRequest(token, request, headers)
 	if err != nil {
 		return nil, err
 	}
@@ -68,8 +68,12 @@ func (client *ApiClientBase) ExecuteBase(ctx context.Context, token, method stri
 	return apiResponse, nil
 }
 
-func (client *ApiClientBase) doRequest(token string, request *http.Request) (*ApiHttpResponse, error) {
+func (client *ApiClientBase) doRequest(token string, request *http.Request, headers http.Header) (*ApiHttpResponse, error) {
 	apiHttpResponse := &ApiHttpResponse{}
+
+	if headers != nil {
+		request.Header = headers
+	}
 
 	if request.Header.Get("Content-Type") == "" {
 		request.Header.Set("Content-Type", "application/json")

--- a/internal/powerplatform/api/api_dataverse.go
+++ b/internal/powerplatform/api/api_dataverse.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	common "github.com/microsoft/terraform-provider-power-platform/internal/powerplatform/common"
@@ -63,10 +64,10 @@ func (client *DataverseClientApi) Initialize(ctx context.Context, environmentUrl
 	}
 }
 
-func (client *DataverseClientApi) Execute(ctx context.Context, environmentUrl, method string, url string, body interface{}, acceptableStatusCodes []int, responseObj interface{}) (*ApiHttpResponse, error) {
+func (client *DataverseClientApi) Execute(ctx context.Context, environmentUrl, method string, url string, headers http.Header, body interface{}, acceptableStatusCodes []int, responseObj interface{}) (*ApiHttpResponse, error) {
 	token, err := client.Initialize(ctx, environmentUrl)
 	if err != nil {
 		return nil, err
 	}
-	return client.baseApi.ExecuteBase(ctx, token, method, url, body, acceptableStatusCodes, responseObj)
+	return client.baseApi.ExecuteBase(ctx, token, method, url, headers, body, acceptableStatusCodes, responseObj)
 }

--- a/internal/powerplatform/api/api_powerplatform.go
+++ b/internal/powerplatform/api/api_powerplatform.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 
+	common "github.com/microsoft/terraform-provider-power-platform/internal/powerplatform/common"
 	models "github.com/microsoft/terraform-provider-power-platform/internal/powerplatform/models"
 )
 
@@ -20,12 +21,16 @@ func NewPowerPlatformClientApi(baseApi *ApiClientBase, auth *PowerPlatformAuth) 
 	}
 }
 
-func (client *PowerPlatformClientApi) Execute(ctx context.Context, method string, url string, body interface{}, acceptableStatusCodes []int, responseObj interface{}) (*ApiHttpResponse, error) {
+func (client *PowerPlatformClientApi) GetConfig() *common.ProviderConfig {
+	return client.baseApi.Config
+}
+
+func (client *PowerPlatformClientApi) Execute(ctx context.Context, method string, url string, headers http.Header, body interface{}, acceptableStatusCodes []int, responseObj interface{}) (*ApiHttpResponse, error) {
 	token, err := client.baseApi.InitializeBase(ctx, client.Auth)
 	if err != nil {
 		return nil, err
 	}
-	return client.baseApi.ExecuteBase(ctx, token, method, url, body, acceptableStatusCodes, responseObj)
+	return client.baseApi.ExecuteBase(ctx, token, method, url, headers, body, acceptableStatusCodes, responseObj)
 }
 
 func (client *PowerPlatformClientApi) GetBillingPolicies(ctx context.Context) ([]models.BillingPolicyDto, error) {
@@ -39,7 +44,7 @@ func (client *PowerPlatformClientApi) GetBillingPolicies(ctx context.Context) ([
 	apiUrl.RawQuery = values.Encode()
 
 	billingPolicies := models.BillingPolicyDtoArray{}
-	_, err := client.Execute(ctx, "GET", apiUrl.String(), nil, []int{http.StatusOK}, &billingPolicies)
+	_, err := client.Execute(ctx, "GET", apiUrl.String(), nil, nil, []int{http.StatusOK}, &billingPolicies)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/powerplatform/services/connectors/api_connectors.go
+++ b/internal/powerplatform/services/connectors/api_connectors.go
@@ -34,7 +34,7 @@ func (client *ConnectorsClient) GetConnectors(ctx context.Context) ([]ConnectorD
 	apiUrl.RawQuery = values.Encode()
 
 	connectorArray := ConnectorDtoArray{}
-	_, err := client.BapiClient.Execute(ctx, "GET", apiUrl.String(), nil, []int{http.StatusOK}, &connectorArray)
+	_, err := client.BapiClient.Execute(ctx, "GET", apiUrl.String(), nil, nil, []int{http.StatusOK}, &connectorArray)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (client *ConnectorsClient) GetConnectors(ctx context.Context) ([]ConnectorD
 		Path:   "/providers/PowerPlatform.Governance/v1/connectors/metadata/unblockable",
 	}
 	unblockableConnectorArray := []UnblockableConnectorDto{}
-	_, err = client.BapiClient.Execute(ctx, "GET", apiUrl.String(), nil, []int{http.StatusOK}, &unblockableConnectorArray)
+	_, err = client.BapiClient.Execute(ctx, "GET", apiUrl.String(), nil, nil, []int{http.StatusOK}, &unblockableConnectorArray)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func (client *ConnectorsClient) GetConnectors(ctx context.Context) ([]ConnectorD
 		Path:   "/providers/PowerPlatform.Governance/v1/connectors/metadata/virtual",
 	}
 	virtualConnectorArray := []VirtualConnectorDto{}
-	_, err = client.BapiClient.Execute(ctx, "GET", apiUrl.String(), nil, []int{http.StatusOK}, &virtualConnectorArray)
+	_, err = client.BapiClient.Execute(ctx, "GET", apiUrl.String(), nil, nil, []int{http.StatusOK}, &virtualConnectorArray)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/powerplatform/services/dlp_policy/api_dlp_policy.go
+++ b/internal/powerplatform/services/dlp_policy/api_dlp_policy.go
@@ -27,7 +27,7 @@ func (client *DlpPolicyClient) GetPolicies(ctx context.Context) ([]DlpPolicyMode
 		Path:   "providers/PowerPlatform.Governance/v2/policies",
 	}
 	policiesArray := DlpPolicyDefinitionDtoArray{}
-	_, err := client.BapiClient.Execute(ctx, "GET", apiUrl.String(), nil, []int{http.StatusOK}, &policiesArray)
+	_, err := client.BapiClient.Execute(ctx, "GET", apiUrl.String(), nil, nil, []int{http.StatusOK}, &policiesArray)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func (client *DlpPolicyClient) GetPolicies(ctx context.Context) ([]DlpPolicyMode
 			Path:   fmt.Sprintf("providers/PowerPlatform.Governance/v2/policies/%s", policy.PolicyDefinition.Name),
 		}
 		policy := DlpPolicyDto{}
-		_, err := client.BapiClient.Execute(ctx, "GET", apiUrl.String(), nil, []int{http.StatusOK}, &policy)
+		_, err := client.BapiClient.Execute(ctx, "GET", apiUrl.String(), nil, nil, []int{http.StatusOK}, &policy)
 		if err != nil {
 			return nil, err
 		}
@@ -61,7 +61,7 @@ func (client *DlpPolicyClient) GetPolicy(ctx context.Context, name string) (*Dlp
 		Path:   fmt.Sprintf("providers/PowerPlatform.Governance/v2/policies/%s", name),
 	}
 	policy := DlpPolicyDto{}
-	_, err := client.BapiClient.Execute(ctx, "GET", apiUrl.String(), nil, []int{http.StatusOK}, &policy)
+	_, err := client.BapiClient.Execute(ctx, "GET", apiUrl.String(), nil, nil, []int{http.StatusOK}, &policy)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (client *DlpPolicyClient) DeletePolicy(ctx context.Context, name string) er
 		Host:   client.BapiClient.GetConfig().Urls.BapiUrl,
 		Path:   fmt.Sprintf("providers/PowerPlatform.Governance/v1/policies/%s", name),
 	}
-	_, err := client.BapiClient.Execute(ctx, "DELETE", apiUrl.String(), nil, []int{http.StatusNoContent}, nil)
+	_, err := client.BapiClient.Execute(ctx, "DELETE", apiUrl.String(), nil, nil, []int{http.StatusNoContent}, nil)
 	if err != nil {
 		return err
 	}
@@ -91,7 +91,7 @@ func (client *DlpPolicyClient) UpdatePolicy(ctx context.Context, name string, po
 	}
 	createdPolicy := DlpPolicyDto{}
 
-	_, err := client.BapiClient.Execute(ctx, "PATCH", apiUrl.String(), policyToCreate, []int{http.StatusAccepted}, &createdPolicy)
+	_, err := client.BapiClient.Execute(ctx, "PATCH", apiUrl.String(), nil, policyToCreate, []int{http.StatusAccepted}, &createdPolicy)
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +244,7 @@ func (client *DlpPolicyClient) CreatePolicy(ctx context.Context, policy DlpPolic
 	}
 
 	createdPolicy := DlpPolicyDto{}
-	_, err := client.BapiClient.Execute(ctx, "POST", apiUrl.String(), policyToCreate, []int{http.StatusCreated}, &createdPolicy)
+	_, err := client.BapiClient.Execute(ctx, "POST", apiUrl.String(), nil, policyToCreate, []int{http.StatusCreated}, &createdPolicy)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/powerplatform/services/environment/api_environment.go
+++ b/internal/powerplatform/services/environment/api_environment.go
@@ -50,7 +50,7 @@ func (client *EnvironmentClient) GetEnvironment(ctx context.Context, environment
 	apiUrl.RawQuery = values.Encode()
 
 	env := EnvironmentDto{}
-	_, err := client.bapiClient.Execute(ctx, "GET", apiUrl.String(), nil, []int{http.StatusOK}, &env)
+	_, err := client.bapiClient.Execute(ctx, "GET", apiUrl.String(), nil, nil, []int{http.StatusOK}, &env)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (client *EnvironmentClient) DeleteEnvironment(ctx context.Context, environm
 		Message: "Deleted using Terraform Provider for Power Platform",
 	}
 
-	_, err := client.bapiClient.Execute(ctx, "DELETE", apiUrl.String(), environmentDelete, []int{http.StatusAccepted}, nil)
+	_, err := client.bapiClient.Execute(ctx, "DELETE", apiUrl.String(), nil, environmentDelete, []int{http.StatusAccepted}, nil)
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func (client *EnvironmentClient) CreateEnvironment(ctx context.Context, environm
 	values := url.Values{}
 	values.Add("api-version", "2023-06-01")
 	apiUrl.RawQuery = values.Encode()
-	apiResponse, err := client.bapiClient.Execute(ctx, "POST", apiUrl.String(), environment, []int{http.StatusAccepted, http.StatusCreated}, nil)
+	apiResponse, err := client.bapiClient.Execute(ctx, "POST", apiUrl.String(), nil, environment, []int{http.StatusAccepted, http.StatusCreated}, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +125,7 @@ func (client *EnvironmentClient) CreateEnvironment(ctx context.Context, environm
 		for {
 
 			lifecycleResponse := EnvironmentLifecycleDto{}
-			apiResponse, err = client.bapiClient.Execute(ctx, "GET", locationHeader, nil, []int{http.StatusOK}, &lifecycleResponse)
+			apiResponse, err = client.bapiClient.Execute(ctx, "GET", locationHeader, nil, nil, []int{http.StatusOK}, &lifecycleResponse)
 			if err != nil {
 				return nil, err
 			}
@@ -171,7 +171,7 @@ func (client *EnvironmentClient) UpdateEnvironment(ctx context.Context, environm
 	values := url.Values{}
 	values.Add("api-version", "2022-05-01")
 	apiUrl.RawQuery = values.Encode()
-	_, err := client.bapiClient.Execute(ctx, "PATCH", apiUrl.String(), environment, []int{http.StatusAccepted}, nil)
+	_, err := client.bapiClient.Execute(ctx, "PATCH", apiUrl.String(), nil, environment, []int{http.StatusAccepted}, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +216,7 @@ func (client *EnvironmentClient) GetEnvironments(ctx context.Context) ([]Environ
 	apiUrl.RawQuery = values.Encode()
 
 	envArray := EnvironmentDtoArray{}
-	_, err := client.bapiClient.Execute(ctx, "GET", apiUrl.String(), nil, []int{http.StatusOK}, &envArray)
+	_, err := client.bapiClient.Execute(ctx, "GET", apiUrl.String(), nil, nil, []int{http.StatusOK}, &envArray)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/powerplatform/services/powerapps/api_powerapps.go
+++ b/internal/powerplatform/services/powerapps/api_powerapps.go
@@ -41,7 +41,7 @@ func (client *PowerAppssClient) GetPowerApps(ctx context.Context, environmentId 
 		apiUrl.RawQuery = values.Encode()
 
 		appsArray := PowerAppDtoArray{}
-		_, err := client.bapiClient.Execute(ctx, "GET", apiUrl.String(), nil, []int{http.StatusOK}, &appsArray)
+		_, err := client.bapiClient.Execute(ctx, "GET", apiUrl.String(), nil, nil, []int{http.StatusOK}, &appsArray)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/powerplatform/services/solution/api_solution.go
+++ b/internal/powerplatform/services/solution/api_solution.go
@@ -43,7 +43,7 @@ func (client *SolutionClient) GetSolutions(ctx context.Context, environmentId st
 	apiUrl.RawQuery = values.Encode()
 
 	solutionArray := SolutionDtoArray{}
-	_, err = client.dataverseClient.Execute(ctx, environmentUrl, "GET", apiUrl.String(), nil, []int{http.StatusOK}, &solutionArray)
+	_, err = client.dataverseClient.Execute(ctx, environmentUrl, "GET", apiUrl.String(), nil, nil, []int{http.StatusOK}, &solutionArray)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (client *SolutionClient) CreateSolution(ctx context.Context, environmentId 
 	}
 
 	stageSolutionResponse := StageSolutionImportResponseDto{}
-	_, err = client.dataverseClient.Execute(ctx, environmentUrl, "POST", apiUrl.String(), stageSolutionRequestBody, []int{http.StatusOK}, &stageSolutionResponse)
+	_, err = client.dataverseClient.Execute(ctx, environmentUrl, "POST", apiUrl.String(), nil, stageSolutionRequestBody, []int{http.StatusOK}, &stageSolutionResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (client *SolutionClient) CreateSolution(ctx context.Context, environmentId 
 		Path:   "/api/data/v9.2/ImportSolutionAsync",
 	}
 	importSolutionResponse := ImportSolutionResponseDto{}
-	_, err = client.dataverseClient.Execute(ctx, environmentUrl, "POST", apiUrl.String(), importSolutionRequestBody, []int{http.StatusOK}, &importSolutionResponse)
+	_, err = client.dataverseClient.Execute(ctx, environmentUrl, "POST", apiUrl.String(), nil, importSolutionRequestBody, []int{http.StatusOK}, &importSolutionResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (client *SolutionClient) CreateSolution(ctx context.Context, environmentId 
 	}
 	for {
 		asyncSolutionPullResponse := AsyncSolutionPullResponseDto{}
-		_, err = client.dataverseClient.Execute(ctx, environmentUrl, "GET", apiUrl.String(), nil, []int{http.StatusOK}, &asyncSolutionPullResponse)
+		_, err = client.dataverseClient.Execute(ctx, environmentUrl, "GET", apiUrl.String(), nil, nil, []int{http.StatusOK}, &asyncSolutionPullResponse)
 		if err != nil {
 			return nil, err
 		}
@@ -206,7 +206,7 @@ func (client *SolutionClient) validateSolutionImportResult(ctx context.Context, 
 	}
 
 	validateSolutionImportResponseDto := ValidateSolutionImportResponseDto{}
-	_, err := client.dataverseClient.Execute(ctx, environmentUrl, "GET", apiUrl.String(), nil, []int{http.StatusOK}, &validateSolutionImportResponseDto)
+	_, err := client.dataverseClient.Execute(ctx, environmentUrl, "GET", apiUrl.String(), nil, nil, []int{http.StatusOK}, &validateSolutionImportResponseDto)
 	if err != nil {
 		return err
 	}
@@ -232,7 +232,7 @@ func (client *SolutionClient) DeleteSolution(ctx context.Context, environmentId 
 		Host:   strings.TrimPrefix(environmentUrl, "https://"),
 		Path:   fmt.Sprintf("/api/data/v9.2/solutions(%s)", solution.Id),
 	}
-	_, err = client.dataverseClient.Execute(ctx, environmentUrl, "DELETE", apiUrl.String(), nil, []int{http.StatusNoContent}, nil)
+	_, err = client.dataverseClient.Execute(ctx, environmentUrl, "DELETE", apiUrl.String(), nil, nil, []int{http.StatusNoContent}, nil)
 	if err != nil {
 		return err
 	}
@@ -252,7 +252,7 @@ func (client *SolutionClient) GetTableData(ctx context.Context, environmentId, t
 	if odataQuery != "" {
 		apiUrl.RawQuery = odataQuery
 	}
-	_, err = client.dataverseClient.Execute(ctx, environmentUrl, "GET", apiUrl.String(), nil, []int{http.StatusOK}, &responseObj)
+	_, err = client.dataverseClient.Execute(ctx, environmentUrl, "GET", apiUrl.String(), nil, nil, []int{http.StatusOK}, &responseObj)
 	if err != nil {
 		return err
 	}
@@ -281,7 +281,7 @@ func (client *SolutionClient) getEnvironment(ctx context.Context, environmentId 
 	apiUrl.RawQuery = values.Encode()
 
 	env := EnvironmentIdDto{}
-	_, err := client.bapiClient.Execute(ctx, "GET", apiUrl.String(), nil, []int{http.StatusOK}, &env)
+	_, err := client.bapiClient.Execute(ctx, "GET", apiUrl.String(), nil, nil, []int{http.StatusOK}, &env)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/powerplatform/services/tenant_settings/api_tenant_settings.go
+++ b/internal/powerplatform/services/tenant_settings/api_tenant_settings.go
@@ -30,7 +30,7 @@ func (client *TenantSettingsClient) GetTenantSettings(ctx context.Context) (*Ten
 	apiUrl.RawQuery = values.Encode()
 
 	tenantSettings := TenantSettingsDto{}
-	_, err := client.bapiClient.Execute(ctx, "POST", apiUrl.String(), nil, []int{http.StatusOK}, &tenantSettings)
+	_, err := client.bapiClient.Execute(ctx, "POST", apiUrl.String(), nil, nil, []int{http.StatusOK}, &tenantSettings)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (client *TenantSettingsClient) UpdateTenantSettings(ctx context.Context, te
 	values.Add("api-version", "2023-06-01")
 	apiUrl.RawQuery = values.Encode()
 
-	_, err := client.bapiClient.Execute(ctx, "POST", apiUrl.String(), tenantSettings, []int{http.StatusOK}, &tenantSettings)
+	_, err := client.bapiClient.Execute(ctx, "POST", apiUrl.String(), nil, tenantSettings, []int{http.StatusOK}, &tenantSettings)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
adding `headers` support to api calls

so, if needed, it's possible to set headers, before making api calls

fixes #127 