### PR TITLE
fixing rest to apply infrastructure changes

### DIFF
--- a/internal/powerplatform/modifiers/force_string_value_unknown_modifier.go
+++ b/internal/powerplatform/modifiers/force_string_value_unknown_modifier.go
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package powerplatform_modifiers
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func ForceStringValueUnknownModifier() planmodifier.String {
+	return &forceStringValueUnknownModifier{}
+}
+
+type forceStringValueUnknownModifier struct {
+}
+
+func (d *forceStringValueUnknownModifier) Description(ctx context.Context) string {
+	return "Ensures that file attribute and file checksum attribute are kept synchronised."
+}
+
+func (d *forceStringValueUnknownModifier) MarkdownDescription(ctx context.Context) string {
+	return d.Description(ctx)
+}
+
+func (d *forceStringValueUnknownModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+
+	r, _ := req.Private.GetKey(ctx, "force_value_unknown")
+	if r == nil || !bytes.Equal(r, []byte("true")) {
+		return
+	}
+	resp.PlanValue = types.StringUnknown()
+}

--- a/internal/powerplatform/services/rest/datasource_rest_query.go
+++ b/internal/powerplatform/services/rest/datasource_rest_query.go
@@ -141,7 +141,7 @@ func (d *DataverseWebApiDatasource) Read(ctx context.Context, req datasource.Rea
 		return
 	}
 
-	state.Output = *outputObjectType
+	state.Output = outputObjectType
 
 	diags := resp.State.Set(ctx, &state)
 


### PR DESCRIPTION
This pull request includes several changes in the `internal/powerplatform` package, primarily focusing on refining the handling of operations and responses in the REST API. The most significant changes include the creation of a new `forceStringValueUnknownModifier` function, modifications to the `SendOperation` method to return `types.Object` instead of `*types.Object`, and several changes to the `DataverseWebApiResource` methods to enhance the handling of operations and responses.

Changes related to `forceStringValueUnknownModifier`:

* [`internal/powerplatform/modifiers/force_string_value_unknown_modifier.go`](diffhunk://#diff-c76915a0f8c902cf1947219a134dec51cd1296f048e3ff465b664c588dfa2ab4R1-R36): Created a new `ForceStringValueUnknownModifier` function that returns an instance of `forceStringValueUnknownModifier`. This function is used to ensure that file attribute and file checksum attribute are kept synchronised.

Changes related to `SendOperation`:

* [`internal/powerplatform/services/rest/api_rest.go`](diffhunk://#diff-f51e586c3bf17a19357ad1dc482d6d3c6b6eb56a70a4c88a49c7542050bade2bL40-R44): Modified the `SendOperation` method to return `types.Object` instead of `*types.Object`. In case of an unexpected HTTP return code, it now returns `types.ObjectUnknown` instead of `nil`. [[1]](diffhunk://#diff-f51e586c3bf17a19357ad1dc482d6d3c6b6eb56a70a4c88a49c7542050bade2bL40-R44) [[2]](diffhunk://#diff-f51e586c3bf17a19357ad1dc482d6d3c6b6eb56a70a4c88a49c7542050bade2bL58-R70) [[3]](diffhunk://#diff-f51e586c3bf17a19357ad1dc482d6d3c6b6eb56a70a4c88a49c7542050bade2bL74-R81)

Changes related to `DataverseWebApiResource`:

* [`internal/powerplatform/services/rest/resource_rest.go`](diffhunk://#diff-de6fe419b93bd475cf65ad57f912b87c7147005aa8c8c57113735db1d7eaf8aaR81): Made several changes to `DataverseWebApiResource` methods. These include making the `output` attribute optional and adding `ForceStringValueUnknownModifier` to its plan modifiers, modifying the `Create` method to handle `Read` operation after `Create`, and updating the `Read`, `Update`, and `Delete` methods to better handle operations and responses. Also, the `NullOutputValue` function now returns an empty JSON object instead of a null string. [[1]](diffhunk://#diff-de6fe419b93bd475cf65ad57f912b87c7147005aa8c8c57113735db1d7eaf8aaR81) [[2]](diffhunk://#diff-de6fe419b93bd475cf65ad57f912b87c7147005aa8c8c57113735db1d7eaf8aaL89-R101) [[3]](diffhunk://#diff-de6fe419b93bd475cf65ad57f912b87c7147005aa8c8c57113735db1d7eaf8aaL179-R228) [[4]](diffhunk://#diff-de6fe419b93bd475cf65ad57f912b87c7147005aa8c8c57113735db1d7eaf8aaR238-R261) [[5]](diffhunk://#diff-de6fe419b93bd475cf65ad57f912b87c7147005aa8c8c57113735db1d7eaf8aaL243-R291) [[6]](diffhunk://#diff-de6fe419b93bd475cf65ad57f912b87c7147005aa8c8c57113735db1d7eaf8aaL267-R315) [[7]](diffhunk://#diff-de6fe419b93bd475cf65ad57f912b87c7147005aa8c8c57113735db1d7eaf8aaL284-R325)

Other changes:

* [`internal/powerplatform/services/rest/api_rest.go`](diffhunk://#diff-f51e586c3bf17a19357ad1dc482d6d3c6b6eb56a70a4c88a49c7542050bade2bR104-R130): Added a new `getEnvironmentUrlById` function to retrieve the environment URL by its ID.
* [`internal/powerplatform/services/rest/datasource_rest_query.go`](diffhunk://#diff-53a0e97f9438c2b23304968ff32a53b4fc52c630b09fe4b3ea4087636225ca7eL144-R144): Removed the pointer dereference from the assignment of `state.Output` to `outputObjectType`.