### PR TITLE
powerplatform_solution environment variable empty value will be imported into the Dataverse

### DIFF
--- a/internal/powerplatform/modifiers/sync_attribute_plan_modifier.go
+++ b/internal/powerplatform/modifiers/sync_attribute_plan_modifier.go
@@ -53,6 +53,8 @@ func (d *syncAttributePlanModifier) PlanModifyString(ctx context.Context, req pl
 
 		if value == "" {
 			resp.PlanValue = types.StringUnknown()
+		} else {
+			resp.PlanValue = types.StringValue(value)
 		}
 	}
 }

--- a/internal/powerplatform/services/solution/api_solution.go
+++ b/internal/powerplatform/services/solution/api_solution.go
@@ -206,13 +206,18 @@ func (client *SolutionClient) createSolutionComponentParameters(ctx context.Cont
 		})
 	}
 	for _, envVariableComponent := range solutionSettings.EnvironmentVariables {
-		solutionComponents = append(solutionComponents, ImportSolutionEnvironmentVariablesDto{
-			Type:       "Microsoft.Dynamics.CRM.environmentvariablevalue",
-			SchemaName: envVariableComponent.SchemaName,
-			Value:      envVariableComponent.Value,
-		})
+		if envVariableComponent.Value != "" {
+			solutionComponents = append(solutionComponents, ImportSolutionEnvironmentVariablesDto{
+				Type:       "Microsoft.Dynamics.CRM.environmentvariablevalue",
+				SchemaName: envVariableComponent.SchemaName,
+				Value:      envVariableComponent.Value,
+			})
+		}
 	}
 
+	if len(solutionComponents) == 0 {
+		return nil, nil
+	}
 	return solutionComponents, nil
 }
 


### PR DESCRIPTION
This pull request includes two main changes to the `internal/powerplatform` package in the Go codebase. These changes are primarily aimed at handling empty string values and empty solution components more effectively.

Changes to string value handling:
* [`internal/powerplatform/modifiers/sync_attribute_plan_modifier.go`](diffhunk://#diff-028404ba646e4ae1488335ebb1ed14e06238a6c4f7af823897f500dc08d78932R56-R57): In the `PlanModifyString` method, an else clause was added to assign the `resp.PlanValue` to `types.StringValue(value)` if the `value` is not an empty string. This ensures that the `resp.PlanValue` is not left as `types.StringUnknown()` when there is a valid string value.

Changes to solution components:
* [`internal/powerplatform/services/solution/api_solution.go`](diffhunk://#diff-d216c715fe4713a2806f9701614b7316717af14de3206e6a2b29b8046352556eR209-R220): In the `createSolutionComponentParameters` method, a check was added to only append `ImportSolutionEnvironmentVariablesDto` to `solutionComponents` if `envVariableComponent.Value` is not an empty string. Additionally, if `solutionComponents` is empty after this process, the function now returns `nil, nil` instead of an empty slice. This prevents unnecessary processing of empty solution components.
