### PR TITLE
Fix power platform rest with only destroy #474

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,14 +11,6 @@ assignees: ''
 
 A clear and concise description of what the bug is.
 
-### To Reproduce
-
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
-
 ### Sample Terraform Code
 
 If applicable, add terraform code to help explain your problem.  
@@ -35,14 +27,13 @@ A clear and concise description of what you expected to happen.
 
 ## System Information
 
- - Provider Version: [e.g. 0.2.2]
- - OS & Version: [e.g. Windows, Linux, MacOS]
- 
+- Provider Version: [e.g. 0.2.2]
+- OS & Version: [e.g. Windows, Linux, MacOS]
 
 ## Additional context
+
 Add any other context about the problem here.
 
 ## Contribution
 
-## Contribution
 Do you plan to raise a PR to address this issue?  YES / NO?

--- a/docs/resources/data_record.md
+++ b/docs/resources/data_record.md
@@ -44,6 +44,14 @@ data "powerplatform_data_records" "root_business_unit" {
   select            = ["name"]
 }
 
+module "business_unit" {
+  source = "./res_business_unit"
+  environment_id = powerplatform_environment.data_record_example_env.id
+  name = "my business unit"
+  costcenter = "123"
+  parent_business_unit_id = one(data.powerplatform_data_records.root_business_unit.rows).businessunitid  
+}
+
 resource "powerplatform_data_record" "role" {
   environment_id     = powerplatform_environment.data_record_example_env.id
   table_logical_name = "role"

--- a/examples/resources/powerplatform_data_record/res_business_unit/main.tf
+++ b/examples/resources/powerplatform_data_record/res_business_unit/main.tf
@@ -1,0 +1,64 @@
+terraform {
+  required_providers {
+    powerplatform = {
+      source = "microsoft/power-platform"
+    }
+  }
+}
+
+variable "environment_id" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "costcenter" {
+  type = string
+}
+
+variable "parent_business_unit_id" {
+  type = string
+}
+
+resource "powerplatform_data_record" "business_unit" {
+  environment_id     = var.environment_id
+  table_logical_name = "businessunit"
+  columns = {
+    name       = var.name
+    costcenter = var.costcenter
+    parentbusinessunitid = {
+      table_logical_name = "businessunit"
+      data_record_id     = var.parent_business_unit_id
+    }
+  }
+}
+
+data "powerplatform_environments" "envs" {
+}
+
+locals {
+  dataverse_url = tostring(one([for e in data.powerplatform_environments.envs.environments : e.dataverse.url if e.id == var.environment_id]))
+}
+
+resource "powerplatform_rest" "business_unit_disable_on_destroy" {
+  destroy = {
+    scope                = "${local.dataverse_url}.default"
+    method               = "PATCH"
+    url                  = "${local.dataverse_url}api/data/v9.2/businessunits(${powerplatform_data_record.business_unit.id})"
+    expected_http_status = [200, 204]
+    body = jsonencode({
+      isdisabled    = true
+    })
+  }
+  depends_on = [powerplatform_data_record.business_unit]
+}
+
+output "resource_id" {
+  value = powerplatform_data_record.business_unit.id
+}
+
+output "resource" {
+  value = powerplatform_data_record.business_unit
+}

--- a/examples/resources/powerplatform_data_record/resource.tf
+++ b/examples/resources/powerplatform_data_record/resource.tf
@@ -29,6 +29,14 @@ data "powerplatform_data_records" "root_business_unit" {
   select            = ["name"]
 }
 
+module "business_unit" {
+  source = "./res_business_unit"
+  environment_id = powerplatform_environment.data_record_example_env.id
+  name = "my business unit"
+  costcenter = "123"
+  parent_business_unit_id = one(data.powerplatform_data_records.root_business_unit.rows).businessunitid  
+}
+
 resource "powerplatform_data_record" "role" {
   environment_id     = powerplatform_environment.data_record_example_env.id
   table_logical_name = "role"

--- a/internal/services/rest/api_rest.go
+++ b/internal/services/rest/api_rest.go
@@ -48,7 +48,7 @@ func (client *client) SendOperation(ctx context.Context, operation *DataverseWeb
 	}
 
 	res, err := client.ExecuteApiRequest(ctx, operation.Scope.ValueStringPointer(), url, method, body, headers, expectedStatusCodes)
-	var unexpected *customerrors.UnexpectedHttpStatusCodeError
+	var unexpected customerrors.UnexpectedHttpStatusCodeError
 	if errors.As(err, &unexpected) {
 		return types.ObjectUnknown(map[string]attr.Type{
 			"body": types.StringType,

--- a/internal/services/rest/resource_rest.go
+++ b/internal/services/rest/resource_rest.go
@@ -238,6 +238,8 @@ func (r *DataverseWebApiResource) Create(ctx context.Context, req resource.Creat
 			}
 			state.Output = bodyWrapped
 		}
+	} else {
+		state.Output = r.NullOutputValue()
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }


### PR DESCRIPTION
This pull request includes changes to the `bug_report.md` template, additions to the `powerplatform_data_record` module, and minor adjustments to error handling in the REST API client. The most important changes include the removal of the "Steps to reproduce" section from the bug report template, the addition of a new Terraform module for managing business units, and refinements to error handling in the REST API client.

### Changes to Bug Report Template:
* [`.github/ISSUE_TEMPLATE/bug_report.md`](diffhunk://#diff-185833cb26d7ac66a4d39042fd576a820c2c2c6d05ad18973bb9c7dce77267c5L14-L21): Removed the "Steps to reproduce" section to streamline the bug report process.

### Additions to Terraform Module:
* [`docs/resources/data_record.md`](diffhunk://#diff-0355f94f8ebd58f4747c74d9279cea1378d8260d340dc453a1f9635140b37007R47-R54): Added a new module for managing business units, including variables for `environment_id`, `name`, `costcenter`, and `parent_business_unit_id`.
* [`examples/resources/powerplatform_data_record/res_business_unit/main.tf`](diffhunk://#diff-a8298ada221156cc78393598c803596bd811958806dcc5171a893502bc81d72fR1-R64): Introduced a new Terraform module for creating and managing business units with necessary variables and resources.

### Error Handling Adjustments:
* [`internal/services/rest/api_rest.go`](diffhunk://#diff-508b88487f5a19cc0a2d7da2a9819699090fcf5a64fa5f9f93c26e7a555e35c8L51-R51): Refined error handling by changing the type of `unexpected` error from a pointer to a value.
* [`internal/services/rest/resource_rest.go`](diffhunk://#diff-100372b3e4649c24e2f0e385c92152c263bb3333bc77bbcc5a95777b7db357dfR241-R242): Added a fallback to set `state.Output` to `r.NullOutputValue()` in case of an error during resource creation.