### PR TITLE
Fix goreleaser's ldflags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - '-s -w -X github.com/microsoft/terraform-provider-power-platform/common.ProviderVersion={{ .Version }} -X github.com/microsoft/terraform-provider-power-platform/common.Commit={{.Commit}}' -X github.com/microsoft/terraform-provider-power-platform/common.Branch=$(git rev-parse --abbrev-ref HEAD)'
+      - '-s -w -X github.com/microsoft/terraform-provider-power-platform/common.ProviderVersion={{ .Version }} -X github.com/microsoft/terraform-provider-power-platform/common.Commit={{.Commit}} -X github.com/microsoft/terraform-provider-power-platform/common.Branch={{ .Branch }}'
       
     goos:
       - freebsd


### PR DESCRIPTION
This pull request includes a change to the `ldflags` in the `.goreleaser.yml` file to fix an issue with the branch name.

* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L17-R17): Modified the `ldflags` to correctly set the branch name using `{{ .Branch }}` instead of a `git` command.