### PR TITLE
Refactor authentication configuration in api_client.go and auth.go

### DIFF
--- a/internal/api/api_client.go
+++ b/internal/api/api_client.go
@@ -152,7 +152,7 @@ func (client *ApiClient) RetryAfterDefault() time.Duration {
 }
 
 func (client *ApiClient) SleepWithContext(ctx context.Context, duration time.Duration) error {
-	if client.Config.Credentials.TestMode {
+	if client.Config.TestMode {
 		//Don't sleep during testing
 		return nil
 	} else {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,7 +9,23 @@ import (
 )
 
 type ProviderConfig struct {
-	Credentials      *ProviderCredentials
+	UseCli  bool
+	UseOidc bool
+
+	TenantId     string
+	ClientId     string
+	ClientSecret string
+
+	ClientCertificatePassword string
+	ClientCertificateRaw      string
+
+	OidcRequestToken  string
+	OidcRequestUrl    string
+	OidcToken         string
+	OidcTokenFilePath string
+
+	// internal runtime configuration values
+	TestMode         bool
 	Urls             ProviderConfigUrls
 	TelemetryOptout  bool
 	Cloud            cloud.Configuration
@@ -25,41 +41,25 @@ type ProviderConfigUrls struct {
 	LicensingUrl       string
 }
 
-type ProviderCredentials struct {
-	TestMode bool
-	UseCli   bool
-	UseOidc  bool
-
-	TenantId     string
-	ClientId     string
-	ClientSecret string
-
-	ClientCertificatePassword string
-	ClientCertificateRaw      string
-
-	OidcRequestToken  string
-	OidcRequestUrl    string
-	OidcToken         string
-	OidcTokenFilePath string
-}
-
-func (model *ProviderCredentials) IsClientSecretCredentialsProvided() bool {
+// IsClientSecretCredentialsProvided returns true if all the required cred 
+func (model *ProviderConfig) IsClientSecretCredentialsProvided() bool {
 	return model.ClientId != "" && model.ClientSecret != "" && model.TenantId != ""
 }
 
-func (model *ProviderCredentials) IsClientCertificateCredentialsProvided() bool {
+func (model *ProviderConfig) IsClientCertificateCredentialsProvided() bool {
 	return model.ClientCertificateRaw != ""
 }
 
-func (model *ProviderCredentials) IsCliProvided() bool {
+func (model *ProviderConfig) IsCliProvided() bool {
 	return model.UseCli
 }
 
-func (model *ProviderCredentials) IsOidcProvided() bool {
+func (model *ProviderConfig) IsOidcProvided() bool {
 	return model.UseOidc
 }
 
-type ProviderCredentialsModel struct {
+// ProviderConfigModel is a model for the provider configuration.
+type ProviderConfigModel struct {
 	UseCli  types.Bool `tfsdk:"use_cli"`
 	UseOidc types.Bool `tfsdk:"use_oidc"`
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -17,8 +17,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/microsoft/terraform-provider-power-platform/common"
-	"github.com/microsoft/terraform-provider-power-platform/internal/api"
 	"github.com/microsoft/terraform-provider-power-platform/internal/config"
+	"github.com/microsoft/terraform-provider-power-platform/internal/api"
 	"github.com/microsoft/terraform-provider-power-platform/internal/constants"
 	"github.com/microsoft/terraform-provider-power-platform/internal/helpers"
 	"github.com/microsoft/terraform-provider-power-platform/internal/services/admin_management_application"
@@ -53,9 +53,7 @@ type PowerPlatformProvider struct {
 }
 
 func NewPowerPlatformProvider(ctx context.Context, testModeEnabled ...bool) func() provider.Provider {
-	cred := config.ProviderCredentials{}
 	config := config.ProviderConfig{
-		Credentials: &cred,
 		Urls: config.ProviderConfigUrls{
 			BapiUrl:            constants.PUBLIC_BAPI_DOMAIN,
 			PowerAppsUrl:       constants.PUBLIC_POWERAPPS_API_DOMAIN,
@@ -71,7 +69,7 @@ func NewPowerPlatformProvider(ctx context.Context, testModeEnabled ...bool) func
 
 	if len(testModeEnabled) > 0 && testModeEnabled[0] {
 		tflog.Warn(ctx, "Test mode enabled. Authentication requests will not be sent to the backend APIs.")
-		config.Credentials.TestMode = true
+		config.TestMode = true
 	}
 
 	return func() provider.Provider {
@@ -177,7 +175,7 @@ func (p *PowerPlatformProvider) Configure(ctx context.Context, req provider.Conf
 	_, exitContext := helpers.EnterProviderContext(ctx, req)
 	defer exitContext()
 
-	var config config.ProviderCredentialsModel
+	var config config.ProviderConfigModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 
 	if resp.Diagnostics.HasError() {
@@ -315,23 +313,23 @@ func (p *PowerPlatformProvider) Configure(ctx context.Context, req provider.Conf
 	ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, "oidc_token")
 	ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, "oidc_token_file_path")
 
-	if p.Config.Credentials.TestMode {
+	if p.Config.TestMode {
 		tflog.Info(ctx, "Test mode enabled. Authentication requests will not be sent to the backend APIs.")
 	} else if useCli {
 		tflog.Info(ctx, "Using CLI for authentication")
-		p.Config.Credentials.UseCli = true
+		p.Config.UseCli = true
 	} else if useOidc {
 		tflog.Info(ctx, "Using OpenID Connect for authentication")
 		ValidateProviderAttribute(resp, path.Root("tenant_id"), "tenant id", tenantId, "POWER_PLATFORM_TENANT_ID")
 		ValidateProviderAttribute(resp, path.Root("client_id"), "client id", clientId, "POWER_PLATFORM_CLIENT_ID")
 
-		p.Config.Credentials.UseOidc = true
-		p.Config.Credentials.TenantId = tenantId
-		p.Config.Credentials.ClientId = clientId
-		p.Config.Credentials.OidcRequestToken = oidcRequestToken
-		p.Config.Credentials.OidcRequestUrl = oidcRequestUrl
-		p.Config.Credentials.OidcToken = oidcToken
-		p.Config.Credentials.OidcTokenFilePath = oidcTokenFilePath
+		p.Config.UseOidc = true
+		p.Config.TenantId = tenantId
+		p.Config.ClientId = clientId
+		p.Config.OidcRequestToken = oidcRequestToken
+		p.Config.OidcRequestUrl = oidcRequestUrl
+		p.Config.OidcToken = oidcToken
+		p.Config.OidcTokenFilePath = oidcTokenFilePath
 	} else if clientCertificatePassword != "" && (clientCertificate != "" || clientCertificateFilePath != "") {
 		tflog.Info(ctx, "Using client certificate for authentication")
 		ValidateProviderAttribute(resp, path.Root("tenant_id"), "tenant id", tenantId, "POWER_PLATFORM_TENANT_ID")
@@ -341,16 +339,16 @@ func (p *PowerPlatformProvider) Configure(ctx context.Context, req provider.Conf
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root("client_certificate"), "Error getting certificate", err.Error())
 		}
-		p.Config.Credentials.ClientCertificateRaw = cert
-		p.Config.Credentials.ClientCertificatePassword = clientCertificatePassword
-		p.Config.Credentials.TenantId = tenantId
-		p.Config.Credentials.ClientId = clientId
+		p.Config.ClientCertificateRaw = cert
+		p.Config.ClientCertificatePassword = clientCertificatePassword
+		p.Config.TenantId = tenantId
+		p.Config.ClientId = clientId
 	} else {
 		tflog.Info(ctx, "Using client id and secret for authentication")
 		if tenantId != "" && clientId != "" && clientSecret != "" {
-			p.Config.Credentials.TenantId = tenantId
-			p.Config.Credentials.ClientId = clientId
-			p.Config.Credentials.ClientSecret = clientSecret
+			p.Config.TenantId = tenantId
+			p.Config.ClientId = clientId
+			p.Config.ClientSecret = clientSecret
 		} else {
 			ValidateProviderAttribute(resp, path.Root("tenant_id"), "tenant id", tenantId, "POWER_PLATFORM_TENANT_ID")
 			ValidateProviderAttribute(resp, path.Root("client_id"), "client id", clientId, "POWER_PLATFORM_CLIENT_ID")


### PR DESCRIPTION
This pull request involves a significant refactor of the configuration and authentication handling in the `internal/config` and `internal/api` packages. The main goal is to simplify the configuration structure by moving several fields from `ProviderCredentials` to `ProviderConfig`.

### Configuration Refactor:

* [`internal/config/config.go`](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL12-L29): Moved several fields from `ProviderCredentials` to `ProviderConfig`, including `TestMode`, `Urls`, `TelemetryOptout`, `Cloud`, and `TerraformVersion`. Updated methods to reflect these changes. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL12-L29) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR26-R62)

### Authentication Updates:

* [`internal/api/auth.go`](diffhunk://#diff-1a28b89630d0f9aa800869f02725ff42a4f02b1fe79f01fb62477b700a07df8fL65-R72): Updated various authentication methods to use the new `ProviderConfig` structure instead of `ProviderCredentials`. This includes methods like `AuthenticateClientCertificate`, `AuthenticateUsingCli`, `AuthenticateClientSecret`, and `AuthenticateOIDC`. [[1]](diffhunk://#diff-1a28b89630d0f9aa800869f02725ff42a4f02b1fe79f01fb62477b700a07df8fL65-R72) [[2]](diffhunk://#diff-1a28b89630d0f9aa800869f02725ff42a4f02b1fe79f01fb62477b700a07df8fL111-R113) [[3]](diffhunk://#diff-1a28b89630d0f9aa800869f02725ff42a4f02b1fe79f01fb62477b700a07df8fL124-R124) [[4]](diffhunk://#diff-1a28b89630d0f9aa800869f02725ff42a4f02b1fe79f01fb62477b700a07df8fL179-R184) [[5]](diffhunk://#diff-1a28b89630d0f9aa800869f02725ff42a4f02b1fe79f01fb62477b700a07df8fL273-R273) [[6]](diffhunk://#diff-1a28b89630d0f9aa800869f02725ff42a4f02b1fe79f01fb62477b700a07df8fL283-R289)

### Provider Initialization:

* [`internal/provider/provider.go`](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22L20-R21): Modified the `NewPowerPlatformProvider` and `Configure` functions to align with the new `ProviderConfig` structure. This includes setting fields like `TestMode`, `UseCli`, `UseOidc`, `TenantId`, `ClientId`, and others directly on `ProviderConfig`. [[1]](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22L20-R21) [[2]](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22L56-L58) [[3]](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22L74-R72) [[4]](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22L180-R178) [[5]](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22L318-R332) [[6]](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22L344-R351)

### Minor Fixes:

* [`internal/api/api_client.go`](diffhunk://#diff-f96a2c3a33ffb71e758da079bd1e4a09bacb0bf87c70c9185145ef18896d2d3cL155-R155): Fixed a conditional check to use `client.Config.TestMode` instead of `client.Config.Credentials.TestMode`.