### PR TITLE
fixing many to many relationships on data_record resource

### DIFF
--- a/internal/powerplatform/services/data_record/api_data_record.go
+++ b/internal/powerplatform/services/data_record/api_data_record.go
@@ -235,11 +235,11 @@ func (client *DataRecordClient) GetEntityRelationDefinitionInfo(ctx context.Cont
 	}
 	for _, list := range manyToMany {
 		item := list.(map[string]interface{})
-		if item["Entity1NavigationPropertyName"] == relationLogicalName {
+		if item["Entity1NavigationPropertyName"] == relationLogicalName && item["Entity1LogicalName"] != entityLogicalName {
 			tableName = item["Entity1LogicalName"].(string)
 			break
 		}
-		if item["Entity2NavigationPropertyName"] == relationLogicalName {
+		if item["Entity2NavigationPropertyName"] == relationLogicalName && item["Entity2LogicalName"] != entityLogicalName {
 			tableName = item["Entity2LogicalName"].(string)
 			break
 		}


### PR DESCRIPTION
This pull request includes a change in the `GetEntityRelationDefinitionInfo` function in the `internal/powerplatform/services/data_record/api_data_record.go` file. The change involves adding an additional condition to the if statements that check the `Entity1NavigationPropertyName` and `Entity2NavigationPropertyName` values. The new condition checks if the `Entity1LogicalName` and `Entity2LogicalName` values are not equal to the `entityLogicalName`. This change ensures that the `tableName` is only set when the logical name of the entity does not match the `entityLogicalName`, providing a more precise selection of the table name.fixing determining wrong primary id field name for the referenced navigation property

fixing determining wrong primary id field name for the referenced navigation property