### PR TITLE
Fixing typo in import documentation

### DIFF
--- a/docs/guides/importing.md
+++ b/docs/guides/importing.md
@@ -19,11 +19,11 @@ terraform import powerplatform_environment.example_env 00000000-0000-0000-0000-0
 
 ## Using import blocks
 
-Terraform allows the use of import blocks to import existing resources into your configuration.  This can be useful if you have pre-existing resources that you want to manage with Terraform.  The following is an example of an import block used to import the default Power Platform environment:
+Terraform allows the use of [import blocks](https://developer.hashicorp.com/terraform/language/import/) to import existing resources into your configuration.  This can be useful if you have pre-existing resources that you want to manage with Terraform.  The following is an example of an import block used to import the default Power Platform environment:
 
 ```terraform
 import {
-  to = powerplatform_environment.example_env
+  to = powerplatform_environment.default
   id = "00000000-0000-0000-0000-000000000001"
 }
 

--- a/templates/guides/importing.md.tmpl
+++ b/templates/guides/importing.md.tmpl
@@ -19,11 +19,11 @@ terraform import powerplatform_environment.example_env 00000000-0000-0000-0000-0
 
 ## Using import blocks
 
-Terraform allows the use of import blocks to import existing resources into your configuration.  This can be useful if you have pre-existing resources that you want to manage with Terraform.  The following is an example of an import block used to import the default Power Platform environment:
+Terraform allows the use of [import blocks](https://developer.hashicorp.com/terraform/language/import/) to import existing resources into your configuration.  This can be useful if you have pre-existing resources that you want to manage with Terraform.  The following is an example of an import block used to import the default Power Platform environment:
 
 ```terraform
 import {
-  to = powerplatform_environment.example_env
+  to = powerplatform_environment.default
   id = "00000000-0000-0000-0000-000000000001"
 }
 


### PR DESCRIPTION
This pull request includes updates to the import block examples in the documentation and templates for better clarity and accuracy. The changes involve adding a hyperlink to the Terraform import documentation and updating the resource identifier.

Updates to documentation and templates:

* [`docs/guides/importing.md`](diffhunk://#diff-33402b61bb568a48539140fd75dadb5b734c99f962d58fa52bb144b5b24e6036L22-R26): Added a hyperlink to the Terraform import documentation and updated the resource identifier from `powerplatform_environment.example_env` to `powerplatform_environment.default`.
* [`templates/guides/importing.md.tmpl`](diffhunk://#diff-74b8502195eae53381c912b068a9f597e99fa6ec1e1621766b2942027cb52749L22-R26): Added a hyperlink to the Terraform import documentation and updated the resource identifier from `powerplatform_environment.example_env` to `powerplatform_environment.default`.