### PR TITLE
Refactor to use request context in all resources and data sources

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,4 +43,8 @@ linters-settings:
     issues:
       max-issues-per-linter: 1
       max-same-issues: 1
- 
+
+issues:
+  exclude:
+    - "ineffectual assignment to ctx"
+    - "SA4006: this value of `ctx` is never used"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,3 +48,4 @@ issues:
   exclude:
     - "ineffectual assignment to ctx"
     - "SA4006: this value of `ctx` is never used"
+    - "unused parameter (ctx|diags|req|resp)"

--- a/docs/resources/environment_group.md
+++ b/docs/resources/environment_group.md
@@ -55,7 +55,6 @@ resource "powerplatform_tenant_settings" "environment_routing" {
   }
 
   walk_me_opt_out = true
-
 }
 ```
 

--- a/examples/data-sources/powerplatform_connection_shares/variables.tf
+++ b/examples/data-sources/powerplatform_connection_shares/variables.tf
@@ -8,5 +8,4 @@ variable "azure_openai_connection_id" {
   default     = "00000000-0000-0000-0000-000000000002"
   description = "Unique identifier of the connection"
   type        = string
-
 }

--- a/examples/resources/powerplatform_connection_share/variables.tf
+++ b/examples/resources/powerplatform_connection_share/variables.tf
@@ -27,5 +27,4 @@ variable "user_object_id" {
   default     = "00000000-0000-0000-0000-000000000003"
   description = "Entra Object Id identifier of the user that will be granted access to the connection"
   type        = string
-
 }

--- a/examples/resources/powerplatform_environment_group/resource.tf
+++ b/examples/resources/powerplatform_environment_group/resource.tf
@@ -40,5 +40,4 @@ resource "powerplatform_tenant_settings" "environment_routing" {
   }
 
   walk_me_opt_out = true
-
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -93,7 +93,7 @@ func (p *PowerPlatformProvider) Metadata(ctx context.Context, req provider.Metad
 }
 
 func (p *PowerPlatformProvider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
-	_, exitContext := helpers.EnterProviderContext(ctx, req)
+	ctx, exitContext := helpers.EnterProviderContext(ctx, req)
 	defer exitContext()
 
 	resp.Schema = schema.Schema{
@@ -171,7 +171,7 @@ func (p *PowerPlatformProvider) Schema(ctx context.Context, req provider.SchemaR
 }
 
 func (p *PowerPlatformProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
-	_, exitContext := helpers.EnterProviderContext(ctx, req)
+	ctx, exitContext := helpers.EnterProviderContext(ctx, req)
 	defer exitContext()
 
 	// Get Provider Configuration from the provider block in the configuration.

--- a/internal/services/admin_management_application/resource_admin_management_application.go
+++ b/internal/services/admin_management_application/resource_admin_management_application.go
@@ -80,6 +80,7 @@ func (r *AdminManagementApplicationResource) Configure(ctx context.Context, req 
 	defer exitContext()
 
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
 		return
 	}
 

--- a/internal/services/admin_management_application/resource_admin_management_application.go
+++ b/internal/services/admin_management_application/resource_admin_management_application.go
@@ -80,7 +80,7 @@ func (r *AdminManagementApplicationResource) Configure(ctx context.Context, req 
 	defer exitContext()
 
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 

--- a/internal/services/admin_management_application/resource_admin_management_application.go
+++ b/internal/services/admin_management_application/resource_admin_management_application.go
@@ -15,18 +15,20 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/microsoft/terraform-provider-power-platform/internal/api"
-	"github.com/microsoft/terraform-provider-power-platform/internal/constants"
 	"github.com/microsoft/terraform-provider-power-platform/internal/customtypes"
+	"github.com/microsoft/terraform-provider-power-platform/internal/helpers"
 )
 
 func NewAdminManagementApplicationResource() resource.Resource {
 	return &AdminManagementApplicationResource{
-		ProviderTypeName: "powerplatform",
-		TypeName:         "_admin_management_application",
+		TypeInfo: helpers.TypeInfo{
+			TypeName: "admin_management_application",
+		},
 	}
 }
 
 type AdminManagementApplicationResource struct {
+	helpers.TypeInfo
 	AdminManagementApplicationClient AdminManagementApplicationClient
 	ProviderTypeName                 string
 	TypeName                         string
@@ -38,10 +40,21 @@ type AdminManagementApplicationResourceModel struct {
 }
 
 func (r *AdminManagementApplicationResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + r.TypeName
+	// update our own internal storage of the provider type name.
+	r.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = r.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (r *AdminManagementApplicationResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
 	resp.Schema = schema.Schema{
 		Description:         "Power Platform Admin Management Application",
 		MarkdownDescription: "This resource allows you to register a service principal as an administrator for Power Platform.\n\nThis resource implements the process documented here [Registering an admin management application](https://learn.microsoft.com/power-platform/admin/powerplatform-api-create-service-principal). A service principal can't register itself—by design, the application must be registered by an administrator.",
@@ -65,6 +78,9 @@ func (r *AdminManagementApplicationResource) Schema(ctx context.Context, req res
 }
 
 func (r *AdminManagementApplicationResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
 	if req.ProviderData == nil {
 		return
 	}
@@ -79,26 +95,21 @@ func (r *AdminManagementApplicationResource) Configure(ctx context.Context, req 
 }
 
 func (r *AdminManagementApplicationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
 func (r *AdminManagementApplicationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	tflog.Debug(ctx, fmt.Sprintf("READ RESOURCE START: %s", r.ProviderTypeName))
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 
 	var state AdminManagementApplicationResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	timeout, diags := state.Timeouts.Read(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	adminApp, err := r.AdminManagementApplicationClient.GetAdminApplication(ctx, state.Id.ValueString())
 	if err != nil {
@@ -110,27 +121,17 @@ func (r *AdminManagementApplicationResource) Read(ctx context.Context, req resou
 		Timeouts: state.Timeouts,
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
-
-	tflog.Debug(ctx, fmt.Sprintf("READ RESOURCE END: %s", r.ProviderTypeName))
 }
 
 func (r *AdminManagementApplicationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	tflog.Debug(ctx, fmt.Sprintf("CREATE RESOURCE START: %s", r.ProviderTypeName))
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 
 	var plan AdminManagementApplicationResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	timeout, diags := plan.Timeouts.Create(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	adminApp, err := r.AdminManagementApplicationClient.RegisterAdminApplication(ctx, plan.Id.ValueString())
 	if err != nil {
@@ -144,11 +145,11 @@ func (r *AdminManagementApplicationResource) Create(ctx context.Context, req res
 			Timeouts: plan.Timeouts,
 		})...)
 
-	tflog.Debug(ctx, fmt.Sprintf("CREATE RESOURCE END: %s", r.ProviderTypeName))
 }
 
 func (r *AdminManagementApplicationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	tflog.Debug(ctx, fmt.Sprintf("DELETE RESOURCE START: %s", r.ProviderTypeName))
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 
 	var state AdminManagementApplicationResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -156,22 +157,11 @@ func (r *AdminManagementApplicationResource) Delete(ctx context.Context, req res
 		return
 	}
 
-	timeout, diags := state.Timeouts.Delete(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
 	err := r.AdminManagementApplicationClient.UnregisterAdminApplication(ctx, state.Id.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to unregister admin application", fmt.Sprintf("Failed to unregister admin application: %v", err))
 		return
 	}
-
-	tflog.Debug(ctx, fmt.Sprintf("DELETE RESOURCE END: %s", r.ProviderTypeName))
 }
 
 func (r *AdminManagementApplicationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/internal/services/admin_management_application/resource_admin_management_application.go
+++ b/internal/services/admin_management_application/resource_admin_management_application.go
@@ -144,7 +144,6 @@ func (r *AdminManagementApplicationResource) Create(ctx context.Context, req res
 			Id:       customtypes.NewUUIDValue(adminApp.ClientId),
 			Timeouts: plan.Timeouts,
 		})...)
-
 }
 
 func (r *AdminManagementApplicationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/services/admin_management_application/resource_admin_management_application.go
+++ b/internal/services/admin_management_application/resource_admin_management_application.go
@@ -30,8 +30,6 @@ func NewAdminManagementApplicationResource() resource.Resource {
 type AdminManagementApplicationResource struct {
 	helpers.TypeInfo
 	AdminManagementApplicationClient AdminManagementApplicationClient
-	ProviderTypeName                 string
-	TypeName                         string
 }
 
 type AdminManagementApplicationResourceModel struct {

--- a/internal/services/admin_management_application/resource_admin_management_application.go
+++ b/internal/services/admin_management_application/resource_admin_management_application.go
@@ -162,5 +162,8 @@ func (r *AdminManagementApplicationResource) Delete(ctx context.Context, req res
 }
 
 func (r *AdminManagementApplicationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
 	resp.Diagnostics.AddError("Update not supported", "Update not supported")
 }

--- a/internal/services/application/datasource_environment_application_packages.go
+++ b/internal/services/application/datasource_environment_application_packages.go
@@ -68,7 +68,9 @@ func (d *EnvironmentApplicationPackagesDataSource) Metadata(ctx context.Context,
 	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
-func (d *EnvironmentApplicationPackagesDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *EnvironmentApplicationPackagesDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
 	resp.Schema = schema.Schema{
 		Description:         "Fetches the list of Dynamics 365 applications in a tenant",
 		MarkdownDescription: "Fetches the list of Dynamics 365 applications in a tenant.  The data source can be filtered by name and publisher name.\n\nThis is functionally equivalent to the [Environment-level view of apps](https://learn.microsoft.com/power-platform/admin/manage-apps#environment-level-view-of-apps) in the Power Platform Admin Center or the [`pac application list` command from Power Platform CLI](https://learn.microsoft.com/power-platform/developer/cli/reference/application#pac-application-list).  This data source uses the [Get Environment Application Package](https://learn.microsoft.com/rest/api/power-platform/appmanagement/applications/get-environment-application-package) endpoint in the Power Platform API.",
@@ -156,8 +158,11 @@ func (d *EnvironmentApplicationPackagesDataSource) Schema(ctx context.Context, _
 }
 
 func (d *EnvironmentApplicationPackagesDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 	clientApi := req.ProviderData.(*api.ProviderClient).Api

--- a/internal/services/application/datasource_environment_application_packages.go
+++ b/internal/services/application/datasource_environment_application_packages.go
@@ -57,7 +57,15 @@ type EnvironmentApplicationPackageDataSourceModel struct {
 }
 
 func (d *EnvironmentApplicationPackagesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (d *EnvironmentApplicationPackagesDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/services/application/datasource_environment_application_packages.go
+++ b/internal/services/application/datasource_environment_application_packages.go
@@ -157,6 +157,7 @@ func (d *EnvironmentApplicationPackagesDataSource) Schema(ctx context.Context, _
 
 func (d *EnvironmentApplicationPackagesDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 	clientApi := req.ProviderData.(*api.ProviderClient).Api

--- a/internal/services/application/datasource_tenant_application_packages.go
+++ b/internal/services/application/datasource_tenant_application_packages.go
@@ -208,6 +208,7 @@ func (d *TenantApplicationPackagesDataSource) Schema(ctx context.Context, _ data
 
 func (d *TenantApplicationPackagesDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 	clientApi := req.ProviderData.(*api.ProviderClient).Api

--- a/internal/services/application/datasource_tenant_application_packages.go
+++ b/internal/services/application/datasource_tenant_application_packages.go
@@ -68,7 +68,15 @@ type TenantApplicationErrorDetailsDataSourceModel struct {
 }
 
 func (d *TenantApplicationPackagesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (d *TenantApplicationPackagesDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/services/application/resource_environment_application_package_install.go
+++ b/internal/services/application/resource_environment_application_package_install.go
@@ -92,6 +92,7 @@ func (r *EnvironmentApplicationPackageInstallResource) Configure(ctx context.Con
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
 		return
 	}
 

--- a/internal/services/application/resource_environment_application_package_install.go
+++ b/internal/services/application/resource_environment_application_package_install.go
@@ -92,7 +92,7 @@ func (r *EnvironmentApplicationPackageInstallResource) Configure(ctx context.Con
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 

--- a/internal/services/application/resource_environment_application_package_install.go
+++ b/internal/services/application/resource_environment_application_package_install.go
@@ -180,26 +180,25 @@ func (r *EnvironmentApplicationPackageInstallResource) Update(ctx context.Contex
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 
-	tflog.Debug(ctx, fmt.Sprintf("UPDATE RESOURCE END: %s", r.ProviderTypeName))
 	tflog.Debug(ctx, "No application have been updated, as this is the expected behavior")
 }
 
 func (r *EnvironmentApplicationPackageInstallResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var state *EnvironmentApplicationPackageInstallResourceModel
-
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 
+	var state *EnvironmentApplicationPackageInstallResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	tflog.Debug(ctx, fmt.Sprintf("DELETE RESOURCE END: %s", r.ProviderTypeName))
 	tflog.Debug(ctx, "No application have been uninstalled, as this is the expected behavior")
 }
 
 func (r *EnvironmentApplicationPackageInstallResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/services/application/resource_environment_application_package_install.go
+++ b/internal/services/application/resource_environment_application_package_install.go
@@ -144,7 +144,6 @@ func (r *EnvironmentApplicationPackageInstallResource) Create(ctx context.Contex
 	tflog.Trace(ctx, fmt.Sprintf("created a resource with ID %s", state.UniqueName.ValueString()))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-
 }
 
 func (r *EnvironmentApplicationPackageInstallResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {

--- a/internal/services/authorization/datasource_securityroles.go
+++ b/internal/services/authorization/datasource_securityroles.go
@@ -122,7 +122,15 @@ func (d *SecurityRolesDataSource) Configure(ctx context.Context, req datasource.
 }
 
 func (d *SecurityRolesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (d *SecurityRolesDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {

--- a/internal/services/authorization/datasource_securityroles.go
+++ b/internal/services/authorization/datasource_securityroles.go
@@ -107,6 +107,7 @@ func (_ *SecurityRolesDataSource) Schema(ctx context.Context, _ datasource.Schem
 
 func (d *SecurityRolesDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 	clientApi := req.ProviderData.(*api.ProviderClient).Api

--- a/internal/services/authorization/resource_user.go
+++ b/internal/services/authorization/resource_user.go
@@ -142,6 +142,7 @@ func (r *UserResource) Configure(ctx context.Context, req resource.ConfigureRequ
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
 		return
 	}
 
@@ -285,7 +286,6 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	plan.BusinessUnitId = model.BusinessUnitId
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-
 }
 
 func (r *UserResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/services/authorization/resource_user.go
+++ b/internal/services/authorization/resource_user.go
@@ -142,7 +142,7 @@ func (r *UserResource) Configure(ctx context.Context, req resource.ConfigureRequ
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 

--- a/internal/services/authorization/resource_user.go
+++ b/internal/services/authorization/resource_user.go
@@ -195,7 +195,6 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 	tflog.Trace(ctx, fmt.Sprintf("created a resource with ID %s", plan.Id.ValueString()))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-
 }
 
 func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {

--- a/internal/services/authorization/resource_user.go
+++ b/internal/services/authorization/resource_user.go
@@ -27,15 +27,15 @@ var _ resource.ResourceWithImportState = &UserResource{}
 
 func NewUserResource() resource.Resource {
 	return &UserResource{
-		ProviderTypeName: "powerplatform",
-		TypeName:         "_user",
+		TypeInfo: helpers.TypeInfo{
+			TypeName: "user",
+		},
 	}
 }
 
 type UserResource struct {
-	UserClient       UserClient
-	ProviderTypeName string
-	TypeName         string
+	helpers.TypeInfo
+	UserClient UserClient
 }
 
 type UserResourceModel struct {
@@ -52,10 +52,20 @@ type UserResourceModel struct {
 }
 
 func (r *UserResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + r.TypeName
+	// update our own internal storage of the provider type name.
+	r.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = r.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "This resource associates a user to a Power Platform environment. Additional Resources:\n\n* [Add users to an environment](https://learn.microsoft.com/power-platform/admin/add-users-to-environment)\n\n* [Overview of User Security](https://learn.microsoft.com/power-platform/admin/grant-users-access)",
 		Description:         "This resource associates a user to a Power Platform environment",
@@ -130,6 +140,8 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 }
 
 func (r *UserResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	if req.ProviderData == nil {
 		return
 	}
@@ -148,24 +160,14 @@ func (r *UserResource) Configure(ctx context.Context, req resource.ConfigureRequ
 }
 
 func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
 	var plan *UserResourceModel
-
-	tflog.Debug(ctx, fmt.Sprintf("CREATE RESOURCE START: %s", r.ProviderTypeName))
-
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	timeout, diags := plan.Timeouts.Create(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	userDto, err := r.UserClient.CreateUser(ctx, plan.EnvironmentId.ValueString(), plan.AadId.ValueString())
 	if err != nil {
@@ -194,10 +196,11 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 
-	tflog.Debug(ctx, fmt.Sprintf("CREATE RESOURCE END: %s", r.ProviderTypeName))
 }
 
 func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	var state *UserResourceModel
 
 	tflog.Debug(ctx, fmt.Sprintf("READ RESOURCE START: %s", r.ProviderTypeName))
@@ -207,15 +210,6 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	timeout, diags := state.Timeouts.Read(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	userDto, err := r.UserClient.GetUserByAadObjectId(ctx, state.EnvironmentId.ValueString(), state.AadId.ValueString())
 	if err != nil {
@@ -241,14 +235,13 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	tflog.Debug(ctx, fmt.Sprintf("READ: %s_environment with id %s", r.ProviderTypeName, state.Id.ValueString()))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-
-	tflog.Debug(ctx, fmt.Sprintf("READ RESOURCE END: %s", r.ProviderTypeName))
 }
 
 func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan *UserResourceModel
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 
-	tflog.Debug(ctx, fmt.Sprintf("UPDATE RESOURCE START: %s", r.ProviderTypeName))
+	var plan *UserResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 
@@ -310,24 +303,15 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 }
 
 func (r *UserResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
 	var state *UserResourceModel
-
-	tflog.Debug(ctx, fmt.Sprintf("DELETE RESOURCE START: %s", r.ProviderTypeName))
-
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	timeout, diags := state.Timeouts.Delete(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	if state.DisableDelete.ValueBool() {
 		err := r.UserClient.DeleteUser(ctx, state.EnvironmentId.ValueString(), state.Id.ValueString())

--- a/internal/services/capacity/datasource_tenant_capacity.go
+++ b/internal/services/capacity/datasource_tenant_capacity.go
@@ -137,6 +137,7 @@ func (d *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, res
 
 func (d *DataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 	client := req.ProviderData.(*api.ProviderClient).Api

--- a/internal/services/capacity/datasource_tenant_capacity.go
+++ b/internal/services/capacity/datasource_tenant_capacity.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/microsoft/terraform-provider-power-platform/internal/api"
 	"github.com/microsoft/terraform-provider-power-platform/internal/helpers"
 )
@@ -56,7 +57,15 @@ type ConsumptionDataSourceModel struct {
 }
 
 func (d *DataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (d *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/services/capacity/datasource_tenant_capacity.go
+++ b/internal/services/capacity/datasource_tenant_capacity.go
@@ -68,7 +68,9 @@ func (d *DataSource) Metadata(ctx context.Context, req datasource.MetadataReques
 	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
-func (d *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *DataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
 	resp.Schema = schema.Schema{
 		Description:         "Fetches the capacity information for a given tenant.",
 		MarkdownDescription: "Fetches the capacity information for a given tenant.",
@@ -136,8 +138,11 @@ func (d *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, res
 }
 
 func (d *DataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 	client := req.ProviderData.(*api.ProviderClient).Api
@@ -157,6 +162,7 @@ func (d *DataSource) Configure(ctx context.Context, req datasource.ConfigureRequ
 func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
 	defer exitContext()
+
 	var state DataSourceModel
 	var tenantId string
 	req.Config.GetAttribute(ctx, path.Root("tenant_id"), &tenantId)

--- a/internal/services/capacity/datasource_tenant_capacity.go
+++ b/internal/services/capacity/datasource_tenant_capacity.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/microsoft/terraform-provider-power-platform/internal/api"
+	"github.com/microsoft/terraform-provider-power-platform/internal/helpers"
 )
 
 var (
@@ -21,15 +22,15 @@ var (
 
 func NewTenantCapcityDataSource() datasource.DataSource {
 	return &DataSource{
-		ProviderTypeName: "powerplatform",
-		TypeName:         "_tenant_capacity",
+		TypeInfo: helpers.TypeInfo{
+			TypeName: "tenant_capacity",
+		},
 	}
 }
 
 type DataSource struct {
-	CapacityClient   Client
-	ProviderTypeName string
-	TypeName         string
+	helpers.TypeInfo
+	CapacityClient Client
 }
 
 type DataSourceModel struct {
@@ -144,6 +145,8 @@ func (d *DataSource) Configure(ctx context.Context, req datasource.ConfigureRequ
 }
 
 func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
 	var state DataSourceModel
 	var tenantId string
 	req.Config.GetAttribute(ctx, path.Root("tenant_id"), &tenantId)

--- a/internal/services/connection/datasource_connection_shares.go
+++ b/internal/services/connection/datasource_connection_shares.go
@@ -56,7 +56,15 @@ type SharesPrincipalDataSourceModel struct {
 }
 
 func (d *SharesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (d *SharesDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/services/connection/datasource_connection_shares.go
+++ b/internal/services/connection/datasource_connection_shares.go
@@ -126,6 +126,7 @@ func (d *SharesDataSource) Schema(ctx context.Context, _ datasource.SchemaReques
 
 func (d *SharesDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 	client := req.ProviderData.(*api.ProviderClient).Api

--- a/internal/services/connection/datasource_connections.go
+++ b/internal/services/connection/datasource_connections.go
@@ -65,7 +65,10 @@ func (d *ConnectionsDataSource) Metadata(ctx context.Context, req datasource.Met
 	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
-func (d *ConnectionsDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *ConnectionsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
 	resp.Schema = schema.Schema{
 		Description:         "Fetches a list of \"Connections\" for a given environment. Each connection represents an connection instance to an external data source or service.",
 		MarkdownDescription: "Fetches a list of [Connection](https://learn.microsoft.com/en-us/power-apps/maker/canvas-apps/add-manage-connections) for a given environment. Each connection represents an connection instance to an external data source or service.",
@@ -120,8 +123,11 @@ func (d *ConnectionsDataSource) Schema(ctx context.Context, _ datasource.SchemaR
 }
 
 func (d *ConnectionsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 	client := req.ProviderData.(*api.ProviderClient).Api
@@ -141,6 +147,7 @@ func (d *ConnectionsDataSource) Configure(ctx context.Context, req datasource.Co
 func (d *ConnectionsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
 	defer exitContext()
+
 	var state ConnectionsListDataSourceModel
 	resp.State.Get(ctx, &state)
 

--- a/internal/services/connection/datasource_connections.go
+++ b/internal/services/connection/datasource_connections.go
@@ -121,6 +121,7 @@ func (d *ConnectionsDataSource) Schema(ctx context.Context, _ datasource.SchemaR
 
 func (d *ConnectionsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 	client := req.ProviderData.(*api.ProviderClient).Api

--- a/internal/services/connection/datasource_connections.go
+++ b/internal/services/connection/datasource_connections.go
@@ -54,7 +54,15 @@ type ConnectionsDataSourceModel struct {
 }
 
 func (d *ConnectionsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (d *ConnectionsDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/services/connection/resource_connection.go
+++ b/internal/services/connection/resource_connection.go
@@ -141,6 +141,7 @@ func (r *Resource) Configure(ctx context.Context, req resource.ConfigureRequest,
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
 		return
 	}
 

--- a/internal/services/connection/resource_connection.go
+++ b/internal/services/connection/resource_connection.go
@@ -30,15 +30,15 @@ var _ resource.ResourceWithImportState = &Resource{}
 
 func NewConnectionResource() resource.Resource {
 	return &Resource{
-		ProviderTypeName: "powerplatform",
-		TypeName:         "_connection",
+		TypeInfo: helpers.TypeInfo{
+			TypeName: "connection",
+		},
 	}
 }
 
 type Resource struct {
+	helpers.TypeInfo
 	ConnectionsClient ConnectionsClient
-	ProviderTypeName  string
-	TypeName          string
 }
 
 type ResourceModel struct {
@@ -53,10 +53,20 @@ type ResourceModel struct {
 }
 
 func (r *Resource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + r.TypeName
+	// update our own internal storage of the provider type name.
+	r.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = r.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages a [Connection](https://learn.microsoft.com/en-us/power-apps/maker/canvas-apps/add-manage-connections). A connection in Power Platform serves as a means to integrate external data sources and services with your Power Platform apps, flows, and other solutions. It acts as a bridge, facilitating secure communication between your solutions and various external systems.",
 		Attributes: map[string]schema.Attribute{
@@ -129,6 +139,8 @@ func (d *Resource) ConfigValidators(ctx context.Context) []resource.ConfigValida
 }
 
 func (r *Resource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	if req.ProviderData == nil {
 		return
 	}
@@ -147,9 +159,9 @@ func (r *Resource) Configure(ctx context.Context, req resource.ConfigureRequest,
 }
 
 func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	var plan *ResourceModel
-
-	tflog.Debug(ctx, fmt.Sprintf("CREATE RESOURCE START: %s", r.ProviderTypeName))
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 
@@ -186,15 +198,6 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		connectionToCreate.Properties.ConnectionParametersSet = params
 	}
 
-	timeout, diags := plan.Timeouts.Create(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
 	connection, err := r.ConnectionsClient.CreateConnection(ctx, plan.EnvironmentId.ValueString(), plan.Name.ValueString(), connectionToCreate)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create connection", err.Error())
@@ -220,10 +223,11 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 
-	tflog.Debug(ctx, fmt.Sprintf("CREATE RESOURCE END: %s", r.ProviderTypeName))
 }
 
 func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	var state *ResourceModel
 
 	tflog.Debug(ctx, fmt.Sprintf("READ RESOURCE START: %s", r.TypeName))
@@ -233,15 +237,6 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	timeout, diags := state.Timeouts.Read(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	connection, err := r.ConnectionsClient.GetConnection(ctx, state.EnvironmentId.ValueString(), state.Name.ValueString(), state.Id.ValueString())
 	if err != nil {
@@ -270,9 +265,10 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 }
 
 func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan *ResourceModel
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 
-	tflog.Debug(ctx, fmt.Sprintf("UPDATE RESOURCE START: %s", r.ProviderTypeName))
+	var plan *ResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 
@@ -341,22 +337,14 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state *ResourceModel
 
-	tflog.Debug(ctx, fmt.Sprintf("DELETE RESOURCE START: %s", r.ProviderTypeName))
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	timeout, diags := state.Timeouts.Delete(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	err := r.ConnectionsClient.DeleteConnection(ctx, state.EnvironmentId.ValueString(), state.Name.ValueString(), state.Id.ValueString())
 	if err != nil {

--- a/internal/services/connection/resource_connection.go
+++ b/internal/services/connection/resource_connection.go
@@ -222,7 +222,6 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-
 }
 
 func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {

--- a/internal/services/connection/resource_connection.go
+++ b/internal/services/connection/resource_connection.go
@@ -141,7 +141,7 @@ func (r *Resource) Configure(ctx context.Context, req resource.ConfigureRequest,
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 

--- a/internal/services/connection/resource_connection_share.go
+++ b/internal/services/connection/resource_connection_share.go
@@ -140,8 +140,9 @@ func (r *ShareResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 func (r *ShareResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
+
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 
@@ -161,6 +162,7 @@ func (r *ShareResource) Configure(ctx context.Context, req resource.ConfigureReq
 func (r *ShareResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
+
 	var plan *ShareResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -192,6 +194,7 @@ func (r *ShareResource) Create(ctx context.Context, req resource.CreateRequest, 
 func (r *ShareResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
+
 	var state *ShareResourceModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)

--- a/internal/services/connection/resource_connection_share.go
+++ b/internal/services/connection/resource_connection_share.go
@@ -187,7 +187,6 @@ func (r *ShareResource) Create(ctx context.Context, req resource.CreateRequest, 
 	state := ConvertFromConnectionResourceSharesDto(plan, share)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-
 }
 
 func (r *ShareResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {

--- a/internal/services/connection/resource_connection_share.go
+++ b/internal/services/connection/resource_connection_share.go
@@ -141,6 +141,7 @@ func (r *ShareResource) Configure(ctx context.Context, req resource.ConfigureReq
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
 		return
 	}
 
@@ -211,7 +212,6 @@ func (r *ShareResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	newState := ConvertFromConnectionResourceSharesDto(state, share)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
-
 }
 
 func (r *ShareResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/internal/services/connectors/datasource_connectors.go
+++ b/internal/services/connectors/datasource_connectors.go
@@ -77,7 +77,9 @@ func (d *DataSource) Metadata(ctx context.Context, req datasource.MetadataReques
 	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
-func (d *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *DataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
 	resp.Schema = schema.Schema{
 		Description:         "Fetches the list of available connectors within a specific Power Platform tenant. Each connector represents a service that can be used to enhance the capabilities of Power Apps, Power Automate, and Power Virtual Agents. The returned list includes both standard and custom connectors, providing a comprehensive view of the services that can be integrated into your Power Platform solutions. The list can be used to understand what services are readily available for use within your tenant, and can assist in planning and developing new applications or flows. It's important to note that the availability of connectors may vary based on the specific licenses and permissions assigned within your tenant.",
 		MarkdownDescription: "Fetches the list of available connectors within a specific Power Platform tenant. Each connector represents a service that can be used to enhance the capabilities of Power Apps, Power Automate, and Power Virtual Agents. The returned list includes both standard and custom connectors, providing a comprehensive view of the services that can be integrated into your Power Platform solutions. The list can be used to understand what services are readily available for use within your tenant, and can assist in planning and developing new applications or flows. It's important to note that the availability of connectors may vary based on the specific licenses and permissions assigned within your tenant.\n\nAdditional Resources:\n\n* [Connectors Overview](https://learn.microsoft.com/connectors/connectors)\n",
@@ -142,8 +144,11 @@ func (d *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, res
 }
 
 func (d *DataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 	client := req.ProviderData.(*api.ProviderClient).Api
@@ -163,10 +168,9 @@ func (d *DataSource) Configure(ctx context.Context, req datasource.ConfigureRequ
 func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
 	defer exitContext()
+
 	var state ListDataSourceModel
 	resp.State.Get(ctx, &state)
-
-	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE CONNECTORS START: %s", d.ProviderTypeName))
 
 	connectors, err := d.ConnectorsClient.GetConnectors(ctx)
 	if err != nil {
@@ -181,8 +185,6 @@ func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp 
 	state.Id = types.StringValue(strconv.Itoa(len(connectors)))
 
 	diags := resp.State.Set(ctx, &state)
-
-	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE CONNECTORS END: %s", d.ProviderTypeName))
 
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/services/connectors/datasource_connectors.go
+++ b/internal/services/connectors/datasource_connectors.go
@@ -143,6 +143,7 @@ func (d *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, res
 
 func (d *DataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 	client := req.ProviderData.(*api.ProviderClient).Api

--- a/internal/services/connectors/datasource_connectors.go
+++ b/internal/services/connectors/datasource_connectors.go
@@ -66,7 +66,15 @@ func ConvertFromConnectorDto(connectorDto Dto) DataSourceModel {
 }
 
 func (d *DataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (d *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/services/currencies/datasource_currencies.go
+++ b/internal/services/currencies/datasource_currencies.go
@@ -117,6 +117,7 @@ func (d *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, res
 
 func (d *DataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 	clientApi := req.ProviderData.(*api.ProviderClient).Api

--- a/internal/services/currencies/datasource_currencies.go
+++ b/internal/services/currencies/datasource_currencies.go
@@ -51,7 +51,15 @@ type DataSource struct {
 }
 
 func (d *DataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (d *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/services/data_record/api_data_record.go
+++ b/internal/services/data_record/api_data_record.go
@@ -561,7 +561,8 @@ func (client *DataRecordClient) DeleteDataRecord(ctx context.Context, recordId s
 		Path:   fmt.Sprintf("/api/data/%s/%s(%s)", constants.DATAVERSE_API_VERSION, tableEntityDefinition.LogicalCollectionName, recordId),
 	}
 	_, err = client.Api.Execute(ctx, "DELETE", apiUrl.String(), nil, columns, []int{http.StatusOK, http.StatusNoContent}, nil)
-	if err != nil && !strings.ContainsAny(err.Error(), "404") {
+	if err != nil && !strings.ContainsAny(err.Error(), "404") { 
+		// TODO: 404 is desired state for delete.  We should pass 404 as acceptable status code and not error
 		return err
 	}
 	return nil
@@ -610,6 +611,7 @@ func applyRelation(ctx context.Context, environmentHost string, entityDefinition
 		return err
 	}
 
+	// TODO: execute will unmarshal the response into the existingRelationsResponse use that instead
 	err = json.Unmarshal(apiResponse.BodyAsBytes, &existingRelationsResponse)
 	if err != nil {
 		return err

--- a/internal/services/data_record/api_data_record.go
+++ b/internal/services/data_record/api_data_record.go
@@ -561,7 +561,7 @@ func (client *DataRecordClient) DeleteDataRecord(ctx context.Context, recordId s
 		Path:   fmt.Sprintf("/api/data/%s/%s(%s)", constants.DATAVERSE_API_VERSION, tableEntityDefinition.LogicalCollectionName, recordId),
 	}
 	_, err = client.Api.Execute(ctx, "DELETE", apiUrl.String(), nil, columns, []int{http.StatusOK, http.StatusNoContent}, nil)
-	if err != nil && !strings.ContainsAny(err.Error(), "404") { 
+	if err != nil && !strings.ContainsAny(err.Error(), "404") {
 		// TODO: 404 is desired state for delete.  We should pass 404 as acceptable status code and not error
 		return err
 	}

--- a/internal/services/data_record/datasource_data_record.go
+++ b/internal/services/data_record/datasource_data_record.go
@@ -142,7 +142,9 @@ func returnExpandSchema(depth int) *schema.ListNestedAttribute {
 	}
 }
 
-func (d *DataRecordDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *DataRecordDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Resource for retrieving data records from Dataverse using (OData Query)[https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/query-data-web-api#page-results].",
 		Attributes: map[string]schema.Attribute{
@@ -212,8 +214,11 @@ func (d *DataRecordDataSource) ConfigValidators(ctx context.Context) []datasourc
 }
 
 func (d *DataRecordDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 

--- a/internal/services/data_record/datasource_data_record.go
+++ b/internal/services/data_record/datasource_data_record.go
@@ -213,6 +213,7 @@ func (d *DataRecordDataSource) ConfigValidators(ctx context.Context) []datasourc
 
 func (d *DataRecordDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 

--- a/internal/services/data_record/datasource_data_record.go
+++ b/internal/services/data_record/datasource_data_record.go
@@ -66,7 +66,15 @@ type DataRecordListDataSourceModel struct {
 }
 
 func (d *DataRecordDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 var navigationPropertySchema = schema.StringAttribute{

--- a/internal/services/data_record/resource_data_record.go
+++ b/internal/services/data_record/resource_data_record.go
@@ -151,7 +151,6 @@ func (r *DataRecordResource) Create(ctx context.Context, req resource.CreateRequ
 	tflog.Trace(ctx, fmt.Sprintf("created a resource with ID %s", plan.TableLogicalName.ValueString()))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-
 }
 
 func (r *DataRecordResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -189,7 +188,6 @@ func (r *DataRecordResource) Read(ctx context.Context, req resource.ReadRequest,
 	tflog.Debug(ctx, fmt.Sprintf("READ: %s_data_record with table_name %s", r.ProviderTypeName, state.TableLogicalName.ValueString()))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-
 }
 
 func (r *DataRecordResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/internal/services/data_record/resource_data_record.go
+++ b/internal/services/data_record/resource_data_record.go
@@ -105,7 +105,7 @@ func (r *DataRecordResource) Configure(ctx context.Context, req resource.Configu
 	defer exitContext()
 
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 

--- a/internal/services/data_record/resource_data_record.go
+++ b/internal/services/data_record/resource_data_record.go
@@ -103,6 +103,7 @@ func (r *DataRecordResource) Schema(ctx context.Context, req resource.SchemaRequ
 func (r *DataRecordResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
+
 	if req.ProviderData == nil {
 		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
 		return
@@ -123,14 +124,14 @@ func (r *DataRecordResource) Configure(ctx context.Context, req resource.Configu
 func (r *DataRecordResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
+
 	var plan DataRecordResourceModel
-
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
+	// TODO: Why are we setting plan to itself? Remove?
 	plan.Id = types.StringValue(plan.Id.ValueString())
 	plan.EnvironmentId = types.StringValue(plan.EnvironmentId.ValueString())
 	plan.TableLogicalName = types.StringValue(plan.TableLogicalName.ValueString())

--- a/internal/services/data_record/resource_data_record.go
+++ b/internal/services/data_record/resource_data_record.go
@@ -104,6 +104,7 @@ func (r *DataRecordResource) Configure(ctx context.Context, req resource.Configu
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
 		return
 	}
 
@@ -226,7 +227,6 @@ func (r *DataRecordResource) Update(ctx context.Context, req resource.UpdateRequ
 	plan.Id = types.StringValue(dr.Id)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-
 }
 
 func (r *DataRecordResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/services/dlp_policy/datasource_dlp_policy.go
+++ b/internal/services/dlp_policy/datasource_dlp_policy.go
@@ -49,7 +49,10 @@ func (d *DataLossPreventionPolicyDataSource) Metadata(ctx context.Context, req d
 	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
-func (d *DataLossPreventionPolicyDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *DataLossPreventionPolicyDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
 	connectorSchema := schema.NestedAttributeObject{
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -244,8 +247,11 @@ func (d *DataLossPreventionPolicyDataSource) Schema(ctx context.Context, _ datas
 }
 
 func (d *DataLossPreventionPolicyDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 
@@ -266,6 +272,7 @@ func (d *DataLossPreventionPolicyDataSource) Configure(ctx context.Context, req 
 func (d *DataLossPreventionPolicyDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
 	defer exitContext()
+
 	var state PoliciesListDataSourceModel
 
 	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE POLICIES START: %s_%s", d.ProviderTypeName, d.TypeName))
@@ -302,9 +309,6 @@ func (d *DataLossPreventionPolicyDataSource) Read(ctx context.Context, req datas
 	}
 
 	diags := resp.State.Set(ctx, &state)
-
-	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE POLICIES END: %s_%s", d.ProviderTypeName, d.TypeName))
-
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/services/dlp_policy/datasource_dlp_policy.go
+++ b/internal/services/dlp_policy/datasource_dlp_policy.go
@@ -38,7 +38,15 @@ type DataLossPreventionPolicyDataSource struct {
 }
 
 func (d *DataLossPreventionPolicyDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (d *DataLossPreventionPolicyDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/services/dlp_policy/datasource_dlp_policy.go
+++ b/internal/services/dlp_policy/datasource_dlp_policy.go
@@ -245,6 +245,7 @@ func (d *DataLossPreventionPolicyDataSource) Schema(ctx context.Context, _ datas
 
 func (d *DataLossPreventionPolicyDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 

--- a/internal/services/dlp_policy/resource_dlp_policy.go
+++ b/internal/services/dlp_policy/resource_dlp_policy.go
@@ -246,7 +246,7 @@ func (r *DataLossPreventionPolicyResource) Configure(ctx context.Context, req re
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 

--- a/internal/services/dlp_policy/resource_dlp_policy.go
+++ b/internal/services/dlp_policy/resource_dlp_policy.go
@@ -246,6 +246,7 @@ func (r *DataLossPreventionPolicyResource) Configure(ctx context.Context, req re
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
 		return
 	}
 
@@ -299,7 +300,6 @@ func (r *DataLossPreventionPolicyResource) Read(ctx context.Context, req resourc
 	state.BlockedConnectors = convertToAttrValueConnectorsGroup("Blocked", policy.ConnectorGroups)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-
 }
 
 func (r *DataLossPreventionPolicyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/services/environment/datasource_environments.go
+++ b/internal/services/environment/datasource_environments.go
@@ -203,6 +203,7 @@ func (d *EnvironmentsDataSource) Schema(ctx context.Context, _ datasource.Schema
 
 func (d *EnvironmentsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 	clientApi := req.ProviderData.(*api.ProviderClient).Api

--- a/internal/services/environment/datasource_environments.go
+++ b/internal/services/environment/datasource_environments.go
@@ -37,7 +37,15 @@ type EnvironmentsDataSource struct {
 }
 
 func (d *EnvironmentsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (d *EnvironmentsDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/services/environment/resource_environment.go
+++ b/internal/services/environment/resource_environment.go
@@ -247,7 +247,7 @@ func (r *Resource) Configure(ctx context.Context, req resource.ConfigureRequest,
 	defer exitContext()
 
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 

--- a/internal/services/environment/resource_environment.go
+++ b/internal/services/environment/resource_environment.go
@@ -234,8 +234,6 @@ func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 }
 
 func (d *Resource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
-	path.Root("dataverse").AtName("administration_mode_enabled").Expression()
-
 	return []resource.ConfigValidator{
 		resourcevalidator.RequiredTogether(
 			path.Root("dataverse").AtName("administration_mode_enabled").Expression(),
@@ -249,7 +247,7 @@ func (r *Resource) Configure(ctx context.Context, req resource.ConfigureRequest,
 	defer exitContext()
 
 	if req.ProviderData == nil {
-		// TODO: Should we add a warning here?
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
 		return
 	}
 

--- a/internal/services/environment/resource_environment.go
+++ b/internal/services/environment/resource_environment.go
@@ -284,15 +284,6 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		resp.Diagnostics.AddError("Error when converting source model to create environment dto", err.Error())
 	}
 
-	// timeout, diags := plan.Timeouts.Create(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	// if diags != nil {
-	// 	resp.Diagnostics.Append(diags...)
-	// 	return
-	// }
-
-	// ctx, cancel := context.WithTimeout(ctx, timeout)
-	// defer cancel()
-
 	err = r.EnvironmentClient.LocationValidator(ctx, envToCreate.Location, envToCreate.Properties.AzureRegion)
 	if err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("Location validation failed for %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
@@ -352,15 +343,6 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	// timeout, diags := state.Timeouts.Read(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	// if diags != nil {
-	// 	resp.Diagnostics.Append(diags...)
-	// 	return
-	// }
-
-	// ctx, cancel := context.WithTimeout(ctx, timeout)
-	// defer cancel()
 
 	envDto, err := r.EnvironmentClient.GetEnvironment(ctx, state.Id.ValueString())
 	if err != nil {
@@ -462,15 +444,6 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 			Id: plan.BillingPolicyId.ValueString(),
 		}
 	}
-
-	// timeout, diags := plan.Timeouts.Update(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	// if diags != nil {
-	// 	resp.Diagnostics.Append(diags...)
-	// 	return
-	// }
-
-	// ctx, cancel := context.WithTimeout(ctx, timeout)
-	// defer cancel()
 
 	var currencyCode string
 	if !IsDataverseEnvironmentEmpty(ctx, state) && !IsDataverseEnvironmentEmpty(ctx, plan) {
@@ -608,15 +581,6 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	// timeout, diags := state.Timeouts.Delete(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	// if diags != nil {
-	// 	resp.Diagnostics.Append(diags...)
-	// 	return
-	// }
-
-	// ctx, cancel := context.WithTimeout(ctx, timeout)
-	// defer cancel()
 
 	err := r.EnvironmentClient.DeleteEnvironment(ctx, state.Id.ValueString())
 	if err != nil {

--- a/internal/services/environment_groups/resource_environment_group.go
+++ b/internal/services/environment_groups/resource_environment_group.go
@@ -81,6 +81,7 @@ func (r *EnvironmentGroupResource) Configure(ctx context.Context, req resource.C
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
 		return
 	}
 

--- a/internal/services/environment_groups/resource_environment_group.go
+++ b/internal/services/environment_groups/resource_environment_group.go
@@ -97,9 +97,10 @@ func (r *EnvironmentGroupResource) Configure(ctx context.Context, req resource.C
 	r.EnvironmentGroupClient = NewEnvironmentGroupClient(client)
 }
 
-// Read function.
+// Read function for EnvironmentGroupResource.
 func (r *EnvironmentGroupResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	tflog.Debug(ctx, fmt.Sprintf("READ RESOURCE START: %s", r.TypeName))
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 
 	state := EnvironmentGroupResourceModel{}
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -122,13 +123,12 @@ func (r *EnvironmentGroupResource) Read(ctx context.Context, req resource.ReadRe
 	state.DisplayName = types.StringValue(environmentGroup.DisplayName)
 	state.Description = types.StringValue(environmentGroup.Description)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-
-	tflog.Debug(ctx, fmt.Sprintf("READ RESOURCE END: %s", r.TypeName))
 }
 
 // Create function.
 func (r *EnvironmentGroupResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	tflog.Debug(ctx, fmt.Sprintf("CREATE RESOURCE START: %s", r.TypeName))
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 
 	var plan *EnvironmentGroupResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -153,12 +153,12 @@ func (r *EnvironmentGroupResource) Create(ctx context.Context, req resource.Crea
 	state.Description = types.StringValue(eg.Description)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-	tflog.Debug(ctx, fmt.Sprintf("CREATE RESOURCE END: %s", r.TypeName))
 }
 
 // Update function.
 func (r *EnvironmentGroupResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	tflog.Debug(ctx, fmt.Sprintf("UPDATE RESOURCE START: %s", r.TypeName))
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 
 	var plan *EnvironmentGroupResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -189,12 +189,12 @@ func (r *EnvironmentGroupResource) Update(ctx context.Context, req resource.Upda
 	state.Description = types.StringValue(eg.Description)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-	tflog.Debug(ctx, fmt.Sprintf("UPDATE RESOURCE END: %s", r.TypeName))
 }
 
 // Delete function.
 func (r *EnvironmentGroupResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	tflog.Debug(ctx, fmt.Sprintf("DELETE RESOURCE START: %s", r.TypeName))
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 
 	var state *EnvironmentGroupResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -207,14 +207,12 @@ func (r *EnvironmentGroupResource) Delete(ctx context.Context, req resource.Dele
 		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
 		return
 	}
-
-	tflog.Debug(ctx, fmt.Sprintf("DELETE RESOURCE END: %s", r.TypeName))
 }
 
 // ImportState function.
 func (r *EnvironmentGroupResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	tflog.Debug(ctx, fmt.Sprintf("IMPORT STATE RESOURCE START: %s", r.TypeName))
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
-	tflog.Debug(ctx, fmt.Sprintf("IMPORT STATE RESOURCE END: %s", r.TypeName))
 }

--- a/internal/services/environment_groups/resource_environment_group.go
+++ b/internal/services/environment_groups/resource_environment_group.go
@@ -81,7 +81,7 @@ func (r *EnvironmentGroupResource) Configure(ctx context.Context, req resource.C
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 

--- a/internal/services/environment_settings/datasource_environment_settings.go
+++ b/internal/services/environment_settings/datasource_environment_settings.go
@@ -211,5 +211,13 @@ func (d *EnvironmentSettingsDataSource) Schema(ctx context.Context, _ datasource
 }
 
 func (d *EnvironmentSettingsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }

--- a/internal/services/environment_settings/datasource_environment_settings.go
+++ b/internal/services/environment_settings/datasource_environment_settings.go
@@ -37,6 +37,7 @@ type EnvironmentSettingsDataSource struct {
 
 func (d *EnvironmentSettingsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 

--- a/internal/services/environment_settings/datasource_environment_settings.go
+++ b/internal/services/environment_settings/datasource_environment_settings.go
@@ -36,8 +36,11 @@ type EnvironmentSettingsDataSource struct {
 }
 
 func (d *EnvironmentSettingsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 
@@ -99,7 +102,9 @@ func (d *EnvironmentSettingsDataSource) Read(ctx context.Context, req datasource
 	}
 }
 
-func (d *EnvironmentSettingsDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *EnvironmentSettingsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
 	resp.Schema = schema.Schema{
 		Description:         "Power Platform Environment Settings Data Source",
 		MarkdownDescription: "Power Platform Environment Settings Data Source. Power Platform Settings are configuration options that apply to a specific environment. They control various aspects of Power Platform features and behaviors, See [Environment Settings Overview](https://learn.microsoft.com/power-platform/admin/admin-settings) for more details.",

--- a/internal/services/environment_settings/resources_environment_settings.go
+++ b/internal/services/environment_settings/resources_environment_settings.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/microsoft/terraform-provider-power-platform/internal/api"
 	"github.com/microsoft/terraform-provider-power-platform/internal/constants"
+	"github.com/microsoft/terraform-provider-power-platform/internal/helpers"
 )
 
 var _ resource.Resource = &EnvironmentSettingsResource{}
@@ -28,22 +29,32 @@ var _ resource.ResourceWithImportState = &EnvironmentSettingsResource{}
 
 func NewEnvironmentSettingsResource() resource.Resource {
 	return &EnvironmentSettingsResource{
-		ProviderTypeName: "powerplatform",
-		TypeName:         "_environment_settings",
+		TypeInfo: helpers.TypeInfo{
+			TypeName: "environment_settings",
+		},
 	}
 }
 
 type EnvironmentSettingsResource struct {
+	helpers.TypeInfo
 	EnvironmentSettingClient EnvironmentSettingsClient
-	ProviderTypeName         string
-	TypeName                 string
 }
 
 func (r *EnvironmentSettingsResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + r.TypeName
+	// update our own internal storage of the provider type name.
+	r.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = r.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (r *EnvironmentSettingsResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	resp.Schema = schema.Schema{
 		Description:         "Manages Power Platform Settings for a given environment.",
 		MarkdownDescription: "Manages Power Platform Settings for a given environment. They control various aspects of Power Platform features and behaviors, See [Environment Settings Overview](https://learn.microsoft.com/power-platform/admin/admin-settings) for more details.",
@@ -193,6 +204,8 @@ func (r *EnvironmentSettingsResource) Schema(ctx context.Context, req resource.S
 }
 
 func (r *EnvironmentSettingsResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	if req.ProviderData == nil {
 		return
 	}
@@ -212,6 +225,8 @@ func (r *EnvironmentSettingsResource) Configure(ctx context.Context, req resourc
 }
 
 func (r *EnvironmentSettingsResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	var plan EnvironmentSettingsSourceModel
 
 	tflog.Debug(ctx, fmt.Sprintf("CREATE ENVIRONMENT SETTINGS RESOURCE START: %s", r.ProviderTypeName))
@@ -221,15 +236,6 @@ func (r *EnvironmentSettingsResource) Create(ctx context.Context, req resource.C
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	timeout, diags := plan.Timeouts.Create(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	settingsToUpdate, err := ConvertFromEnvironmentSettingsModel(ctx, plan)
 	if err != nil {
@@ -266,6 +272,8 @@ func (r *EnvironmentSettingsResource) Create(ctx context.Context, req resource.C
 }
 
 func (r *EnvironmentSettingsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	var state EnvironmentSettingsSourceModel
 
 	tflog.Debug(ctx, fmt.Sprintf("READ ENVIRONMENT SETTINGS RESOURCE START: %s", r.ProviderTypeName))
@@ -280,15 +288,6 @@ func (r *EnvironmentSettingsResource) Read(ctx context.Context, req resource.Rea
 		resp.Diagnostics.AddError("environment_id connot be an empty string", "environment_id connot be an empty string")
 		return
 	}
-
-	timeout, diags := state.Timeouts.Read(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	envSettings, err := r.EnvironmentSettingClient.GetEnvironmentSettings(ctx, state.EnvironmentId.ValueString())
 	if err != nil {
@@ -305,6 +304,9 @@ func (r *EnvironmentSettingsResource) Read(ctx context.Context, req resource.Rea
 }
 
 func (r *EnvironmentSettingsResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
 	var plan EnvironmentSettingsSourceModel
 	var state EnvironmentSettingsSourceModel
 

--- a/internal/services/environment_settings/resources_environment_settings.go
+++ b/internal/services/environment_settings/resources_environment_settings.go
@@ -206,6 +206,7 @@ func (r *EnvironmentSettingsResource) Configure(ctx context.Context, req resourc
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
 		return
 	}
 

--- a/internal/services/environment_settings/resources_environment_settings.go
+++ b/internal/services/environment_settings/resources_environment_settings.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/microsoft/terraform-provider-power-platform/internal/api"
-	"github.com/microsoft/terraform-provider-power-platform/internal/constants"
 	"github.com/microsoft/terraform-provider-power-platform/internal/helpers"
 )
 
@@ -227,12 +226,9 @@ func (r *EnvironmentSettingsResource) Configure(ctx context.Context, req resourc
 func (r *EnvironmentSettingsResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
+
 	var plan EnvironmentSettingsSourceModel
-
-	tflog.Debug(ctx, fmt.Sprintf("CREATE ENVIRONMENT SETTINGS RESOURCE START: %s", r.ProviderTypeName))
-
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -268,18 +264,14 @@ func (r *EnvironmentSettingsResource) Create(ctx context.Context, req resource.C
 
 	tflog.Trace(ctx, fmt.Sprintf("created a resource with ID %s", state.Id.ValueString()))
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-	tflog.Debug(ctx, fmt.Sprintf("CREATE ENVIRONMENT SETTINGS RESOURCE END: %s", r.ProviderTypeName))
 }
 
 func (r *EnvironmentSettingsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
+
 	var state EnvironmentSettingsSourceModel
-
-	tflog.Debug(ctx, fmt.Sprintf("READ ENVIRONMENT SETTINGS RESOURCE START: %s", r.ProviderTypeName))
-
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -300,7 +292,6 @@ func (r *EnvironmentSettingsResource) Read(ctx context.Context, req resource.Rea
 	newState.EnvironmentId = state.EnvironmentId
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
-	tflog.Debug(ctx, fmt.Sprintf("READ ENVIRONMENT SETTINGS RESOURCE END: %s", r.ProviderTypeName))
 }
 
 func (r *EnvironmentSettingsResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -309,11 +300,7 @@ func (r *EnvironmentSettingsResource) Update(ctx context.Context, req resource.U
 
 	var plan EnvironmentSettingsSourceModel
 	var state EnvironmentSettingsSourceModel
-
-	tflog.Debug(ctx, fmt.Sprintf("UPDATE ENVIRONMENT SETTINGS RESOURCE START: %s", r.ProviderTypeName))
-
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -327,15 +314,6 @@ func (r *EnvironmentSettingsResource) Update(ctx context.Context, req resource.U
 		resp.Diagnostics.AddError("environment_id connot be an empty string", "environment_id connot be an empty string")
 		return
 	}
-
-	timeout, diags := plan.Timeouts.Update(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	envSettingsToUpdate, err := ConvertFromEnvironmentSettingsModel(ctx, plan)
 	if err != nil {
@@ -356,12 +334,18 @@ func (r *EnvironmentSettingsResource) Update(ctx context.Context, req resource.U
 	plan.EnvironmentId = state.EnvironmentId
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-	tflog.Debug(ctx, fmt.Sprintf("UPDATE ENVIRONMENT SETTINGS RESOURCE END: %s", r.ProviderTypeName))
 }
 
 func (r *EnvironmentSettingsResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
+	// Do nothing on purpose
 }
 
 func (r *EnvironmentSettingsResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
 	resource.ImportStatePassthroughID(ctx, path.Root("environment_id"), req, resp)
 }

--- a/internal/services/environment_settings/resources_environment_settings.go
+++ b/internal/services/environment_settings/resources_environment_settings.go
@@ -206,7 +206,7 @@ func (r *EnvironmentSettingsResource) Configure(ctx context.Context, req resourc
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 

--- a/internal/services/environment_templates/datasource_environment_templates.go
+++ b/internal/services/environment_templates/datasource_environment_templates.go
@@ -137,6 +137,7 @@ func (d *EnvironmentTemplatesDataSource) Schema(ctx context.Context, _ datasourc
 
 func (d *EnvironmentTemplatesDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 	clientApi := req.ProviderData.(*api.ProviderClient).Api

--- a/internal/services/environment_templates/datasource_environment_templates.go
+++ b/internal/services/environment_templates/datasource_environment_templates.go
@@ -55,7 +55,15 @@ type EnvironmentTemplatesDataModel struct {
 }
 
 func (d *EnvironmentTemplatesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (d *EnvironmentTemplatesDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/services/languages/datasource_languages.go
+++ b/internal/services/languages/datasource_languages.go
@@ -51,7 +51,15 @@ type DataModel struct {
 }
 
 func (d *DataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (d *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/services/languages/datasource_languages.go
+++ b/internal/services/languages/datasource_languages.go
@@ -118,6 +118,7 @@ func (d *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, res
 
 func (d *DataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 	clientApi := req.ProviderData.(*api.ProviderClient).Api

--- a/internal/services/languages/datasource_languages.go
+++ b/internal/services/languages/datasource_languages.go
@@ -62,7 +62,9 @@ func (d *DataSource) Metadata(ctx context.Context, req datasource.MetadataReques
 	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
-func (d *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *DataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
 	resp.Schema = schema.Schema{
 		Description:         "Fetches the list of Dynamics 365 languages",
 		MarkdownDescription: "Fetches the list of Dynamics 365 languages. For more information see [Power Platform Enable Languages](https://learn.microsoft.com/power-platform/admin/enable-languages)",
@@ -117,8 +119,11 @@ func (d *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, res
 }
 
 func (d *DataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 	clientApi := req.ProviderData.(*api.ProviderClient).Api

--- a/internal/services/licensing/datasource_billing_policies.go
+++ b/internal/services/licensing/datasource_billing_policies.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/microsoft/terraform-provider-power-platform/internal/api"
-	"github.com/microsoft/terraform-provider-power-platform/internal/constants"
+	"github.com/microsoft/terraform-provider-power-platform/internal/helpers"
 )
 
 var (
@@ -23,15 +23,15 @@ var (
 
 func NewBillingPoliciesDataSource() datasource.DataSource {
 	return &BillingPoliciesDataSource{
-		ProviderTypeName: "powerplatform",
-		TypeName:         "_billing_policies",
+		TypeInfo: helpers.TypeInfo{
+			TypeName: "billing_policies",
+		},
 	}
 }
 
 type BillingPoliciesDataSource struct {
-	LicensingClient  Client
-	ProviderTypeName string
-	TypeName         string
+	helpers.TypeInfo
+	LicensingClient Client
 }
 
 type BillingPoliciesListDataSourceModel struct {
@@ -154,15 +154,6 @@ func (d *BillingPoliciesDataSource) Read(ctx context.Context, _ datasource.ReadR
 
 	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE BILLING POLICIES START: %s", d.ProviderTypeName))
 
-	timeout, diags := state.Timeouts.Read(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
 	policies, err := d.LicensingClient.GetBillingPolicies(ctx)
 
 	if err != nil {
@@ -185,7 +176,7 @@ func (d *BillingPoliciesDataSource) Read(ctx context.Context, _ datasource.ReadR
 	}
 
 	state.Id = types.Int64Value(int64(len(policies)))
-	diags = resp.State.Set(ctx, &state)
+	diags := resp.State.Set(ctx, &state)
 
 	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE BILLING POLICIES END: %s", d.ProviderTypeName))
 

--- a/internal/services/licensing/datasource_billing_policies.go
+++ b/internal/services/licensing/datasource_billing_policies.go
@@ -137,6 +137,7 @@ func (d *BillingPoliciesDataSource) Schema(ctx context.Context, _ datasource.Sch
 
 func (d *BillingPoliciesDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 

--- a/internal/services/licensing/datasource_billing_policies.go
+++ b/internal/services/licensing/datasource_billing_policies.go
@@ -55,7 +55,15 @@ type BillingInstrumentDataSourceModel struct {
 }
 
 func (d *BillingPoliciesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (d *BillingPoliciesDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/services/licensing/datasource_billing_policies_environments.go
+++ b/internal/services/licensing/datasource_billing_policies_environments.go
@@ -42,7 +42,15 @@ type BillingPoliciesEnvironmetsListDataSourceModel struct {
 }
 
 func (d *BillingPoliciesEnvironmetsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (d *BillingPoliciesEnvironmetsDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/services/licensing/datasource_billing_policies_environments.go
+++ b/internal/services/licensing/datasource_billing_policies_environments.go
@@ -78,6 +78,7 @@ func (d *BillingPoliciesEnvironmetsDataSource) Schema(ctx context.Context, _ dat
 
 func (d *BillingPoliciesEnvironmetsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 

--- a/internal/services/licensing/resource_billing_policy.go
+++ b/internal/services/licensing/resource_billing_policy.go
@@ -204,7 +204,6 @@ func (r *BillingPolicyResource) Create(ctx context.Context, req resource.CreateR
 	tflog.Trace(ctx, fmt.Sprintf("created a resource with ID %s", plan.Id.ValueString()))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-
 }
 
 func (r *BillingPolicyResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -241,7 +240,6 @@ func (r *BillingPolicyResource) Read(ctx context.Context, req resource.ReadReque
 	tflog.Debug(ctx, fmt.Sprintf("READ %s_%s with Id: %s", r.ProviderTypeName, r.TypeName, billing.Id))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-
 }
 
 func (r *BillingPolicyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -262,7 +260,6 @@ func (r *BillingPolicyResource) Update(ctx context.Context, req resource.UpdateR
 
 	if plan.Name.ValueString() != state.Name.ValueString() ||
 		plan.Status.ValueString() != state.Status.ValueString() {
-
 		policyToUpdate := BillingPolicyUpdateDto{
 			Name:   plan.Name.ValueString(),
 			Status: plan.Status.ValueString(),

--- a/internal/services/licensing/resource_billing_policy.go
+++ b/internal/services/licensing/resource_billing_policy.go
@@ -146,7 +146,7 @@ func (r *BillingPolicyResource) Configure(ctx context.Context, req resource.Conf
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 

--- a/internal/services/licensing/resource_billing_policy.go
+++ b/internal/services/licensing/resource_billing_policy.go
@@ -209,12 +209,9 @@ func (r *BillingPolicyResource) Create(ctx context.Context, req resource.CreateR
 func (r *BillingPolicyResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
+
 	var state *BillingPolicyResourceModel
-
-	tflog.Debug(ctx, fmt.Sprintf("READ RESOURCE START: %s", r.ProviderTypeName))
-
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -281,8 +278,6 @@ func (r *BillingPolicyResource) Update(ctx context.Context, req resource.UpdateR
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-
-	tflog.Debug(ctx, fmt.Sprintf("UPDATE RESOURCE END: %s", r.ProviderTypeName))
 }
 
 func (r *BillingPolicyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -300,10 +295,11 @@ func (r *BillingPolicyResource) Delete(ctx context.Context, req resource.DeleteR
 		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
 		return
 	}
-
-	tflog.Debug(ctx, fmt.Sprintf("DELETE RESOURCE END: %s", r.ProviderTypeName))
 }
 
 func (r *BillingPolicyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/services/licensing/resource_billing_policy.go
+++ b/internal/services/licensing/resource_billing_policy.go
@@ -146,6 +146,7 @@ func (r *BillingPolicyResource) Configure(ctx context.Context, req resource.Conf
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
 		return
 	}
 

--- a/internal/services/licensing/resource_billing_policy_environment.go
+++ b/internal/services/licensing/resource_billing_policy_environment.go
@@ -88,7 +88,7 @@ func (r *BillingPolicyEnvironmentResource) Configure(ctx context.Context, req re
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 

--- a/internal/services/licensing/resource_billing_policy_environment.go
+++ b/internal/services/licensing/resource_billing_policy_environment.go
@@ -25,15 +25,15 @@ var _ resource.ResourceWithImportState = &BillingPolicyEnvironmentResource{}
 
 func NewBillingPolicyEnvironmentResource() resource.Resource {
 	return &BillingPolicyEnvironmentResource{
-		ProviderTypeName: "powerplatform",
-		TypeName:         "_billing_policy_environment",
+		TypeInfo: helpers.TypeInfo{
+			TypeName: "billing_policy_environment",
+		},
 	}
 }
 
 type BillingPolicyEnvironmentResource struct {
-	LicensingClient  Client
-	ProviderTypeName string
-	TypeName         string
+	helpers.TypeInfo
+	LicensingClient Client
 }
 
 type BillingPolicyEnvironmentResourceModel struct {
@@ -43,10 +43,20 @@ type BillingPolicyEnvironmentResourceModel struct {
 }
 
 func (r *BillingPolicyEnvironmentResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + r.TypeName
+	// update our own internal storage of the provider type name.
+	r.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = r.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
-func (r *BillingPolicyEnvironmentResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *BillingPolicyEnvironmentResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	resp.Schema = schema.Schema{
 		Description:         "This resource allows you to manage the environments associated with a Billing Policy",
 		MarkdownDescription: "This resource allows you to manage the environments associated with a [billing policy](https://learn.microsoft.com/power-platform/admin/pay-as-you-go-overview#what-is-a-billing-policy). A billing policy is a set of rules that define how a tenant is billed for usage of Power Platform services. A billing policy is associated with a billing instrument, which is a subscription and resource group that is used to pay for usage of Power Platform services.",
@@ -76,6 +86,8 @@ func (r *BillingPolicyEnvironmentResource) Schema(ctx context.Context, _ resourc
 }
 
 func (r *BillingPolicyEnvironmentResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	if req.ProviderData == nil {
 		return
 	}
@@ -94,23 +106,14 @@ func (r *BillingPolicyEnvironmentResource) Configure(ctx context.Context, req re
 }
 
 func (r *BillingPolicyEnvironmentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	var plan *BillingPolicyEnvironmentResourceModel
-
-	tflog.Debug(ctx, fmt.Sprintf("CREATE RESOURCE START: %s", r.ProviderTypeName))
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	timeout, diags := plan.Timeouts.Create(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	environments, err := r.LicensingClient.GetEnvironmentsForBillingPolicy(ctx, plan.BillingPolicyId)
 	if err != nil {
@@ -144,10 +147,11 @@ func (r *BillingPolicyEnvironmentResource) Create(ctx context.Context, req resou
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 
-	tflog.Debug(ctx, fmt.Sprintf("CREATE RESOURCE END: %s", r.ProviderTypeName))
 }
 
 func (r *BillingPolicyEnvironmentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	var state *BillingPolicyEnvironmentResourceModel
 
 	tflog.Debug(ctx, fmt.Sprintf("READ RESOURCE START: %s", r.ProviderTypeName))
@@ -157,15 +161,6 @@ func (r *BillingPolicyEnvironmentResource) Read(ctx context.Context, req resourc
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	timeout, diags := state.Timeouts.Read(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	environments, err := r.LicensingClient.GetEnvironmentsForBillingPolicy(ctx, state.BillingPolicyId)
 	if err != nil {
@@ -185,13 +180,14 @@ func (r *BillingPolicyEnvironmentResource) Read(ctx context.Context, req resourc
 	tflog.Debug(ctx, fmt.Sprintf("READ %s_%s with Id: %s", r.ProviderTypeName, r.TypeName, state.BillingPolicyId))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-	tflog.Debug(ctx, fmt.Sprintf("READ RESOURCE END: %s", r.ProviderTypeName))
+
 }
 
 func (r *BillingPolicyEnvironmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan *BillingPolicyEnvironmentResourceModel
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 
-	tflog.Debug(ctx, fmt.Sprintf("UPDATE RESOURCE START: %s", r.ProviderTypeName))
+	var plan *BillingPolicyEnvironmentResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 
@@ -245,22 +241,14 @@ func (r *BillingPolicyEnvironmentResource) Update(ctx context.Context, req resou
 func (r *BillingPolicyEnvironmentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state *BillingPolicyEnvironmentResourceModel
 
-	tflog.Debug(ctx, fmt.Sprintf("DELETE RESOURCE START: %s", r.ProviderTypeName))
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	timeout, diags := state.Timeouts.Delete(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	err := r.LicensingClient.RemoveEnvironmentsToBillingPolicy(ctx, state.BillingPolicyId, state.Environments)
 	if err != nil {

--- a/internal/services/licensing/resource_billing_policy_environment.go
+++ b/internal/services/licensing/resource_billing_policy_environment.go
@@ -88,6 +88,7 @@ func (r *BillingPolicyEnvironmentResource) Configure(ctx context.Context, req re
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
 		return
 	}
 
@@ -220,7 +221,6 @@ func (r *BillingPolicyEnvironmentResource) Update(ctx context.Context, req resou
 	plan.Environments = environments
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-
 }
 
 func (r *BillingPolicyEnvironmentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/services/licensing/resource_billing_policy_environment.go
+++ b/internal/services/licensing/resource_billing_policy_environment.go
@@ -146,7 +146,6 @@ func (r *BillingPolicyEnvironmentResource) Create(ctx context.Context, req resou
 	tflog.Trace(ctx, fmt.Sprintf("created a resource with ID %s", plan.BillingPolicyId))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-
 }
 
 func (r *BillingPolicyEnvironmentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -180,7 +179,6 @@ func (r *BillingPolicyEnvironmentResource) Read(ctx context.Context, req resourc
 	tflog.Debug(ctx, fmt.Sprintf("READ %s_%s with Id: %s", r.ProviderTypeName, r.TypeName, state.BillingPolicyId))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-
 }
 
 func (r *BillingPolicyEnvironmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/internal/services/locations/datasource_locations.go
+++ b/internal/services/locations/datasource_locations.go
@@ -130,6 +130,7 @@ func (d *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, res
 
 func (d *DataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 	clientApi := req.ProviderData.(*api.ProviderClient).Api

--- a/internal/services/locations/datasource_locations.go
+++ b/internal/services/locations/datasource_locations.go
@@ -53,7 +53,15 @@ type DataSource struct {
 }
 
 func (d *DataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (d *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/services/managed_environment/resource_managed_environment.go
+++ b/internal/services/managed_environment/resource_managed_environment.go
@@ -156,7 +156,7 @@ func (r *ManagedEnvironmentResource) Configure(ctx context.Context, req resource
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 

--- a/internal/services/managed_environment/resource_managed_environment.go
+++ b/internal/services/managed_environment/resource_managed_environment.go
@@ -227,7 +227,6 @@ func (r *ManagedEnvironmentResource) Create(ctx context.Context, req resource.Cr
 	plan.MakerOnboardingMarkdown = types.StringValue(env.Properties.GovernanceConfiguration.Settings.ExtendedSettings.MakerOnboardingMarkdown)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-
 }
 
 func (r *ManagedEnvironmentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -278,7 +277,6 @@ func (r *ManagedEnvironmentResource) Read(ctx context.Context, req resource.Read
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-
 }
 
 func (r *ManagedEnvironmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/internal/services/managed_environment/resource_managed_environment.go
+++ b/internal/services/managed_environment/resource_managed_environment.go
@@ -156,6 +156,7 @@ func (r *ManagedEnvironmentResource) Configure(ctx context.Context, req resource
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
 		return
 	}
 
@@ -331,7 +332,6 @@ func (r *ManagedEnvironmentResource) Update(ctx context.Context, req resource.Up
 	plan.MakerOnboardingMarkdown = types.StringValue(env.Properties.GovernanceConfiguration.Settings.ExtendedSettings.MakerOnboardingMarkdown)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-
 }
 
 func (r *ManagedEnvironmentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/services/managed_environment/resource_managed_environment.go
+++ b/internal/services/managed_environment/resource_managed_environment.go
@@ -30,15 +30,15 @@ var _ resource.ResourceWithImportState = &ManagedEnvironmentResource{}
 
 func NewManagedEnvironmentResource() resource.Resource {
 	return &ManagedEnvironmentResource{
-		ProviderTypeName: "powerplatform",
-		TypeName:         "_managed_environment",
+		TypeInfo: helpers.TypeInfo{
+			TypeName: "managed_environment",
+		},
 	}
 }
 
 type ManagedEnvironmentResource struct {
+	helpers.TypeInfo
 	ManagedEnvironmentClient ManagedEnvironmentClient
-	ProviderTypeName         string
-	TypeName                 string
 }
 
 type ManagedEnvironmentResourceModel struct {
@@ -57,10 +57,20 @@ type ManagedEnvironmentResourceModel struct {
 }
 
 func (r *ManagedEnvironmentResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + r.TypeName
+	// update our own internal storage of the provider type name.
+	r.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = r.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (r *ManagedEnvironmentResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	resp.Schema = schema.Schema{
 		Description:         "Manages a \"Managed Environment\" and associated settings",
 		MarkdownDescription: "Manages a [Managed Environment](https://learn.microsoft.com/power-platform/admin/managed-environment-overview) and associated settings. A Power Platform Managed Environment is a suite of premium capabilities that allows administrators to manage Power Platform at scale with more control, less effort, and more insights. Once an environment is managed, it unlocks additional features across the Power Platform",
@@ -144,6 +154,8 @@ func (r *ManagedEnvironmentResource) Schema(ctx context.Context, req resource.Sc
 }
 
 func (r *ManagedEnvironmentResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	if req.ProviderData == nil {
 		return
 	}
@@ -162,9 +174,9 @@ func (r *ManagedEnvironmentResource) Configure(ctx context.Context, req resource
 }
 
 func (r *ManagedEnvironmentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	var plan *ManagedEnvironmentResourceModel
-
-	tflog.Debug(ctx, fmt.Sprintf("CREATE RESOURCE START: %s", r.ProviderTypeName))
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 
@@ -189,15 +201,6 @@ func (r *ManagedEnvironmentResource) Create(ctx context.Context, req resource.Cr
 			},
 		},
 	}
-
-	timeout, diags := plan.Timeouts.Create(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	err := r.ManagedEnvironmentClient.EnableManagedEnvironment(ctx, managedEnvironmentDto, plan.EnvironmentId.ValueString())
 	if err != nil {
@@ -225,10 +228,11 @@ func (r *ManagedEnvironmentResource) Create(ctx context.Context, req resource.Cr
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 
-	tflog.Debug(ctx, fmt.Sprintf("CREATE RESOURCE END: %s", r.ProviderTypeName))
 }
 
 func (r *ManagedEnvironmentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	var state *ManagedEnvironmentResourceModel
 
 	tflog.Debug(ctx, fmt.Sprintf("READ RESOURCE START: %s", r.ProviderTypeName))
@@ -238,15 +242,6 @@ func (r *ManagedEnvironmentResource) Read(ctx context.Context, req resource.Read
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	timeout, diags := state.Timeouts.Read(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	env, err := r.ManagedEnvironmentClient.environmentClient.GetEnvironment(ctx, state.EnvironmentId.ValueString())
 	if err != nil {
@@ -284,13 +279,13 @@ func (r *ManagedEnvironmentResource) Read(ctx context.Context, req resource.Read
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 
-	tflog.Debug(ctx, fmt.Sprintf("READ RESOURCE END: %s", r.ProviderTypeName))
 }
 
 func (r *ManagedEnvironmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan *ManagedEnvironmentResourceModel
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 
-	tflog.Debug(ctx, fmt.Sprintf("UPDATE RESOURCE START: %s", r.ProviderTypeName))
+	var plan *ManagedEnvironmentResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 
@@ -357,22 +352,14 @@ func (r *ManagedEnvironmentResource) Update(ctx context.Context, req resource.Up
 func (r *ManagedEnvironmentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state *ManagedEnvironmentResourceModel
 
-	tflog.Debug(ctx, fmt.Sprintf("DELETE RESOURCE START: %s", r.ProviderTypeName))
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	timeout, diags := state.Timeouts.Delete(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	err := r.ManagedEnvironmentClient.DisableManagedEnvironment(ctx, state.EnvironmentId.ValueString())
 	if err != nil {

--- a/internal/services/powerapps/datasource_environment_powerapps.go
+++ b/internal/services/powerapps/datasource_environment_powerapps.go
@@ -117,6 +117,7 @@ func (d *EnvironmentPowerAppsDataSource) Schema(ctx context.Context, _ datasourc
 
 func (d *EnvironmentPowerAppsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 

--- a/internal/services/powerapps/datasource_environment_powerapps.go
+++ b/internal/services/powerapps/datasource_environment_powerapps.go
@@ -58,7 +58,15 @@ func ConvertFromPowerAppDto(powerAppDto PowerAppBapi) EnvironmentPowerAppsDataSo
 }
 
 func (d *EnvironmentPowerAppsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (d *EnvironmentPowerAppsDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/services/rest/datasource_rest_query.go
+++ b/internal/services/rest/datasource_rest_query.go
@@ -120,6 +120,7 @@ func (d *DataverseWebApiDatasource) Schema(ctx context.Context, _ datasource.Sch
 
 func (d *DataverseWebApiDatasource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 	clientApi := req.ProviderData.(*api.ProviderClient).Api

--- a/internal/services/rest/datasource_rest_query.go
+++ b/internal/services/rest/datasource_rest_query.go
@@ -41,7 +41,15 @@ type DataverseWebApiDatasourceModel struct {
 }
 
 func (d *DataverseWebApiDatasource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (d *DataverseWebApiDatasource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/services/rest/resource_rest.go
+++ b/internal/services/rest/resource_rest.go
@@ -187,7 +187,7 @@ func (r *DataverseWebApiResource) Configure(ctx context.Context, req resource.Co
 	defer exitContext()
 
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 

--- a/internal/services/rest/resource_rest.go
+++ b/internal/services/rest/resource_rest.go
@@ -20,20 +20,21 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/microsoft/terraform-provider-power-platform/internal/api"
 	"github.com/microsoft/terraform-provider-power-platform/internal/constants"
+	"github.com/microsoft/terraform-provider-power-platform/internal/helpers"
 	modifier "github.com/microsoft/terraform-provider-power-platform/internal/modifiers"
 )
 
 func NewDataverseWebApiResource() resource.Resource {
 	return &DataverseWebApiResource{
-		ProviderTypeName: "powerplatform",
-		TypeName:         "_rest",
+		TypeInfo: helpers.TypeInfo{
+			TypeName: "rest",
+		},
 	}
 }
 
 type DataverseWebApiResource struct {
+	helpers.TypeInfo
 	DataRecordClient WebApiClient
-	ProviderTypeName string
-	TypeName         string
 }
 
 type DataverseWebApiResourceModel struct {
@@ -61,10 +62,20 @@ type DataverseWebApiOperationHeaderResource struct {
 }
 
 func (r *DataverseWebApiResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + r.TypeName
+	// update our own internal storage of the provider type name.
+	r.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = r.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (r *DataverseWebApiResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `Resource to execute web api requests. There are four distinct operations, that you can define independently. The HTTP response' body of the operation, that was called as last, will be returned in 'output.body' \n\n:
 		* Create: will be called once during the lifecycle of the resource (first 'terraform apply')
