### PR TITLE
Implement golangci linter to improve static analysis of provider code

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,26 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.59

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -55,5 +55,9 @@
         "uniquename",
         "unitedstates"
     ],
-    "window.autoDetectColorScheme": true
+    "window.autoDetectColorScheme": true,
+    "go.lintTool": "golangci-lint",
+    "go.lintFlags": [
+        "--fast"
+    ]
 }

--- a/internal/powerplatform/api/api_client.go
+++ b/internal/powerplatform/api/api_client.go
@@ -97,9 +97,10 @@ func (client *ApiClient) ExecuteForGivenScope(ctx context.Context, scope, method
 				break
 			}
 		}
-		if !isStatusCodeValid {
-			return nil, powerplatform_helpers.WrapIntoProviderError(err, powerplatform_helpers.ERROR_UNEXPECTED_HTTP_RETURN_CODE, fmt.Sprintf("expected status code: %d, recieved: [%d]", acceptableStatusCodes, apiResponse.Response.StatusCode))
-		}
+	}
+
+	if !isStatusCodeValid {
+		return nil, powerplatform_helpers.WrapIntoProviderError(err, powerplatform_helpers.ERROR_UNEXPECTED_HTTP_RETURN_CODE, fmt.Sprintf("expected status code: %d, recieved: [%d]", acceptableStatusCodes, apiResponse.Response.StatusCode))
 	}
 
 	if responseObj != nil {

--- a/internal/powerplatform/api/auth.go
+++ b/internal/powerplatform/api/auth.go
@@ -78,6 +78,9 @@ func (client *Auth) AuthenticateClientCertificate(ctx context.Context, scopes []
 			},
 		},
 	)
+	if err != nil {
+		return "", time.Time{}, err
+	}
 	accessToken, err := azureCertCredentials.GetToken(ctx, policy.TokenRequestOptions{
 		Scopes: scopes,
 	})
@@ -273,7 +276,7 @@ func (client *Auth) GetTokenForScopes(ctx context.Context, scopes []string) (*st
 	}
 
 	token := ""
