### PR TITLE
Fix version # for go tools

### DIFF
--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -76,15 +76,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: Install Provider Linter
+      run: |
+        go install github.com/bflad/tfproviderlint/cmd/tfproviderlint@latest
+        
     - name: Harden Runner
       uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
       with:
         egress-policy: audit
 
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-    - uses: bflad/tfproviderlint-github-action@3d16e28385eb2783700821cdf1b70f9f318bed3d # master
-      with:
-        args: ./...
+    
+#    - uses: bflad/tfproviderlint-github-action@3d16e28385eb2783700821cdf1b70f9f318bed3d # master
+#      with:
+#        args: ./...
+
+    - name: Run Linter
+      run: |
+        tfproviderlint ./...
 
   # run unit tests
   unit_test:

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -93,8 +93,7 @@ jobs:
 
     - name: Run Linter
       run: |
-          echo "$PATH"
-#        /usr/bin/tfproviderlint ./...
+        /usr/bin/tfproviderlint ./...
 
 
   # run unit tests

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -93,7 +93,9 @@ jobs:
 
     - name: Run Linter
       run: |
-        /usr/bin/tfproviderlint ./...
+          echo "$PATH"
+#        /usr/bin/tfproviderlint ./...
+
 
   # run unit tests
   unit_test:

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -93,7 +93,7 @@ jobs:
 
     - name: Run Linter
       run: |
-        tfproviderlint ./...
+        /usr/bin/tfproviderlint ./...
 
   # run unit tests
   unit_test:

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -93,7 +93,9 @@ jobs:
 
     - name: Run Linter
       run: |
-        /usr/bin/tfproviderlint ./...
+        go vet -vettool $(which tfproviderlint) ./...
+
+#      /usr/bin/tfproviderlint ./...
 
 
   # run unit tests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/terraform-provider-power-platform
 
-go 1.21
+go 1.21.9
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1


### PR DESCRIPTION

This pull request includes a minor change to the `go.mod` file. The Go version has been updated from `1.21` to `1.21.9`, ensuring that the project uses the latest patch release of Go 1.21.