@@ -173,6 +184,8 @@ func (r *DataverseWebApiResource) buildOperationSchema(description string) schem
 }
 
 func (r *DataverseWebApiResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	if req.ProviderData == nil {
 		return
 	}
@@ -188,10 +201,10 @@ func (r *DataverseWebApiResource) Configure(ctx context.Context, req resource.Co
 }
 
 func (r *DataverseWebApiResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	var plan DataverseWebApiResourceModel
 	resp.State.Get(ctx, &plan)
-
-	tflog.Debug(ctx, fmt.Sprintf("CREATE RESOURCE START: %s", r.ProviderTypeName))
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 
@@ -206,15 +219,6 @@ func (r *DataverseWebApiResource) Create(ctx context.Context, req resource.Creat
 	state.Destroy = plan.Destroy
 	state.Read = plan.Read
 	state.Output = plan.Output
-
-	timeout, diags := plan.Timeouts.Create(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	state.Id = types.StringValue(strconv.Itoa(int(time.Now().UnixMilli())))
 	if plan.Create != nil {
@@ -239,6 +243,8 @@ func (r *DataverseWebApiResource) Create(ctx context.Context, req resource.Creat
 }
 
 func (r *DataverseWebApiResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	var state DataverseWebApiResourceModel
 
 	tflog.Debug(ctx, fmt.Sprintf("READ RESOURCE START: %s", r.TypeName))
@@ -248,15 +254,6 @@ func (r *DataverseWebApiResource) Read(ctx context.Context, req resource.ReadReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	timeout, diags := state.Timeouts.Read(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	newState := DataverseWebApiResourceModel{}
 	newState.Timeouts = state.Timeouts
@@ -286,6 +283,9 @@ func (r *DataverseWebApiResource) Read(ctx context.Context, req resource.ReadReq
 }
 
 func (r *DataverseWebApiResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
 	var plan *DataverseWebApiResourceModel
 
 	tflog.Debug(ctx, fmt.Sprintf("UPDATE RESOURCE START: %s", r.TypeName))
@@ -337,15 +337,6 @@ func (r *DataverseWebApiResource) Delete(ctx context.Context, req resource.Delet
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	timeout, diags := state.Timeouts.Delete(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	if state.Destroy != nil {
 		bodyWrapped, err := r.DataRecordClient.SendOperation(ctx, state.Destroy)

--- a/internal/services/rest/resource_rest.go
+++ b/internal/services/rest/resource_rest.go
@@ -187,6 +187,7 @@ func (r *DataverseWebApiResource) Configure(ctx context.Context, req resource.Co
 	defer exitContext()
 
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
 		return
 	}
 

--- a/internal/services/rest/resource_rest.go
+++ b/internal/services/rest/resource_rest.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/microsoft/terraform-provider-power-platform/internal/api"
-	"github.com/microsoft/terraform-provider-power-platform/internal/constants"
 	"github.com/microsoft/terraform-provider-power-platform/internal/helpers"
 	modifier "github.com/microsoft/terraform-provider-power-platform/internal/modifiers"
 )
@@ -186,9 +185,11 @@ func (r *DataverseWebApiResource) buildOperationSchema(description string) schem
 func (r *DataverseWebApiResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
+
 	if req.ProviderData == nil {
 		return
 	}
+
 	clientApi := req.ProviderData.(*api.ProviderClient).Api
 	if clientApi == nil {
 		resp.Diagnostics.AddError(
@@ -203,11 +204,10 @@ func (r *DataverseWebApiResource) Configure(ctx context.Context, req resource.Co
 func (r *DataverseWebApiResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
+
 	var plan DataverseWebApiResourceModel
 	resp.State.Get(ctx, &plan)
-
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -239,18 +239,14 @@ func (r *DataverseWebApiResource) Create(ctx context.Context, req resource.Creat
 		}
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-	tflog.Debug(ctx, fmt.Sprintf("CREATE RESOURCE END: %s", r.TypeName))
 }
 
 func (r *DataverseWebApiResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
+
 	var state DataverseWebApiResourceModel
-
-	tflog.Debug(ctx, fmt.Sprintf("READ RESOURCE START: %s", r.TypeName))
-
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -279,7 +275,6 @@ func (r *DataverseWebApiResource) Read(ctx context.Context, req resource.ReadReq
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
-	tflog.Debug(ctx, fmt.Sprintf("READ RESOURCE END: %s", r.TypeName))
 }
 
 func (r *DataverseWebApiResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -287,23 +282,10 @@ func (r *DataverseWebApiResource) Update(ctx context.Context, req resource.Updat
 	defer exitContext()
 
 	var plan *DataverseWebApiResourceModel
-
-	tflog.Debug(ctx, fmt.Sprintf("UPDATE RESOURCE START: %s", r.TypeName))
-
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	timeout, diags := plan.Timeouts.Update(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	if plan.Update != nil {
 		bodyWrapped, err := r.DataRecordClient.SendOperation(ctx, plan.Update)
@@ -324,16 +306,14 @@ func (r *DataverseWebApiResource) Update(ctx context.Context, req resource.Updat
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-
-	tflog.Debug(ctx, fmt.Sprintf("UPDATE RESOURCE END: %s", r.TypeName))
 }
 
 func (r *DataverseWebApiResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
 	var state *DataverseWebApiResourceModel
-	tflog.Debug(ctx, fmt.Sprintf("DELETE RESOURCE START: %s", r.TypeName))
-
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -346,7 +326,6 @@ func (r *DataverseWebApiResource) Delete(ctx context.Context, req resource.Delet
 		}
 		state.Output = bodyWrapped
 	}
-	tflog.Debug(ctx, fmt.Sprintf("DELETE RESOURCE END: %s", r.TypeName))
 }
 
 func (r *DataverseWebApiResource) NullOutputValue() basetypes.ObjectValue {

--- a/internal/services/solution/datasource_solutions.go
+++ b/internal/services/solution/datasource_solutions.go
@@ -158,6 +158,7 @@ func (d *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, res
 
 func (d *DataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 

--- a/internal/services/solution/datasource_solutions.go
+++ b/internal/services/solution/datasource_solutions.go
@@ -69,7 +69,15 @@ func ConvertFromSolutionDto(solutionDto Dto) DataSourceModel {
 }
 
 func (d *DataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (d *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/services/solution/resource_solution.go
+++ b/internal/services/solution/resource_solution.go
@@ -29,15 +29,15 @@ var _ resource.ResourceWithImportState = &Resource{}
 
 func NewSolutionResource() resource.Resource {
 	return &Resource{
-		ProviderTypeName: "powerplatform",
-		TypeName:         "_solution",
+		TypeInfo: helpers.TypeInfo{
+			TypeName: "solution",
+		},
 	}
 }
 
 type Resource struct {
-	SolutionClient   Client
-	ProviderTypeName string
-	TypeName         string
+	helpers.TypeInfo
+	SolutionClient Client
 }
 
 type ResourceModel struct {
@@ -54,10 +54,20 @@ type ResourceModel struct {
 }
 
 func (r *Resource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + r.TypeName
+	// update our own internal storage of the provider type name.
+	r.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = r.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	resp.Schema = schema.Schema{
 		Description:         "Resource for importing solutions in Power Platform environments",
 		MarkdownDescription: "Resource for importing exporting solutions in Power Platform environments.  This is the equivalent of the [`pac solution import`](https://learn.microsoft.com/power-platform/developer/cli/reference/solution#pac-solution-import) command in the Power Platform CLI.",
@@ -141,6 +151,8 @@ func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 }
 
 func (r *Resource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	if req.ProviderData == nil {
 		return
 	}
@@ -160,24 +172,15 @@ func (r *Resource) Configure(ctx context.Context, req resource.ConfigureRequest,
 }
 
 func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	var plan *ResourceModel
-
-	tflog.Debug(ctx, fmt.Sprintf("CREATE RESOURCE START: %s", r.ProviderTypeName))
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	timeout, diags := plan.Timeouts.Create(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	solution := r.importSolution(ctx, plan, &resp.Diagnostics)
 
@@ -215,10 +218,11 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 
-	tflog.Debug(ctx, fmt.Sprintf("CREATE RESOURCE END: %s", r.ProviderTypeName))
 }
 
 func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	var state *ResourceModel
 
 	tflog.Debug(ctx, fmt.Sprintf("READ RESOURCE START: %s", r.ProviderTypeName))
@@ -228,15 +232,6 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	timeout, diags := state.Timeouts.Read(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	solutionId := getSolutionId(state.Id.ValueString())
 	solution, err := r.SolutionClient.GetSolutionById(ctx, state.EnvironmentId.ValueString(), solutionId)
@@ -267,7 +262,6 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 
-	tflog.Debug(ctx, fmt.Sprintf("READ RESOURCE END: %s", r.ProviderTypeName))
 }
 
 func (r *Resource) importSolution(ctx context.Context, plan *ResourceModel, diagnostics *diag.Diagnostics) *Dto {
@@ -311,7 +305,6 @@ func (r *Resource) importSolution(ctx context.Context, plan *ResourceModel, diag
 }
 
 func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	tflog.Debug(ctx, fmt.Sprintf("UPDATE RESOURCE START: %s", r.ProviderTypeName))
 
 	var plan *ResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -370,22 +363,14 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 
 func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state *ResourceModel
-	tflog.Debug(ctx, fmt.Sprintf("DELETE RESOURCE START: %s", r.ProviderTypeName))
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	timeout, diags := state.Timeouts.Delete(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	if !state.EnvironmentId.IsNull() && !state.Id.IsNull() {
 		solutionId := getSolutionId(state.Id.ValueString())

--- a/internal/services/solution/resource_solution.go
+++ b/internal/services/solution/resource_solution.go
@@ -153,6 +153,7 @@ func (r *Resource) Configure(ctx context.Context, req resource.ConfigureRequest,
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
 		return
 	}
 

--- a/internal/services/solution/resource_solution.go
+++ b/internal/services/solution/resource_solution.go
@@ -153,7 +153,7 @@ func (r *Resource) Configure(ctx context.Context, req resource.ConfigureRequest,
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 

--- a/internal/services/solution/resource_solution.go
+++ b/internal/services/solution/resource_solution.go
@@ -217,7 +217,6 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	plan.Id = types.StringValue(fmt.Sprintf("%s_%s", plan.EnvironmentId.ValueString(), solution.Id))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-
 }
 
 func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -261,7 +260,6 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 	state.DisplayName = types.StringValue(solution.DisplayName)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-
 }
 
 func (r *Resource) importSolution(ctx context.Context, plan *ResourceModel, diagnostics *diag.Diagnostics) *Dto {
@@ -305,6 +303,8 @@ func (r *Resource) importSolution(ctx context.Context, plan *ResourceModel, diag
 }
 
 func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 
 	var plan *ResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)

--- a/internal/services/tenant/datasource_tenant.go
+++ b/internal/services/tenant/datasource_tenant.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/microsoft/terraform-provider-power-platform/internal/api"
+	"github.com/microsoft/terraform-provider-power-platform/internal/helpers"
 )
 
 var (
@@ -20,9 +21,8 @@ var (
 )
 
 type DataSource struct {
-	TenantClient     Client
-	ProviderTypeName string
-	TypeName         string
+	helpers.TypeInfo
+	TenantClient Client
 }
 
 type DataSourceModel struct {
@@ -38,8 +38,9 @@ type DataSourceModel struct {
 
 func NewTenantDataSource() datasource.DataSource {
 	return &DataSource{
-		ProviderTypeName: "powerplatform",
-		TypeName:         "_tenant",
+		TypeInfo: helpers.TypeInfo{
+			TypeName: "tenant",
+		},
 	}
 }
 

--- a/internal/services/tenant/datasource_tenant.go
+++ b/internal/services/tenant/datasource_tenant.go
@@ -129,6 +129,7 @@ func (d *DataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *d
 
 func (d *DataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 

--- a/internal/services/tenant/datasource_tenant.go
+++ b/internal/services/tenant/datasource_tenant.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/microsoft/terraform-provider-power-platform/internal/api"
 	"github.com/microsoft/terraform-provider-power-platform/internal/helpers"
@@ -45,7 +46,15 @@ func NewTenantDataSource() datasource.DataSource {
 }
 
 func (d *DataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (d *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/services/tenant_settings/datasource_tenant_settings.go
+++ b/internal/services/tenant_settings/datasource_tenant_settings.go
@@ -476,5 +476,13 @@ func (d *TenantSettingsDataSource) Schema(ctx context.Context, _ datasource.Sche
 
 // Metadata returns the metadata for the resource, which includes the resource type name.
 func (d *TenantSettingsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + d.TypeName
+	// update our own internal storage of the provider type name.
+	d.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, d.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = d.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }

--- a/internal/services/tenant_settings/datasource_tenant_settings.go
+++ b/internal/services/tenant_settings/datasource_tenant_settings.go
@@ -144,6 +144,7 @@ type UserManagementSettings struct {
 
 func (d *TenantSettingsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", d.TypeName)
 		return
 	}
 

--- a/internal/services/tenant_settings/resource_tenant_settings.go
+++ b/internal/services/tenant_settings/resource_tenant_settings.go
@@ -418,7 +418,6 @@ func (r *TenantSettingsResource) Create(ctx context.Context, req resource.Create
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 
 	tflog.Trace(ctx, fmt.Sprintf("created a resource with ID %s", plan.Id.ValueString()))
-
 }
 
 func (r *TenantSettingsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -458,7 +457,6 @@ func (r *TenantSettingsResource) Read(ctx context.Context, req resource.ReadRequ
 	tflog.Debug(ctx, fmt.Sprintf("READ: %s_tenant_settings with id %s", r.ProviderTypeName, newState.Id.ValueString()))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
-
 }
 
 func (r *TenantSettingsResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/internal/services/tenant_settings/resource_tenant_settings.go
+++ b/internal/services/tenant_settings/resource_tenant_settings.go
@@ -350,6 +350,7 @@ func (r *TenantSettingsResource) Configure(ctx context.Context, req resource.Con
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
+		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
 		return
 	}
 

--- a/internal/services/tenant_settings/resource_tenant_settings.go
+++ b/internal/services/tenant_settings/resource_tenant_settings.go
@@ -350,7 +350,7 @@ func (r *TenantSettingsResource) Configure(ctx context.Context, req resource.Con
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 	if req.ProviderData == nil {
-		resp.Diagnostics.AddError("Failed to configure %s because provider data is nil", r.TypeName)
+		// ProviderData will be null when Configure is called from ValidateConfig.  It's ok.
 		return
 	}
 

--- a/internal/services/tenant_settings/resource_tenant_settings.go
+++ b/internal/services/tenant_settings/resource_tenant_settings.go
@@ -21,6 +21,7 @@ import (
 	"github.com/microsoft/terraform-provider-power-platform/internal/api"
 	"github.com/microsoft/terraform-provider-power-platform/internal/constants"
 	"github.com/microsoft/terraform-provider-power-platform/internal/customtypes"
+	"github.com/microsoft/terraform-provider-power-platform/internal/helpers"
 )
 
 var _ resource.Resource = &TenantSettingsResource{}
@@ -29,22 +30,32 @@ var _ resource.ResourceWithModifyPlan = &TenantSettingsResource{}
 
 func NewTenantSettingsResource() resource.Resource {
 	return &TenantSettingsResource{
-		ProviderTypeName: "powerplatform",
-		TypeName:         "_tenant_settings",
+		TypeInfo: helpers.TypeInfo{
+			TypeName: "tenant_settings",
+		},
 	}
 }
 
 type TenantSettingsResource struct {
+	helpers.TypeInfo
 	TenantSettingClient TenantSettingsClient
-	ProviderTypeName    string
-	TypeName            string
 }
 
 func (r *TenantSettingsResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + r.TypeName
+	// update our own internal storage of the provider type name.
+	r.ProviderTypeName = req.ProviderTypeName
+
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
+
+	// Set the type name for the resource to providername_resourcename.
+	resp.TypeName = r.FullTypeName()
+	tflog.Debug(ctx, fmt.Sprintf("METADATA: %s", resp.TypeName))
 }
 
 func (r *TenantSettingsResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	resp.Schema = schema.Schema{
 		Description:         "Manages Power Platform Tenant Settings.",
 		MarkdownDescription: "Manages Power Platform Tenant Settings. Power Platform Tenant Settings are configuration options that apply to the entire tenant. They control various aspects of Power Platform features and behaviors, such as security, data protection, licensing, and more. These settings apply to all environments within your tenant. See [Tenant Settings Overview](https://learn.microsoft.com/power-platform/admin/tenant-settings) for more details.",
@@ -336,6 +347,8 @@ func (r *TenantSettingsResource) Schema(ctx context.Context, req resource.Schema
 }
 
 func (r *TenantSettingsResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	if req.ProviderData == nil {
 		return
 	}
@@ -355,23 +368,14 @@ func (r *TenantSettingsResource) Configure(ctx context.Context, req resource.Con
 }
 
 func (r *TenantSettingsResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	var plan TenantSettingsSourceModel
-
-	tflog.Debug(ctx, fmt.Sprintf("CREATE RESOURCE START: %s", r.ProviderTypeName))
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	timeout, diags := plan.Timeouts.Create(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	// Save the original tenant settings in private state
 	originalSettings, erro := r.TenantSettingClient.GetTenantSettings(ctx)
@@ -414,10 +418,12 @@ func (r *TenantSettingsResource) Create(ctx context.Context, req resource.Create
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 
 	tflog.Trace(ctx, fmt.Sprintf("created a resource with ID %s", plan.Id.ValueString()))
-	tflog.Debug(ctx, fmt.Sprintf("CREATE RESOURCE END: %s", r.ProviderTypeName))
+
 }
 
 func (r *TenantSettingsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 	var state TenantSettingsSourceModel
 	tflog.Debug(ctx, fmt.Sprintf("READ RESOURCE START: %s", r.ProviderTypeName))
 
@@ -425,15 +431,6 @@ func (r *TenantSettingsResource) Read(ctx context.Context, req resource.ReadRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	timeout, diags := state.Timeouts.Read(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	tenantSettings, err := r.TenantSettingClient.GetTenantSettings(ctx)
 	if err != nil {
@@ -461,13 +458,14 @@ func (r *TenantSettingsResource) Read(ctx context.Context, req resource.ReadRequ
 	tflog.Debug(ctx, fmt.Sprintf("READ: %s_tenant_settings with id %s", r.ProviderTypeName, newState.Id.ValueString()))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
-	tflog.Debug(ctx, fmt.Sprintf("READ RESOURCE END: %s", r.ProviderTypeName))
+
 }
 
 func (r *TenantSettingsResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var plan TenantSettingsSourceModel
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 
-	tflog.Debug(ctx, fmt.Sprintf("UPDATE RESOURCE START: %s", r.ProviderTypeName))
+	var plan TenantSettingsSourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -531,7 +529,8 @@ func (r *TenantSettingsResource) Update(ctx context.Context, req resource.Update
 
 func (r *TenantSettingsResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state TenantSettingsSourceModel
-	tflog.Debug(ctx, fmt.Sprintf("DELETE RESOURCE START: %s", r.ProviderTypeName))
+	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
+	defer exitContext()
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -539,15 +538,6 @@ func (r *TenantSettingsResource) Delete(ctx context.Context, req resource.Delete
 	}
 
 	resp.Diagnostics.AddWarning("Tenant Settings are not deleted", "Tenant Settings may not be deleted in Power Platform.  Deleting this resource will attempt to restore settings to their previous values and remove this configuration from Terraform state.")
-
-	timeout, diags := state.Timeouts.Delete(ctx, constants.DEFAULT_RESOURCE_OPERATION_TIMEOUT_IN_MINUTES)
-	if diags != nil {
-		resp.Diagnostics.Append(diags...)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	stateDto := ConvertFromTenantSettingsModel(ctx, state)
 

--- a/makefile
+++ b/makefile
@@ -22,19 +22,23 @@ userdocs:
 	go generate
 
 unittest:
+	clear
 	$(MAKE) clean
 	$(MAKE) install
 	TF_ACC=0 go test -p 16 -timeout 10m -v ./... -run "^TestUnit$(TEST)"
 
 acctest:
+	clear
 	$(MAKE) clean
 	$(MAKE) install
 	TF_ACC=1 go test -p 10 -timeout 300m -v ./... -run "^TestAcc$(TEST)"
 
 test:
+	clear
 	$(MAKE) clean
 	$(MAKE) install
 	TF_ACC=1 go test -p 10 -timeout 300m -v ./...
 
 lint:
+	clear
 	golangci-lint run


### PR DESCRIPTION
This pull request includes significant changes to multiple resource and data source files within the `internal/services` directory. The main focus is on refactoring to use the new `helpers.TypeInfo` structure and improving context management by integrating the `helpers.EnterRequestContext` function.

### Refactoring to use `helpers.TypeInfo`:

* [`internal/services/admin_management_application/resource_admin_management_application.go`](diffhunk://#diff-e1bd976694d434d5a9567f2dca980d78a3dcb578598c088c79e9370175add1d3L18-R31): Replaced `ProviderTypeName` and `TypeName` with `helpers.TypeInfo` and updated methods to use `FullTypeName()`. [[1]](diffhunk://#diff-e1bd976694d434d5a9567f2dca980d78a3dcb578598c088c79e9370175add1d3L18-R31) [[2]](diffhunk://#diff-e1bd976694d434d5a9567f2dca980d78a3dcb578598c088c79e9370175add1d3L41-R57)
* [`internal/services/application/datasource_environment_application_packages.go`](diffhunk://#diff-ffb32d64bf68eeb153b2df1fbd5998cbb5b570452cac71ffdea93806fd66a047L16-R16): Replaced `ProviderTypeName` and `TypeName` with `helpers.TypeInfo`. [[1]](diffhunk://#diff-ffb32d64bf68eeb153b2df1fbd5998cbb5b570452cac71ffdea93806fd66a047L16-R16) [[2]](diffhunk://#diff-ffb32d64bf68eeb153b2df1fbd5998cbb5b570452cac71ffdea93806fd66a047L26-L34)
* [`internal/services/application/datasource_tenant_application_packages.go`](diffhunk://#diff-8765e156a9ebac43d71d1210346acbc3235ccb795724cb1d73e03bd476234784L17-R17): Replaced `ProviderTypeName` and `TypeName` with `helpers.TypeInfo`. [[1]](diffhunk://#diff-8765e156a9ebac43d71d1210346acbc3235ccb795724cb1d73e03bd476234784L17-R17) [[2]](diffhunk://#diff-8765e156a9ebac43d71d1210346acbc3235ccb795724cb1d73e03bd476234784L27-L35)
* [`internal/services/application/resource_environment_application_package_install.go`](diffhunk://#diff-25d5acd5e61b963ec86a41b8c62a614f3cf8b8413cfb86eb5d62747efa9f83bcL20-L33): Replaced `ProviderTypeName` and `TypeName` with `helpers.TypeInfo`. [[1]](diffhunk://#diff-25d5acd5e61b963ec86a41b8c62a614f3cf8b8413cfb86eb5d62747efa9f83bcL20-L33) [[2]](diffhunk://#diff-25d5acd5e61b963ec86a41b8c62a614f3cf8b8413cfb86eb5d62747efa9f83bcL44-R57)

### Improved context management:

* [`internal/services/admin_management_application/resource_admin_management_application.go`](diffhunk://#diff-e1bd976694d434d5a9567f2dca980d78a3dcb578598c088c79e9370175add1d3R81-R83): Integrated `helpers.EnterRequestContext` in multiple methods to manage context more effectively. [[1]](diffhunk://#diff-e1bd976694d434d5a9567f2dca980d78a3dcb578598c088c79e9370175add1d3R81-R83) [[2]](diffhunk://#diff-e1bd976694d434d5a9567f2dca980d78a3dcb578598c088c79e9370175add1d3R98-L102) [[3]](diffhunk://#diff-e1bd976694d434d5a9567f2dca980d78a3dcb578598c088c79e9370175add1d3L113-L134) [[4]](diffhunk://#diff-e1bd976694d434d5a9567f2dca980d78a3dcb578598c088c79e9370175add1d3L147-L174)
* [`internal/services/application/datasource_environment_application_packages.go`](diffhunk://#diff-ffb32d64bf68eeb153b2df1fbd5998cbb5b570452cac71ffdea93806fd66a047R167-L180): Integrated `helpers.EnterRequestContext` in the `Read` method.
* [`internal/services/application/datasource_tenant_application_packages.go`](diffhunk://#diff-8765e156a9ebac43d71d1210346acbc3235ccb795724cb1d73e03bd476234784R218-L231): Integrated `helpers.EnterRequestContext` in the `Read` method.
* [`internal/services/application/resource_environment_application_package_install.go`](diffhunk://#diff-25d5acd5e61b963ec86a41b8c62a614f3cf8b8413cfb86eb5d62747efa9f83bcR92-R93): Integrated `helpers.EnterRequestContext` in multiple methods to manage context more effectively. [[1]](diffhunk://#diff-25d5acd5e61b963ec86a41b8c62a614f3cf8b8413cfb86eb5d62747efa9f83bcR92-R93) [[2]](diffhunk://#diff-25d5acd5e61b963ec86a41b8c62a614f3cf8b8413cfb86eb5d62747efa9f83bcR111-L118) [[3]](diffhunk://#diff-25d5acd5e61b963ec86a41b8c62a614f3cf8b8413cfb86eb5d62747efa9f83bcL145-R154) [[4]](diffhunk://#diff-25d5acd5e61b963ec86a41b8c62a614f3cf8b8413cfb86eb5d62747efa9f83bcL162-R171) [[5]](diffhunk://#diff-25d5acd5e61b963ec86a41b8c62a614f3cf8b8413cfb86eb5d62747efa9f83bcL189-R192)