-	tokenExpiry := time.Time{}
+	var tokenExpiry time.Time
 	var err error
 
 	switch {

--- a/internal/powerplatform/mocks/known_state_value.go
+++ b/internal/powerplatform/mocks/known_state_value.go
@@ -34,7 +34,7 @@ func (v getKnownValue) CheckValue(other any) error {
 }
 
 func (v getKnownValue) String() string {
-	return *&v.value.Value
+	return v.value.Value
 }
 
 func GetStateValue(value *StateValue) getKnownValue {

--- a/internal/powerplatform/resource_data_record_test.go
+++ b/internal/powerplatform/resource_data_record_test.go
@@ -1116,7 +1116,10 @@ func TestUnitDataRecordResource_Validate_Update_Relationships(t *testing.T) {
 		func(req *http.Request) (*http.Response, error) {
 
 			bodyAsBytes := make([]byte, req.ContentLength)
-			req.Body.Read(bodyAsBytes)
+			_, err := req.Body.Read(bodyAsBytes)
+			if err != nil {
+				panic(err)
+			}
 			bodyAsString := string(bodyAsBytes)
 
 			contactId := ""

--- a/internal/powerplatform/services/application/api_application.go
+++ b/internal/powerplatform/services/application/api_application.go
@@ -145,7 +145,10 @@ func (client *ApplicationClient) InstallApplicationInEnvironment(ctx context.Con
 		}
 	} else if response.Response.StatusCode == http.StatusCreated {
 		appCreatedResponse := EnvironmentApplicationLifecycleCreatedDto{}
-		response.MarshallTo(&appCreatedResponse)
+		err = response.MarshallTo(&appCreatedResponse)
+		if err != nil {
+			return "", err
+		}
 		if appCreatedResponse.Properties.ProvisioningState != "Succeeded" {
 			return "", errors.New("application installation failed. provisioning state: " + appCreatedResponse.Properties.ProvisioningState)
 		}

--- a/internal/powerplatform/services/authorization/api_user.go
+++ b/internal/powerplatform/services/authorization/api_user.go
@@ -292,7 +292,7 @@ func (client *UserClient) GetSecurityRoles(ctx context.Context, environmentId, b
 	_, err = client.Api.Execute(ctx, "GET", apiUrl.String(), nil, nil, []int{http.StatusOK}, &securityRoleArray)
 	if err != nil {
 		if strings.ContainsAny(err.Error(), "404") {
-			return nil, powerplatform_helpers.WrapIntoProviderError(err, powerplatform_helpers.ERROR_OBJECT_NOT_FOUND, fmt.Sprintf("security roles not found"))
+			return nil, powerplatform_helpers.WrapIntoProviderError(err, powerplatform_helpers.ERROR_OBJECT_NOT_FOUND, "security roles not found")
 		}
 		return nil, err
 	}

--- a/internal/powerplatform/services/data_record/api_data_record.go
+++ b/internal/powerplatform/services/data_record/api_data_record.go
@@ -277,7 +277,10 @@ func (client *DataRecordClient) GetTableSingularNameFromPlural(ctx context.Conte
 	}
 
 	var mapResponse map[string]interface{}
-	json.Unmarshal(response.BodyAsBytes, &mapResponse)
+	err = json.Unmarshal(response.BodyAsBytes, &mapResponse)
+	if err != nil {
+		return nil, err
+	}
 
 	var result string
 	if mapResponse["value"] != nil && len(mapResponse["value"].([]interface{})) > 0 &&
@@ -306,7 +309,10 @@ func (client *DataRecordClient) GetEntityRelationDefinitionInfo(ctx context.Cont
 	}
 
 	var mapResponse map[string]interface{}
-	json.Unmarshal(response.BodyAsBytes, &mapResponse)
+	err = json.Unmarshal(response.BodyAsBytes, &mapResponse)
+	if err != nil {
+		return "", err
+	}
 
 	oneToMany, ok := mapResponse["OneToManyRelationships"].([]interface{})
 	if !ok {
@@ -422,7 +428,10 @@ func (client *DataRecordClient) ApplyDataRecord(ctx context.Context, recordId, e
 	}
 
 	if len(response.BodyAsBytes) != 0 {
-		json.Unmarshal(response.BodyAsBytes, &result)
+		err = json.Unmarshal(response.BodyAsBytes, &result)
+		if err != nil {
+			return nil, err
+		}
 	} else if response.Response.Header.Get(constants.HEADER_ODATA_ENTITY_ID) != "" {
 		re := regexp.MustCompile("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
 		match := re.FindAllStringSubmatch(response.Response.Header.Get(constants.HEADER_ODATA_ENTITY_ID), -1)
@@ -537,7 +546,10 @@ func applyRelations(ctx context.Context, client *DataRecordClient, relations map
 				return err
 			}
 
-			json.Unmarshal(apiResponse.BodyAsBytes, &existingRelationsResponse)
+			err = json.Unmarshal(apiResponse.BodyAsBytes, &existingRelationsResponse)
+			if err != nil {
+				return err
+			}
 
 			var toBeDeleted []RelationApiBody = make([]RelationApiBody, 0)
 

--- a/internal/powerplatform/services/data_record/resource_data_record.go
+++ b/internal/powerplatform/services/data_record/resource_data_record.go
@@ -257,7 +257,10 @@ func convertResourceModelToMap(columnsAsString *string) (mapColumns map[string]i
 	if err != nil {
 		return nil, err
 	}
-	json.Unmarshal([]byte(unquotedJsonColumns), &mapColumns)
+	err = json.Unmarshal([]byte(unquotedJsonColumns), &mapColumns)
+	if err != nil {
+		return nil, err
+	}
 	return mapColumns, nil
 }
 

--- a/internal/powerplatform/services/dlp_policy/models_dlp_policy.go
+++ b/internal/powerplatform/services/dlp_policy/models_dlp_policy.go
@@ -162,12 +162,6 @@ type DataLossPreventionPolicyResourceEnvironmentsModel struct {
 	Name types.String `tfsdk:"name"`
 }
 
-var environmentSetObjectType = types.ObjectType{
-	AttrTypes: map[string]attr.Type{
-		"name": types.StringType,
-	},
-}
-
 type DataLossPreventionPolicyResourceConnectorModel struct {
 	Id                        types.String                                                 `tfsdk:"id"`
 	DefaultActionRuleBehavior types.String                                                 `tfsdk:"default_action_rule_behavior"`

--- a/internal/powerplatform/services/environment/api_environment.go
+++ b/internal/powerplatform/services/environment/api_environment.go
@@ -374,7 +374,10 @@ func (client *EnvironmentClient) CreateEnvironment(ctx context.Context, environm
 		}
 	} else if apiResponse.Response.StatusCode == http.StatusCreated {
 		envCreatedResponse := EnvironmentLifecycleCreatedDto{}
-		apiResponse.MarshallTo(&envCreatedResponse)
+		err = apiResponse.MarshallTo(&envCreatedResponse)
+		if err != nil {
+			return nil, err
+		}
 		if envCreatedResponse.Properties.ProvisioningState != "Succeeded" {
 			return nil, errors.New("environment creation failed. provisioning state: " + envCreatedResponse.Properties.ProvisioningState)
 		}

--- a/internal/powerplatform/services/rest/api_rest.go
+++ b/internal/powerplatform/services/rest/api_rest.go
@@ -5,10 +5,7 @@ package powerplatform
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-	"net/url"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -97,30 +94,3 @@ func (client *WebApiClient) ExecuteApiRequest(ctx context.Context, scope *string
 	}
 }
 
-func (client *WebApiClient) getEnvironmentUrlById(ctx context.Context, environmentId string) (string, error) {
-	env, err := client.getEnvironment(ctx, environmentId)
-	if err != nil {
-		return "", err
-	}
-	environmentUrl := strings.TrimSuffix(env.Properties.LinkedEnvironmentMetadata.InstanceURL, "/")
-	return environmentUrl, nil
-}
-
-func (client *WebApiClient) getEnvironment(ctx context.Context, environmentId string) (*EnvironmentIdDto, error) {
-	apiUrl := &url.URL{
-		Scheme: "https",
-		Host:   client.Api.GetConfig().Urls.BapiUrl,
-		Path:   fmt.Sprintf("/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/%s", environmentId),
-	}
-	values := url.Values{}
-	values.Add("api-version", "2023-06-01")
-	apiUrl.RawQuery = values.Encode()
-
-	env := EnvironmentIdDto{}
-	_, err := client.Api.Execute(ctx, "GET", apiUrl.String(), nil, nil, []int{http.StatusOK}, &env)
-	if err != nil {
-		return nil, err
-	}
-
-	return &env, nil
-}

--- a/makefile
+++ b/makefile
@@ -40,5 +40,4 @@ test:
 	go test -timeout 120m -v ./...
 
 lint:
-	go install github.com/bflad/tfproviderlint/cmd/tfproviderlintx@latest
-	tfproviderlintx ./...
+	golangci-lint run


### PR DESCRIPTION
This pull request primarily focuses on integrating `golangci-lint` into the project's workflow and settings. There are three main changes: a new GitHub workflow was added to run `golangci-lint` on push and pull request events, the Visual Studio Code settings were updated to use `golangci-lint` as the Go linting tool, and the `makefile` was updated to use `golangci-lint` in the `lint` command.

GitHub Workflow:

* [`.github/workflows/golangci-lint.yml`](diffhunk://#diff-d9a956120ac84289d2650137f64bd8f0893331de05e44cc41899dd984c9e0d48R1-R26): A new workflow was added that runs `golangci-lint` on `push` and `pull_request` events to the `main` branch. It sets up a Go environment with a stable version and uses the `golangci-lint-action` with version `v1.59`.

Visual Studio Code Settings:

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L58-R62): The settings were updated to use `golangci-lint` as the Go linting tool with the `--fast` flag.

Makefile:

* [`makefile`](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0L43-R43): The `lint` command was updated to use `golangci-lint run` instead of the previous `tfproviderlintx` command.