### PR TITLE
Allow provider to manage non-public clouds

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -64,6 +64,7 @@ const (
 	EX_POWERAPPS_SCOPE          = "https://service.powerapps.eaglex.ic.gov/.default"
 	EX_POWERPLATFORM_API_DOMAIN = "api.powerplatform.eaglex.ic.gov"
 	EX_POWERPLATFORM_API_SCOPE  = "https://api.powerplatform.eaglex.ic.gov/.default"
+	EX_AUTHORITY_HOST           = "https://login.microsoftonline.eaglex.ic.gov/"
 )
 
 const (
@@ -73,4 +74,5 @@ const (
 	RX_POWERAPPS_SCOPE          = "https://service.powerapps.microsoft.scloud/.default"
 	RX_POWERPLATFORM_API_DOMAIN = "api.powerplatform.microsoft.scloud"
 	RX_POWERPLATFORM_API_SCOPE  = "https://api.powerplatform.microsoft.scloud/.default"
+	RX_AUTHORITY_HOST           = "https://login.microsoftonline.microsoft.scloud/"
 )

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -3,9 +3,74 @@
 
 package settings
 
+// Cloud	BAPI	Power Apps API	Power Platform API	OAuth Authority
+// public	api.bap.microsoft.com	api.powerapps.com	api.powerplatform.com	login.microsoftonline.com
+// gcc	gov.api.bap.microsoft.us	gov.api.powerapps.us	api.gov.powerplatform.microsoft.us	login.microsoftonline.com
+// gcchigh	high.api.bap.microsoft.us	high.api.powerapps.us	api.high.powerplatform.microsoft.us	login.microsoftonline.us
+// dod	api.bap.appsplatform.us	api.apps.appsplatform.us	api.appsplatform.us	login.microsoftonline.us
+// ex	api.bap.eaglex.ic.gov	api.powerapps.eaglex.ic.gov	api.powerplatform.eaglex.ic.gov	login.microsoftonline.eaglex.ic.gov
+// rx	api.bap.microsoft.scloud	api.powerapps.microsoft.scloud	api.powerplatform.microsoft.scloud	login.microsoftonline.microsoft.scloud
+// china	api.bap.partner.microsoftonline.cn	api.powerapps.cn	api.powerplatform.partner.microsoftonline.cn	login.chinacloudapi.cn
+
 const (
-	OAUTH_AUTHORITY_URL      = "https://login.microsoftonline.com/"
-	BAPI_DOMAIN              = "api.bap.microsoft.com"
-	POWERAPPS_API_DOMAIN     = "api.powerapps.com"
-	POWERPLATFORM_API_DOMAIN = "api.powerplatform.com"
+	PUBLIC_OAUTH_AUTHORITY_URL      = "https://login.microsoftonline.com/"
+	PUBLIC_BAPI_DOMAIN              = "api.bap.microsoft.com"
+	PUBLIC_POWERAPPS_API_DOMAIN     = "api.powerapps.com"
+	PUBLIC_POWERAPPS_SCOPE          = "https://service.powerapps.com/.default"
+	PUBLIC_POWERPLATFORM_API_DOMAIN = "api.powerplatform.com"
+	PUBLIC_POWERPLATFORM_API_SCOPE  = "https://api.powerplatform.com/.default"
+)
+
+const (
+	USDOD_OAUTH_AUTHORITY_URL      = "https://login.microsoftonline.us/"
+	USDOD_BAPI_DOMAIN              = "api.bap.appsplatform.us"
+	USDOD_POWERAPPS_API_DOMAIN     = "api.apps.appsplatform.us"
+	USDOD_POWERAPPS_SCOPE          = "https://service.apps.appsplatform.us/.default"
+	USDOD_POWERPLATFORM_API_DOMAIN = "api.appsplatform.us"
+	USDOD_POWERPLATFORM_API_SCOPE  = "https://api.appsplatform.us/.default"
+)
+
+const (
+	USGOV_OAUTH_AUTHORITY_URL      = "https://login.microsoftonline.com/"
+	USGOV_BAPI_DOMAIN              = "gov.api.bap.microsoft.us"
+	USGOV_POWERAPPS_API_DOMAIN     = "gov.api.powerapps.us"
+	USGOV_POWERAPPS_SCOPE          = "https://service.powerapps.us/.default"
+	USGOV_POWERPLATFORM_API_DOMAIN = "api.gov.powerplatform.microsoft.us"
+	USGOV_POWERPLATFORM_API_SCOPE  = "https://api.gov.powerplatform.microsoft.us/.default"
+)
+
+const (
+	USGOVHIGH_OAUTH_AUTHORITY_URL      = "https://login.microsoftonline.us/"
+	USGOVHIGH_BAPI_DOMAIN              = "high.api.bap.microsoft.us"
+	USGOVHIGH_POWERAPPS_API_DOMAIN     = "high.api.powerapps.us"
+	USGOVHIGH_POWERAPPS_SCOPE          = "https://high.service.apps.appsplatform.us/.default"
+	USGOVHIGH_POWERPLATFORM_API_DOMAIN = "api.appsplatform.us"
+	USGOVHIGH_POWERPLATFORM_API_SCOPE  = "https://api.appsplatform.us/.default"
+)
+
+const (
+	CHINA_OAUTH_AUTHORITY_URL      = "https://login.chinacloudapi.cn/"
+	CHINA_BAPI_DOMAIN              = "api.bap.partner.microsoftonline.cn"
+	CHINA_POWERAPPS_API_DOMAIN     = "api.powerapps.cn"
+	CHINA_POWERAPPS_SCOPE          = "https://service.powerapps.cn/.default"
+	CHINA_POWERPLATFORM_API_DOMAIN = "api.powerplatform.partner.microsoftonline.cn"
+	CHINA_POWERPLATFORM_API_SCOPE  = "https://api.powerplatform.partner.microsoftonline.cn/.default"
+)
+
+const (
+	EX_OAUTH_AUTHORITY_URL      = "https://login.microsoftonline.eaglex.ic.gov/"
+	EX_BAPI_DOMAIN              = "api.bap.eaglex.ic.gov"
+	EX_POWERAPPS_API_DOMAIN     = "api.powerapps.eaglex.ic.gov"
+	EX_POWERAPPS_SCOPE          = "https://service.powerapps.eaglex.ic.gov/.default"
+	EX_POWERPLATFORM_API_DOMAIN = "api.powerplatform.eaglex.ic.gov"
+	EX_POWERPLATFORM_API_SCOPE  = "https://api.powerplatform.eaglex.ic.gov/.default"
+)
+
+const (
+	RX_OAUTH_AUTHORITY_URL      = "https://login.microsoftonline.microsoft.scloud/"
+	RX_BAPI_DOMAIN              = "api.bap.microsoft.scloud"
+	RX_POWERAPPS_API_DOMAIN     = "api.powerapps.microsoft.scloud"
+	RX_POWERAPPS_SCOPE          = "https://service.powerapps.microsoft.scloud/.default"
+	RX_POWERPLATFORM_API_DOMAIN = "api.powerplatform.microsoft.scloud"
+	RX_POWERPLATFORM_API_SCOPE  = "https://api.powerplatform.microsoft.scloud/.default"
 )

--- a/docs/guides/app_registration.md
+++ b/docs/guides/app_registration.md
@@ -91,13 +91,15 @@ Or you can add them directly into your App Registration manifest:
  ]
 ```
 
+>! Note: The `resourceAppId` values are the application IDs of the services in the Public cloud.  If you are using a sovereign cloud, you will need to use the appropriate application IDs for those services.
+
 ## Expose API
 
 In "Expose API" menu of your App Registration, you need to define your application ID URI:
 
 - Application ID URI: `api://<client_id>`, for example:
 
