### PR TITLE
Fix broken acceptance tests and enable acceptance test for labeled PRs

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,16 +21,21 @@ permissions:
   contents: read  # This is required for actions/checkout
 
 jobs:
-  skip-unlabeled-prs:
+  should_run:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-acceptance-tests')
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-acceptance-tests'))
+    outputs:
+      acceptance_tests: ${{ steps.set_acceptance_tests.outputs.acceptance_tests }}
     steps:
-      - name: Skip acceptance tests due to missing label
-        run: exit 0
+      - id: set_acceptance_tests
+        name: Skip acceptance tests due to missing label
+        run: echo "acceptance_tests=true" >> $GITHUB_ENV
   # ensure go.mod and go.sum are updated
   depscheck:
     name: Check Dependencies
     runs-on: ubuntu-latest
+    needs: should_run
+    if: ${{ needs.should_run.outputs.acceptance_tests == 'true' }}
     steps:
 
     - name: Harden Runner
@@ -59,6 +64,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs: should_run
+    if: ${{ needs.should_run.outputs.acceptance_tests == 'true' }}
     timeout-minutes: 5
     steps:
 
@@ -87,7 +94,8 @@ jobs:
 
   tests:
     name: Running Test
-    needs: build
+    needs: [build, should_run]
+    if: ${{ needs.should_run.outputs.acceptance_tests == 'true' }}
     runs-on: ubuntu-latest
     steps:
     

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -6,8 +6,6 @@ on:
      # run at 4 AM UTC every day
      - cron:  '0 4 * * *' 
   pull_request:
-    #  paths:
-    #    - 'go.mod'
   push:
      branches:
        - main
@@ -28,7 +26,7 @@ jobs:
       acceptance_tests: ${{ steps.set_acceptance_tests.outputs.acceptance_tests }}
     steps:
       - id: set_acceptance_tests
-        name: Skip acceptance tests due to missing label
+        name: Only run acceptance tests if necessary
         run: echo "::set-output name=acceptance_tests::true"
   # ensure go.mod and go.sum are updated
   depscheck:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -6,8 +6,8 @@ on:
      # run at 4 AM UTC every day
      - cron:  '0 4 * * *' 
   pull_request:
-     paths:
-       - 'go.mod'
+    #  paths:
+    #    - 'go.mod'
   push:
      branches:
        - main
@@ -21,6 +21,12 @@ permissions:
   contents: read  # This is required for actions/checkout
 
 jobs:
+  skip-unlabeled-prs:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-acceptance-tests')
+    steps:
+      - name: Skip acceptance tests due to missing label
+        run: exit 0
   # ensure go.mod and go.sum are updated
   depscheck:
     name: Check Dependencies

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - id: set_acceptance_tests
         name: Skip acceptance tests due to missing label
-        run: echo "acceptance_tests=true" >> $GITHUB_ENV
+        run: echo "::set-output name=acceptance_tests::true"
   # ensure go.mod and go.sum are updated
   depscheck:
     name: Check Dependencies


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow and improvements to the test suite for the `datasource_environments` in the Terraform provider. The changes focus on conditional execution of jobs based on labels and enhancing test checks with more detailed state validations.

### Workflow Enhancements:
* [`.github/workflows/run_tests.yml`](diffhunk://#diff-c2e9f7c1bfaf65da79bbd29ed3ce389b2acc8b4099a257914a7292a66e6b9bc9R24-R38): Added a new job `should_run` to determine if acceptance tests should run based on the presence of a specific label on pull requests. This job sets an output used to conditionally run subsequent jobs. [[1]](diffhunk://#diff-c2e9f7c1bfaf65da79bbd29ed3ce389b2acc8b4099a257914a7292a66e6b9bc9R24-R38) [[2]](diffhunk://#diff-c2e9f7c1bfaf65da79bbd29ed3ce389b2acc8b4099a257914a7292a66e6b9bc9R67-R68) [[3]](diffhunk://#diff-c2e9f7c1bfaf65da79bbd29ed3ce389b2acc8b4099a257914a7292a66e6b9bc9L84-R98)

### Test Suite Improvements:
* [`internal/services/environment/datasource_environments_test.go`](diffhunk://#diff-0a855bb70ec5cddbb6e05c3b65b6f673834d17e597a7c51c2ace4e9b44c25988R12-R14): Enhanced the test suite by adding new imports for state checking and known values. Refactored the `TestAccEnvironmentsDataSource_Basic` function to use more detailed state checks and output validations, ensuring comprehensive test coverage. [[1]](diffhunk://#diff-0a855bb70ec5cddbb6e05c3b65b6f673834d17e597a7c51c2ace4e9b44c25988R12-R14) [[2]](diffhunk://#diff-0a855bb70ec5cddbb6e05c3b65b6f673834d17e597a7c51c2ace4e9b44c25988L39-R63)