### PR TITLE
Addition of example directories for dependabot scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,13 +11,13 @@ updates:
       interval: "daily"
   - package-ecosystem: "terraform" # See documentation for possible values
     directories: # Location of terraform modules
-    # Workaround for not having glob support yet.  Uncommment globs and remove individual paths when available.
+    # Workaround for not having glob support yet.  Uncommment globs and remove individual paths when available. https://github.blog/changelog/2024-04-29-dependabot-multi-directory-configuration-public-beta-now-available/
     # - "/examples/resources/*"
     # - "/examples/data-sources/*"
     - "/examples/resources/powerplatform_billing_policy" 
     - "/examples/resources/powerplatform_billing_policy_environment"
     - "/examples/resources/powerplatform_data_loss_prevention_policy"
-    - "/examples/resources/powerplatform_environment_settings"
+    - "/examples/resources/powerplatform_environment"
     - "/examples/resources/powerplatform_environment_application_packages"
     - "/examples/resources/powerplatform_environment_settings"
     - "/examples/resources/powerplatform_managed_environment"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,36 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "terraform" # See documentation for possible values
-    directory: "/examples" # Location of package manifests
+    directories: # Location of terraform modules
+    # Workaround for not having glob support yet.  Uncommment globs and remove individual paths when available.
+    # - "/examples/resources/*"
+    # - "/examples/data-sources/*"
+    - "/examples/resources/powerplatform_billing_policy" 
+    - "/examples/resources/powerplatform_billing_policy_environment"
+    - "/examples/resources/powerplatform_data_loss_prevention_policy"
+    - "/examples/resources/powerplatform_environment_settings"
+    - "/examples/resources/powerplatform_environment_application_packages"
+    - "/examples/resources/powerplatform_environment_settings"
+    - "/examples/resources/powerplatform_managed_environment"
+    - "/examples/resources/powerplatform_solution"
+    - "/examples/resources/powerplatform_tenant_settings"
+    - "/examples/resources/powerplatform_user"
+    - "/examples/data-sources/powerplatform_billing_policies"
+    - "/examples/data-sources/powerplatform_billing_policies_environments"
+    - "/examples/data-sources/powerplatform_connectors"
+    - "/examples/data-sources/powerplatform_currencies"
+    - "/examples/data-sources/powerplatform_environment_application_packages"
+    - "/examples/data-sources/powerplatform_environment_powerapps"
+    - "/examples/data-sources/powerplatform_environment_settings"
+    - "/examples/data-sources/powerplatform_environment_templates"
+    - "/examples/data-sources/powerplatform_environments"
+    - "/examples/data-sources/powerplatform_languages"
+    - "/examples/data-sources/powerplatform_locations"
+    - "/examples/data-sources/powerplatform_policies"
+    - "/examples/data-sources/powerplatform_securityroles"
+    - "/examples/data-sources/powerplatform_solutions"
+    - "/examples/data-sources/powerplatform_tenant_application_packages"
+    - "/examples/data-sources/powerplatform_tenant_settings"
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions" # See documentation for possible values


### PR DESCRIPTION
This pull request includes a significant modification to the `updates:` section in the `.github/dependabot.yml` file. The change replaces a single directory for the `terraform` package ecosystem with a detailed list of directories. This update aims to provide more granular control over the Dependabot updates by specifying individual paths for each terraform module.  This fixes #247 where example terraform was not being scanned for dependency updates.  It is a temporary fix which uses this new feature of dependabot https://github.blog/changelog/2024-04-29-dependabot-multi-directory-configuration-public-beta-now-available/ however a better solution would use wildcard globs to ensure that future examples are also included without having to remember to add them.  

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L13-R42): Replaced the single directory `/examples` with a list of individual paths under the `directories:` key for the `terraform` package ecosystem. This change allows Dependabot to check for updates in each of these specified directories. The comment in the code also indicates that this is a temporary workaround until glob support is available for specifying multiple directories.