-```bash
+```plaintext
 api://powerplatform_provider_terraform
 ```
 
@@ -150,5 +152,5 @@ Or you can add them directly into your App Registration manifest:
 After above steps you should be able to authenticate using Azure CLI:
 
 ```bash
-az login --scope api://powerplatform_provider_terraform/access
+az login --scope api://powerplatform_provider_terraform/.default
 ```

--- a/docs/guides/nonpublic_clouds.md
+++ b/docs/guides/nonpublic_clouds.md
@@ -1,0 +1,41 @@
+---
+page_title: "Authentication: Connecting to non-public sovereign clouds"
+subcategory: "Authentication"
+description: |-
+  <no value>
+---
+
+# Connecting to non-public sovereign clouds
+
+Microsoft offers sovereign clouds (for example [US Government](https://learn.microsoft.com/en-us/power-platform/admin/microsoft-dynamics-365-government) and [China](https://learn.microsoft.com/en-us/power-platform/admin/about-microsoft-cloud-china)) that are physically isolated instances of Power Platform, Entra ID, and Azure. These isolated clouds are designed to make sure that data residency, sovereignty, and compliance requirements are honored within geographical boundaries.
+
+>! Warning: Sovereign clouds may not support the same features as the public cloud. Make sure to [check the documentation](https://aka.ms/bapfunctionalparity) for the specific cloud you are using.
+
+## Use Case
+
+This guide can be useful in case you need to connect the Power Platform Terraform Provider to one of these clouds.
+
+## Procedure
+
+Configure the Azure CLI to work with that Cloud:
+
+```bash
+az cloud set --name AzureUSGovernment | AzureChinaCloud
+```
+
+Login to the Azure CLI using:
+
+```bash
+az login --scope api://powerplatform_provider_terraform/.default
+```
+
+Configure Power Platform provider similar to the following example:
+
+```terraform
+provider "azurerm" {
+  cloud = "china" # public (default) | gcc | gcchigh | dod | china | ex | rx
+  ...
+}
+```
+
+The `cloud` configuration parameter accepts `public` (default), `gcc`, `gcchigh`, `dod`, `china`, `ex`, or `rx`

--- a/docs/guides/nonpublic_clouds.md
+++ b/docs/guides/nonpublic_clouds.md
@@ -23,6 +23,8 @@ Configure the Azure CLI to work with that Cloud:
 az cloud set --name AzureUSGovernment | AzureChinaCloud
 ```
 
+See the [Azure CLI documentation](https://learn.microsoft.com/en-us/cli/azure/manage-clouds-azure-cli) for more information on connecting to alternate clouds.
+
 Login to the Azure CLI using:
 
 ```bash

--- a/internal/powerplatform/api/auth.go
+++ b/internal/powerplatform/api/auth.go
@@ -83,7 +83,11 @@ func (client *Auth) AuthenticateClientSecret(ctx context.Context, scopes []strin
 	clientSecretCredential, err := azidentity.NewClientSecretCredential(
 		client.config.Credentials.TenantId,
 		client.config.Credentials.ClientId,
-		client.config.Credentials.ClientSecret, nil)
+		client.config.Credentials.ClientSecret, &azidentity.ClientSecretCredentialOptions{
+			ClientOptions: azcore.ClientOptions{
+				Cloud: client.config.Cloud,
+			},
+		})
 	if err != nil {
 		return "", time.Time{}, err
 	}
@@ -141,12 +145,9 @@ func (w *OidcCredential) GetToken(ctx context.Context, opts policy.TokenRequestO
 func (client *Auth) AuthenticateOIDC(ctx context.Context, scopes []string) (string, time.Time, error) {
 	var creds []azcore.TokenCredential
 
-	//This could be passed in in the future if needed.
-	options := &azidentity.DefaultAzureCredentialOptions{}
-
 	oidcCred, err := NewOidcCredential(&OidcCredentialOptions{
 		ClientOptions: azcore.ClientOptions{
-			Cloud: options.Cloud,
+			Cloud: client.config.Cloud,
 		},
 		TenantID:      client.config.Credentials.TenantId,
 		ClientID:      client.config.Credentials.ClientId,

--- a/internal/powerplatform/api/auth.go
+++ b/internal/powerplatform/api/auth.go
@@ -20,7 +20,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	constants "github.com/microsoft/terraform-provider-power-platform/constants"
 	config "github.com/microsoft/terraform-provider-power-platform/internal/powerplatform/config"
 )
 
@@ -60,9 +59,9 @@ func NewAuthBase(config *config.ProviderConfig) *Auth {
 	}
 }
 
-func (client *Auth) GetAuthority(tenantid string) string {
-	return constants.OAUTH_AUTHORITY_URL + tenantid
-}
+// func (client *Auth) GetAuthority(tenantid string) string {
+// 	return constants.OAUTH_AUTHORITY_URL + tenantid
+// }
 
 func (client *Auth) AuthenticateUsingCli(ctx context.Context, scopes []string) (string, time.Time, error) {
 	azureCLICredentials, err := azidentity.NewAzureCLICredential(nil)

--- a/internal/powerplatform/config/config.go
+++ b/internal/powerplatform/config/config.go
@@ -14,9 +14,11 @@ type ProviderConfig struct {
 }
 
 type ProviderConfigUrls struct {
-	BapiUrl          string
-	PowerAppsUrl     string
-	PowerPlatformUrl string
+	BapiUrl            string
+	PowerAppsUrl       string
+	PowerAppsScope     string
+	PowerPlatformUrl   string
+	PowerPlatformScope string
 }
 
 type ProviderCredentials struct {
@@ -38,7 +40,8 @@ type ProviderCredentialsModel struct {
 	UseCli  types.Bool `tfsdk:"use_cli"`
 	UseOidc types.Bool `tfsdk:"use_oidc"`
 
-	TelemetryOptout types.Bool `tfsdk:"telemetry_optout"`
+	Cloud           types.String `tfsdk:"cloud"`
+	TelemetryOptout types.Bool   `tfsdk:"telemetry_optout"`
 
 	TenantId     types.String `tfsdk:"tenant_id"`
 	ClientId     types.String `tfsdk:"client_id"`

--- a/internal/powerplatform/config/config.go
+++ b/internal/powerplatform/config/config.go
@@ -4,6 +4,7 @@
 package powerplatform_config
 
 import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -11,6 +12,7 @@ type ProviderConfig struct {
 	Credentials     *ProviderCredentials
 	Urls            ProviderConfigUrls
 	TelemetryOptout bool
+	Cloud           cloud.Configuration
 }
 
 type ProviderConfigUrls struct {

--- a/internal/powerplatform/provider.go
+++ b/internal/powerplatform/provider.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 
+	azcloud "github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
@@ -51,6 +52,7 @@ func NewPowerPlatformProvider(ctx context.Context, testModeEnabled ...bool) func
 			PowerPlatformUrl:   constants.PUBLIC_POWERPLATFORM_API_DOMAIN,
 			PowerPlatformScope: constants.PUBLIC_POWERPLATFORM_API_SCOPE,
 		},
+		Cloud: azcloud.AzurePublic,
 	}
 
 	if len(testModeEnabled) > 0 && testModeEnabled[0] {
@@ -282,48 +284,61 @@ func (p *PowerPlatformProvider) Configure(ctx context.Context, req provider.Conf
 		p.Config.Urls.PowerAppsScope = constants.PUBLIC_POWERAPPS_SCOPE
 		p.Config.Urls.PowerPlatformUrl = constants.PUBLIC_POWERPLATFORM_API_DOMAIN
 		p.Config.Urls.PowerPlatformScope = constants.PUBLIC_POWERPLATFORM_API_SCOPE
+		p.Config.Cloud = azcloud.AzurePublic
 	case "gcc":
 		p.Config.Urls.BapiUrl = constants.USGOV_BAPI_DOMAIN
 		p.Config.Urls.PowerAppsUrl = constants.USGOV_POWERAPPS_API_DOMAIN
 		p.Config.Urls.PowerAppsScope = constants.USGOV_POWERAPPS_SCOPE
 		p.Config.Urls.PowerPlatformUrl = constants.USGOV_POWERPLATFORM_API_DOMAIN
 		p.Config.Urls.PowerPlatformScope = constants.USGOV_POWERPLATFORM_API_SCOPE
+		p.Config.Cloud = azcloud.AzurePublic //GCC uses public cloud for authentication
 	case "gcchigh":
 		p.Config.Urls.BapiUrl = constants.USGOVHIGH_BAPI_DOMAIN
 		p.Config.Urls.PowerAppsUrl = constants.USGOVHIGH_POWERAPPS_API_DOMAIN
 		p.Config.Urls.PowerAppsScope = constants.USGOVHIGH_POWERAPPS_SCOPE
 		p.Config.Urls.PowerPlatformUrl = constants.USGOVHIGH_POWERPLATFORM_API_DOMAIN
 		p.Config.Urls.PowerPlatformScope = constants.USGOVHIGH_POWERPLATFORM_API_SCOPE
+		p.Config.Cloud = azcloud.AzureGovernment
 	case "dod":
 		p.Config.Urls.BapiUrl = constants.USDOD_BAPI_DOMAIN
 		p.Config.Urls.PowerAppsUrl = constants.USDOD_POWERAPPS_API_DOMAIN
 		p.Config.Urls.PowerAppsScope = constants.USDOD_POWERAPPS_SCOPE
 		p.Config.Urls.PowerPlatformUrl = constants.USDOD_POWERPLATFORM_API_DOMAIN
 		p.Config.Urls.PowerPlatformScope = constants.USDOD_POWERPLATFORM_API_SCOPE
+		p.Config.Cloud = azcloud.AzureGovernment
 	case "china":
 		p.Config.Urls.BapiUrl = constants.CHINA_BAPI_DOMAIN
 		p.Config.Urls.PowerAppsUrl = constants.CHINA_POWERAPPS_API_DOMAIN
 		p.Config.Urls.PowerAppsScope = constants.CHINA_POWERAPPS_SCOPE
 		p.Config.Urls.PowerPlatformUrl = constants.CHINA_POWERPLATFORM_API_DOMAIN
 		p.Config.Urls.PowerPlatformScope = constants.CHINA_POWERPLATFORM_API_SCOPE
+		p.Config.Cloud = azcloud.AzureChina
 	case "ex":
 		p.Config.Urls.BapiUrl = constants.EX_BAPI_DOMAIN
 		p.Config.Urls.PowerAppsUrl = constants.EX_POWERAPPS_API_DOMAIN
 		p.Config.Urls.PowerAppsScope = constants.EX_POWERAPPS_SCOPE
 		p.Config.Urls.PowerPlatformUrl = constants.EX_POWERPLATFORM_API_DOMAIN
 		p.Config.Urls.PowerPlatformScope = constants.EX_POWERPLATFORM_API_SCOPE
+		p.Config.Cloud = azcloud.Configuration{
+			ActiveDirectoryAuthorityHost: constants.EX_AUTHORITY_HOST,
+			Services:                     map[azcloud.ServiceName]azcloud.ServiceConfiguration{},
+		}
 	case "rx":
 		p.Config.Urls.BapiUrl = constants.RX_BAPI_DOMAIN
 		p.Config.Urls.PowerAppsUrl = constants.RX_POWERAPPS_API_DOMAIN
 		p.Config.Urls.PowerAppsScope = constants.RX_POWERAPPS_SCOPE
 		p.Config.Urls.PowerPlatformUrl = constants.RX_POWERPLATFORM_API_DOMAIN
 		p.Config.Urls.PowerPlatformScope = constants.RX_POWERPLATFORM_API_SCOPE
+		p.Config.Cloud = azcloud.Configuration{
+			ActiveDirectoryAuthorityHost: constants.RX_AUTHORITY_HOST,
+			Services:                     map[azcloud.ServiceName]azcloud.ServiceConfiguration{},
+		}
 	default:
 		resp.Diagnostics.AddAttributeError(
 			path.Root("cloud"),
 			"Unknown cloud",
-			"The provider cannot create the API client as there is an unknown configuration value for the cloud. "+
-				"Either target apply the source of the value first, set the value statically in the configuration, or use the POWER_PLATFORM_CLOUD environment variable.",
+			"The provider cannot create the API client as there is an unknown configuration value for `cloud`. "+
+				"Either set the value in the provider configuration or use the POWER_PLATFORM_CLOUD environment variable.",
 		)
 	}
 

--- a/internal/powerplatform/provider.go
+++ b/internal/powerplatform/provider.go
@@ -122,8 +122,9 @@ func (p *PowerPlatformProvider) Schema(ctx context.Context, req provider.SchemaR
 				Optional:    true,
 			},
 			"cloud": schema.StringAttribute{
-				Description: "The cloud to use for authentication and Power Platform API requests. Default is `public`. Valid values are `public`, `gcc`, `gcchigh`, `china`, `usdod`",
-				Optional:    true,
+				Description:         "The cloud to use for authentication and Power Platform API requests. Default is `public`. Valid values are `public`, `gcc`, `gcchigh`, `china`, `dod`, `ex`, `rx`",
+				MarkdownDescription: "The cloud to use for authentication and Power Platform API requests. Default is `public`. Valid values are `public`, `gcc`, `gcchigh`, `china`, `dod`, `ex`, `rx`",
+				Optional:            true,
 			},
 			"telemetry_optout": schema.BoolAttribute{
 				Description:         "Flag to indicate whether to opt out of telemetry. Default is `false`",

--- a/internal/powerplatform/provider.go
+++ b/internal/powerplatform/provider.go
@@ -45,9 +45,11 @@ func NewPowerPlatformProvider(ctx context.Context, testModeEnabled ...bool) func
 	config := config.ProviderConfig{
 		Credentials: &cred,
 		Urls: config.ProviderConfigUrls{
-			BapiUrl:          constants.BAPI_DOMAIN,
-			PowerAppsUrl:     constants.POWERAPPS_API_DOMAIN,
-			PowerPlatformUrl: constants.POWERPLATFORM_API_DOMAIN,
+			BapiUrl:            constants.PUBLIC_BAPI_DOMAIN,
+			PowerAppsUrl:       constants.PUBLIC_POWERAPPS_API_DOMAIN,
+			PowerAppsScope:     constants.PUBLIC_POWERAPPS_SCOPE,
+			PowerPlatformUrl:   constants.PUBLIC_POWERPLATFORM_API_DOMAIN,
+			PowerPlatformScope: constants.PUBLIC_POWERPLATFORM_API_SCOPE,
 		},
 	}
 
@@ -119,6 +121,10 @@ func (p *PowerPlatformProvider) Schema(ctx context.Context, req provider.SchemaR
 				Description: "The path to a file containing an OIDC ID token for use when authenticating as a Service Principal using OpenID Connect.",
 				Optional:    true,
 			},
+			"cloud": schema.StringAttribute{
+				Description: "The cloud to use for authentication and Power Platform API requests. Default is `public`. Valid values are `public`, `gcc`, `gcchigh`, `china`, `usdod`",
+				Optional:    true,
+			},
 			"telemetry_optout": schema.BoolAttribute{
 				Description:         "Flag to indicate whether to opt out of telemetry. Default is `false`",
 				MarkdownDescription: "Flag to indicate whether to opt out of telemetry. Default is `false`",
@@ -137,6 +143,14 @@ func (p *PowerPlatformProvider) Configure(ctx context.Context, req provider.Conf
 
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	cloud := "public"
+	envCloud := os.Getenv("POWER_PLATFORM_CLOUD")
+	if config.Cloud.IsNull() && envCloud != "" {
+		cloud = envCloud
+	} else if !config.Cloud.IsNull() {
+		cloud = config.Cloud.ValueString()
 	}
 
 	tenantId := ""
@@ -201,6 +215,7 @@ func (p *PowerPlatformProvider) Configure(ctx context.Context, req provider.Conf
 
 	ctx = tflog.SetField(ctx, "use_cli", config.UseCli.ValueBool())
 	ctx = tflog.SetField(ctx, "use_oidc", config.UseOidc.ValueBool())
+	ctx = tflog.SetField(ctx, "cloud", cloud)
 	ctx = tflog.SetField(ctx, "power_platform_tenant_id", tenantId)
 	ctx = tflog.SetField(ctx, "power_platform_client_id", clientId)
 	ctx = tflog.SetField(ctx, "power_platform_client_secret", clientSecret)
@@ -258,6 +273,59 @@ func (p *PowerPlatformProvider) Configure(ctx context.Context, req provider.Conf
 			}
 		}
 	}
+
+	switch cloud {
+	case "public":
+		p.Config.Urls.BapiUrl = constants.PUBLIC_BAPI_DOMAIN
+		p.Config.Urls.PowerAppsUrl = constants.PUBLIC_POWERAPPS_API_DOMAIN
+		p.Config.Urls.PowerAppsScope = constants.PUBLIC_POWERAPPS_SCOPE
+		p.Config.Urls.PowerPlatformUrl = constants.PUBLIC_POWERPLATFORM_API_DOMAIN
+		p.Config.Urls.PowerPlatformScope = constants.PUBLIC_POWERPLATFORM_API_SCOPE
+	case "gcc":
+		p.Config.Urls.BapiUrl = constants.USGOV_BAPI_DOMAIN
+		p.Config.Urls.PowerAppsUrl = constants.USGOV_POWERAPPS_API_DOMAIN
+		p.Config.Urls.PowerAppsScope = constants.USGOV_POWERAPPS_SCOPE
+		p.Config.Urls.PowerPlatformUrl = constants.USGOV_POWERPLATFORM_API_DOMAIN
+		p.Config.Urls.PowerPlatformScope = constants.USGOV_POWERPLATFORM_API_SCOPE
+	case "gcchigh":
+		p.Config.Urls.BapiUrl = constants.USGOVHIGH_BAPI_DOMAIN
+		p.Config.Urls.PowerAppsUrl = constants.USGOVHIGH_POWERAPPS_API_DOMAIN
+		p.Config.Urls.PowerAppsScope = constants.USGOVHIGH_POWERAPPS_SCOPE
+		p.Config.Urls.PowerPlatformUrl = constants.USGOVHIGH_POWERPLATFORM_API_DOMAIN
+		p.Config.Urls.PowerPlatformScope = constants.USGOVHIGH_POWERPLATFORM_API_SCOPE
+	case "dod":
+		p.Config.Urls.BapiUrl = constants.USDOD_BAPI_DOMAIN
+		p.Config.Urls.PowerAppsUrl = constants.USDOD_POWERAPPS_API_DOMAIN
+		p.Config.Urls.PowerAppsScope = constants.USDOD_POWERAPPS_SCOPE
+		p.Config.Urls.PowerPlatformUrl = constants.USDOD_POWERPLATFORM_API_DOMAIN
+		p.Config.Urls.PowerPlatformScope = constants.USDOD_POWERPLATFORM_API_SCOPE
+	case "china":
+		p.Config.Urls.BapiUrl = constants.CHINA_BAPI_DOMAIN
+		p.Config.Urls.PowerAppsUrl = constants.CHINA_POWERAPPS_API_DOMAIN
+		p.Config.Urls.PowerAppsScope = constants.CHINA_POWERAPPS_SCOPE
+		p.Config.Urls.PowerPlatformUrl = constants.CHINA_POWERPLATFORM_API_DOMAIN
+		p.Config.Urls.PowerPlatformScope = constants.CHINA_POWERPLATFORM_API_SCOPE
+	case "ex":
+		p.Config.Urls.BapiUrl = constants.EX_BAPI_DOMAIN
+		p.Config.Urls.PowerAppsUrl = constants.EX_POWERAPPS_API_DOMAIN
+		p.Config.Urls.PowerAppsScope = constants.EX_POWERAPPS_SCOPE
+		p.Config.Urls.PowerPlatformUrl = constants.EX_POWERPLATFORM_API_DOMAIN
+		p.Config.Urls.PowerPlatformScope = constants.EX_POWERPLATFORM_API_SCOPE
+	case "rx":
+		p.Config.Urls.BapiUrl = constants.RX_BAPI_DOMAIN
+		p.Config.Urls.PowerAppsUrl = constants.RX_POWERAPPS_API_DOMAIN
+		p.Config.Urls.PowerAppsScope = constants.RX_POWERAPPS_SCOPE
+		p.Config.Urls.PowerPlatformUrl = constants.RX_POWERPLATFORM_API_DOMAIN
+		p.Config.Urls.PowerPlatformScope = constants.RX_POWERPLATFORM_API_SCOPE
+	default:
+		resp.Diagnostics.AddAttributeError(
+			path.Root("cloud"),
+			"Unknown cloud",
+			"The provider cannot create the API client as there is an unknown configuration value for the cloud. "+
+				"Either target apply the source of the value first, set the value statically in the configuration, or use the POWER_PLATFORM_CLOUD environment variable.",
+		)
+	}
+
 	p.Config.TelemetryOptout = config.TelemetryOptout.ValueBool()
 
 	providerClient := api.ProviderClient{

--- a/templates/guides/app_registration.md.tmpl
+++ b/templates/guides/app_registration.md.tmpl
@@ -91,13 +91,15 @@ Or you can add them directly into your App Registration manifest:
  ]
 ```
 
+>! Note: The `resourceAppId` values are the application IDs of the services in the Public cloud.  If you are using a sovereign cloud, you will need to use the appropriate application IDs for those services.
+
 ## Expose API
 
 In "Expose API" menu of your App Registration, you need to define your application ID URI:
 
 - Application ID URI: `api://<client_id>`, for example:
 
-```bash
+```plaintext
 api://powerplatform_provider_terraform
 ```
 
@@ -150,5 +152,5 @@ Or you can add them directly into your App Registration manifest:
 After above steps you should be able to authenticate using Azure CLI:
 
 ```bash
-az login --scope api://powerplatform_provider_terraform/access
+az login --scope api://powerplatform_provider_terraform/.default
 ```

--- a/templates/guides/nonpublic_clouds.md.tmpl
+++ b/templates/guides/nonpublic_clouds.md.tmpl
@@ -1,0 +1,41 @@
+---
+page_title: "Authentication: Connecting to non-public sovereign clouds"
+subcategory: "Authentication"
+description: |-
+  {{ .Description }}
+---
+
+# Connecting to non-public sovereign clouds
+
+Microsoft offers sovereign clouds (for example [US Government](https://learn.microsoft.com/en-us/power-platform/admin/microsoft-dynamics-365-government) and [China](https://learn.microsoft.com/en-us/power-platform/admin/about-microsoft-cloud-china)) that are physically isolated instances of Power Platform, Entra ID, and Azure. These isolated clouds are designed to make sure that data residency, sovereignty, and compliance requirements are honored within geographical boundaries.
+
+>! Warning: Sovereign clouds may not support the same features as the public cloud. Make sure to [check the documentation](https://aka.ms/bapfunctionalparity) for the specific cloud you are using.
+
+## Use Case
+
+This guide can be useful in case you need to connect the Power Platform Terraform Provider to one of these clouds.
+
+## Procedure
+
+Configure the Azure CLI to work with that Cloud:
+
+```bash
+az cloud set --name AzureUSGovernment | AzureChinaCloud
+```
+
+Login to the Azure CLI using:
+
+```bash
+az login --scope api://powerplatform_provider_terraform/.default
+```
+
+Configure Power Platform provider similar to the following example:
+
+```terraform
+provider "azurerm" {
+  cloud = "china" # public (default) | gcc | gcchigh | dod | china | ex | rx
+  ...
+}
+```
+
+The `cloud` configuration parameter accepts `public` (default), `gcc`, `gcchigh`, `dod`, `china`, `ex`, or `rx`

--- a/templates/guides/nonpublic_clouds.md.tmpl
+++ b/templates/guides/nonpublic_clouds.md.tmpl
@@ -23,6 +23,8 @@ Configure the Azure CLI to work with that Cloud:
 az cloud set --name AzureUSGovernment | AzureChinaCloud
 ```
 
+See the [Azure CLI documentation](https://learn.microsoft.com/en-us/cli/azure/manage-clouds-azure-cli) for more information on connecting to alternate clouds.
+
 Login to the Azure CLI using:
 
 ```bash


### PR DESCRIPTION
This pull request introduces several changes to improve the support for non-public sovereign clouds in the Power Platform Terraform Provider. The most important changes include the addition of new constants for different cloud configurations, updates to the authentication process, and modifications to the provider configuration.

Cloud Configuration:

* [`constants/constants.go`](diffhunk://#diff-cdc7d16daf2a767578a6bb3cb40e145960555582283f094920f10eecc8f4fb33R6-R77): Added new constants for different cloud configurations including public, US government, US DOD, China, and others. Each configuration includes the OAuth authority URL, BAPI domain, Power Apps API domain, Power Apps scope, Power Platform API domain, and Power Platform API scope.

Authentication:

* [`internal/powerplatform/api/auth.go`](diffhunk://#diff-e16d073d63627064342ce1318299b7634406d3672eeba793dcbb1bceb7735aecL63-R64): Updated the `AuthenticateClientSecret` and `AuthenticateOIDC` methods to use the cloud configuration from the provider config. Removed the `GetAuthority` method. [[1]](diffhunk://#diff-e16d073d63627064342ce1318299b7634406d3672eeba793dcbb1bceb7735aecL63-R64) [[2]](diffhunk://#diff-e16d073d63627064342ce1318299b7634406d3672eeba793dcbb1bceb7735aecL87-R90) [[3]](diffhunk://#diff-e16d073d63627064342ce1318299b7634406d3672eeba793dcbb1bceb7735aecL145-R150)
* [`internal/powerplatform/api/api_client.go`](diffhunk://#diff-03bd6d50cb06de9a7c49a1106113e5d0628b0c8b679d1816973a3e60c741c999L40-R56): Modified the `TryGetScopeFromURL` function to use the cloud configuration from the provider config.

Provider Configuration:

* [`internal/powerplatform/provider.go`](diffhunk://#diff-4ddf04cb6a256a6287ea7f6c6a48a46e29466c3c98d4414dea5bc1f649f6c076L48-R55): Updated the provider configuration to include the cloud configuration. Added a switch case to set the URLs and cloud configuration based on the `cloud` parameter. [[1]](diffhunk://#diff-4ddf04cb6a256a6287ea7f6c6a48a46e29466c3c98d4414dea5bc1f649f6c076L48-R55) [[2]](diffhunk://#diff-4ddf04cb6a256a6287ea7f6c6a48a46e29466c3c98d4414dea5bc1f649f6c076R126-R130) [[3]](diffhunk://#diff-4ddf04cb6a256a6287ea7f6c6a48a46e29466c3c98d4414dea5bc1f649f6c076R279-R344)
* [`internal/powerplatform/config/config.go`](diffhunk://#diff-0f0c223a1d5696fcceb2d1c175af7a2a99c1cb24e5ff422274e6e812363d4252R7-R23): Added the `Cloud` field to the `ProviderConfig` struct and the `cloud` field to the `ProviderCredentialsModel` struct. [[1]](diffhunk://#diff-0f0c223a1d5696fcceb2d1c175af7a2a99c1cb24e5ff422274e6e812363d4252R7-R23) [[2]](diffhunk://#diff-0f0c223a1d5696fcceb2d1c175af7a2a99c1cb24e5ff422274e6e812363d4252R45)

Documentation:

* `docs/guides/app_registration.md`, `docs/guides/nonpublic_clouds.md`, and `templates/guides/app_registration.md.tmpl`: Updated the documentation to reflect the changes in the authentication process and the support for non-public sovereign clouds. [[1]](diffhunk://#diff-66c8935a7243463b00acc9b18699c8c42a8715999cdf30e27ca23048b6adc310R94-R102) [[2]](diffhunk://#diff-66c8935a7243463b00acc9b18699c8c42a8715999cdf30e27ca23048b6adc310L153-R155) [[3]](diffhunk://#diff-d4cec5dbd93a9aabbc4c86c595640ee2aba7d732311258657ad970f1aeb14b06R1-R41) [[4]](diffhunk://#diff-bf16406cc259ba96f68a99bc3695fafede763306493cfafd38b2e1f5318da8cdR94-R102) [[5]](diffhunk://#diff-bf16406cc259ba96f68a99bc3695fafede763306493cfafd38b2e1f5318da8cdL153-R155)This pull request primarily focuses on enhancing the flexibility of the Power Platform API client to support different cloud environments. The changes include the addition of constants for various cloud environments, modification of the `TryGetScopeFromURL` function to accept a `cloudConfig` parameter, and the introduction of a `cloud` configuration option for the provider.

Here are the top five most important changes:

Constants for different cloud environments:

* [`constants/constants.go`](diffhunk://#diff-cdc7d16daf2a767578a6bb3cb40e145960555582283f094920f10eecc8f4fb33R6-R75): Added constants for different cloud environments (Public, US Government, US DOD, China, etc.) including their respective OAuth authority URLs, BAPI domains, PowerApps API domains, and PowerPlatform API domains.

Modifications to the `TryGetScopeFromURL` function:

* [`internal/powerplatform/api/api_client.go`](diffhunk://#diff-03bd6d50cb06de9a7c49a1106113e5d0628b0c8b679d1816973a3e60c741c999L40-R56): The `TryGetScopeFromURL` function now accepts a `cloudConfig` parameter, which is used to determine the scope from the URL. The function has been updated to use the `cloudConfig` parameters instead of hardcoded values.

Introduction of a `cloud` configuration option for the provider:

* [`internal/powerplatform/config/config.go`](diffhunk://#diff-0f0c223a1d5696fcceb2d1c175af7a2a99c1cb24e5ff422274e6e812363d4252R43): Added `cloud` to the `ProviderCredentialsModel` struct.
* [`internal/powerplatform/provider.go`](diffhunk://#diff-4ddf04cb6a256a6287ea7f6c6a48a46e29466c3c98d4414dea5bc1f649f6c076L48-R52): Added a `cloud` attribute to the provider schema and updated the `Configure` function to read the `cloud` configuration option. The function now sets the URLs and scopes based on the `cloud` configuration. [[1]](diffhunk://#diff-4ddf04cb6a256a6287ea7f6c6a48a46e29466c3c98d4414dea5bc1f649f6c076L48-R52) [[2]](diffhunk://#diff-4ddf04cb6a256a6287ea7f6c6a48a46e29466c3c98d4414dea5bc1f649f6c076R124-R128) [[3]](diffhunk://#diff-4ddf04cb6a256a6287ea7f6c6a48a46e29466c3c98d4414dea5bc1f649f6c076R149-R156) [[4]](diffhunk://#diff-4ddf04cb6a256a6287ea7f6c6a48a46e29466c3c98d4414dea5bc1f649f6c076R219) [[5]](diffhunk://#diff-4ddf04cb6a256a6287ea7f6c6a48a46e29466c3c98d4414dea5bc1f649f6c076R277-R329)

Removal of unused imports:

* [`internal/powerplatform/api/api_client.go`](diffhunk://#diff-03bd6d50cb06de9a7c49a1106113e5d0628b0c8b679d1816973a3e60c741c999L10-R13): Removed the unused `errors` import and added the `net/url` import as `neturl`.
* [`internal/powerplatform/api/auth.go`](diffhunk://#diff-e16d073d63627064342ce1318299b7634406d3672eeba793dcbb1bceb7735aecL23): Removed the unused `constants` import.