### PR TITLE
Refactor test files to use dynamic resource group names

### DIFF
--- a/internal/services/data_record/resource_data_record_test.go
+++ b/internal/services/data_record/resource_data_record_test.go
@@ -1538,8 +1538,8 @@ func TestUnitDataRecordResource_Validate_Disable_On_Delete(t *testing.T) {
 
 func TestAccDataRecordResource_Validate_Disable_On_Delete(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		IsUnitTest:               true,
-		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+		IsUnitTest:               false,
+		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: `

--- a/internal/services/licensing/datasource_billing_policies_environments_test.go
+++ b/internal/services/licensing/datasource_billing_policies_environments_test.go
@@ -4,8 +4,10 @@
 package licensing_test
 
 import (
+	"math/rand/v2"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -34,7 +36,7 @@ func TestAccBillingPoliciesEnvironmentsDataSource_Validate_Read(t *testing.T) {
 				resource "azapi_resource" "rg_example" {
 					type      = "Microsoft.Resources/resourceGroups@2021-04-01"
 					location  = "East US"
-					name      = "power-platform-billing-` + mocks.TestName() + `"
+					name      = "power-platform-billing-` + mocks.TestName() + strconv.Itoa(rand.IntN(9999)) + `"
 
 					body = jsonencode({
 						properties = {}

--- a/internal/services/licensing/datasource_billing_policies_test.go
+++ b/internal/services/licensing/datasource_billing_policies_test.go
@@ -4,8 +4,10 @@
 package licensing_test
 
 import (
+	"math/rand/v2"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -34,7 +36,7 @@ func TestAccBillingPoliciesDataSource_Validate_Read(t *testing.T) {
 				resource "azapi_resource" "rg_example" {
 					type      = "Microsoft.Resources/resourceGroups@2021-04-01"
 					location  = "East US"
-					name      = "power-platform-billing-` + mocks.TestName() + `"
+					name      = "power-platform-billing-` + mocks.TestName() + strconv.Itoa(rand.IntN(9999)) + `"
 
 					body = jsonencode({
 						properties = {}

--- a/internal/services/licensing/resource_billing_policy_environment_test.go
+++ b/internal/services/licensing/resource_billing_policy_environment_test.go
@@ -5,8 +5,10 @@ package licensing_test
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -35,7 +37,7 @@ func TestAccBillingPolicyResourceEnvironment_Validate_Create(t *testing.T) {
 				resource "azapi_resource" "rg_example" {
 					type      = "Microsoft.Resources/resourceGroups@2021-04-01"
 					location  = "East US"
-					name      = "power-platform-billing-` + mocks.TestName() + `"
+					name      = "power-platform-billing-` + mocks.TestName() + strconv.Itoa(rand.IntN(9999)) + `"
 
 					body = jsonencode({
 						properties = {}
@@ -122,6 +124,7 @@ func TestUnitBillingPolicyResourceEnvironment_Validate_Create(t *testing.T) {
 }
 
 func TestAccBillingPolicyResourceEnvironment_Validate_Update(t *testing.T) {
+	rgName := "power-platform-billing-" + mocks.TestName() + strconv.Itoa(rand.IntN(9999))
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,
 		ExternalProviders: map[string]resource.ExternalProvider{
@@ -139,7 +142,7 @@ func TestAccBillingPolicyResourceEnvironment_Validate_Update(t *testing.T) {
 				resource "azapi_resource" "rg_example" {
 					type      = "Microsoft.Resources/resourceGroups@2021-04-01"
 					location  = "East US"
-					name      = "power-platform-billing-` + mocks.TestName() + `"
+					name      = "` + rgName + `"
 
 					body = jsonencode({
 						properties = {}
@@ -191,7 +194,7 @@ func TestAccBillingPolicyResourceEnvironment_Validate_Update(t *testing.T) {
 				resource "azapi_resource" "rg_example" {
 					type      = "Microsoft.Resources/resourceGroups@2021-04-01"
 					location  = "East US"
-					name      = "power-platform-billing-` + mocks.TestName() + `"
+					name      = "` + rgName + `"
 
 					body = jsonencode({
 						properties = {}
@@ -243,7 +246,7 @@ func TestAccBillingPolicyResourceEnvironment_Validate_Update(t *testing.T) {
 				resource "azapi_resource" "rg_example" {
 					type      = "Microsoft.Resources/resourceGroups@2021-04-01"
 					location  = "East US"
-					name      = "power-platform-billing-` + mocks.TestName() + `"
+					name      = "` + rgName + `"
 
 					body = jsonencode({
 						properties = {}

--- a/internal/services/licensing/resource_billing_policy_test.go
+++ b/internal/services/licensing/resource_billing_policy_test.go
@@ -5,8 +5,10 @@ package licensing_test
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -18,6 +20,8 @@ import (
 )
 
 func TestAccBillingPolicyResource_Validate_Create(t *testing.T) {
+	rgName := "power-platform-billing-" + mocks.TestName() + strconv.Itoa(rand.IntN(9999))
+	println("rgName: " + rgName)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,
 		ExternalProviders: map[string]resource.ExternalProvider{
@@ -35,7 +39,7 @@ func TestAccBillingPolicyResource_Validate_Create(t *testing.T) {
 				resource "azapi_resource" "rg_example" {
 					type      = "Microsoft.Resources/resourceGroups@2021-04-01"
 					location  = "East US"
-					name      = "power-platform-billing-` + mocks.TestName() + `"
+					name      = "` + rgName + `"
 
 					body = jsonencode({
 						properties = {}
@@ -57,7 +61,7 @@ func TestAccBillingPolicyResource_Validate_Create(t *testing.T) {
 					resource.TestCheckResourceAttr("powerplatform_billing_policy.pay_as_you_go", "name", strings.ReplaceAll(mocks.TestName(), "_", "")),
 					resource.TestCheckResourceAttr("powerplatform_billing_policy.pay_as_you_go", "location", "unitedstates"),
 					resource.TestCheckResourceAttr("powerplatform_billing_policy.pay_as_you_go", "status", "Enabled"),
-					resource.TestCheckResourceAttr("powerplatform_billing_policy.pay_as_you_go", "billing_instrument.resource_group", "power-platform-billing-"+mocks.TestName()),
+					resource.TestCheckResourceAttr("powerplatform_billing_policy.pay_as_you_go", "billing_instrument.resource_group", rgName),
 					resource.TestMatchResourceAttr("powerplatform_billing_policy.pay_as_you_go", "billing_instrument.subscription_id", regexp.MustCompile(helpers.GuidRegex)),
 				),
 			},
@@ -120,6 +124,7 @@ func TestUnitTestBillingPolicyResource_Validate_Create(t *testing.T) {
 }
 
 func TestAccBillingPolicy_Validate_Update(t *testing.T) {
+	rgName := "power-platform-billing-" + mocks.TestName() + strconv.Itoa(rand.IntN(9999))
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,
 		ExternalProviders: map[string]resource.ExternalProvider{
@@ -137,7 +142,7 @@ func TestAccBillingPolicy_Validate_Update(t *testing.T) {
 				resource "azapi_resource" "rg_example" {
 					type      = "Microsoft.Resources/resourceGroups@2021-04-01"
 					location  = "East US"
-					name      = "power-platform-billing-` + mocks.TestName() + `"
+					name      = "` + rgName + `"
 
 					body = jsonencode({
 						properties = {}
@@ -166,7 +171,7 @@ func TestAccBillingPolicy_Validate_Update(t *testing.T) {
 				resource "azapi_resource" "rg_example" {
 					type      = "Microsoft.Resources/resourceGroups@2021-04-01"
 					location  = "East US"
-					name      = "power-platform-billing-` + mocks.TestName() + `"
+					name      = "` + rgName + `"
 
 					body = jsonencode({
 						properties = {}
@@ -197,7 +202,7 @@ func TestAccBillingPolicy_Validate_Update(t *testing.T) {
 				resource "azapi_resource" "rg_example" {
 					type      = "Microsoft.Resources/resourceGroups@2021-04-01"
 					location  = "East US"
-					name      = "power-platform-billing-` + mocks.TestName() + `"
+					name      = "` + rgName + `"
 
 					body = jsonencode({
 						properties = {}
@@ -311,6 +316,7 @@ func TestUnitTestBillingPolicy_Validate_Update(t *testing.T) {
 }
 
 func TestAccBillingPolicy_Validate_Update_ForceRecreate(t *testing.T) {
+	rgName := "power-platform-billing-" + mocks.TestName() + strconv.Itoa(rand.IntN(9999))
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,
 		ExternalProviders: map[string]resource.ExternalProvider{
@@ -327,7 +333,7 @@ func TestAccBillingPolicy_Validate_Update_ForceRecreate(t *testing.T) {
 				resource "azapi_resource" "rg_example" {
 					type      = "Microsoft.Resources/resourceGroups@2021-04-01"
 					location  = "East US"
-					name      = "power-platform-billing-` + mocks.TestName() + `"
+					name      = "` + rgName + `"
 
 					body = jsonencode({
 						properties = {}
@@ -355,7 +361,7 @@ func TestAccBillingPolicy_Validate_Update_ForceRecreate(t *testing.T) {
 				resource "azapi_resource" "rg_example" {
 					type      = "Microsoft.Resources/resourceGroups@2021-04-01"
 					location  = "East US"
-					name      = "power-platform-billing-` + mocks.TestName() + `"
+					name      = "` + rgName + `"
 
 					body = jsonencode({
 						properties = {}
@@ -383,7 +389,7 @@ func TestAccBillingPolicy_Validate_Update_ForceRecreate(t *testing.T) {
 				resource "azapi_resource" "rg_example" {
 					type      = "Microsoft.Resources/resourceGroups@2021-04-01"
 					location  = "East US"
-					name      = "power-platform-billing-` + mocks.TestName() + `1"
+					name      = "` + rgName + `1"
 
 					body = jsonencode({
 						properties = {}
@@ -402,7 +408,7 @@ func TestAccBillingPolicy_Validate_Update_ForceRecreate(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("powerplatform_billing_policy.pay_as_you_go", "id", regexp.MustCompile(helpers.GuidRegex)),
 					resource.TestCheckResourceAttr("powerplatform_billing_policy.pay_as_you_go", "location", "switzerland"),
-					resource.TestCheckResourceAttr("powerplatform_billing_policy.pay_as_you_go", "billing_instrument.resource_group", "power-platform-billing-"+mocks.TestName()+"1"),
+					resource.TestCheckResourceAttr("powerplatform_billing_policy.pay_as_you_go", "billing_instrument.resource_group", rgName+"1"),
 				),
 			},
 		},

--- a/internal/services/licensing/resource_billing_policy_test.go
+++ b/internal/services/licensing/resource_billing_policy_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestAccBillingPolicyResource_Validate_Create(t *testing.T) {
 	rgName := "power-platform-billing-" + mocks.TestName() + strconv.Itoa(rand.IntN(9999))
-	println("rgName: " + rgName)
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,
 		ExternalProviders: map[string]resource.ExternalProvider{


### PR DESCRIPTION
This pull request introduces changes to the test files in the `internal/services/licensing` directory to ensure unique resource group names by appending a random number. The most important changes involve modifying the resource group names in various test functions and importing necessary packages.

### Test Function Updates:
* [`internal/services/licensing/datasource_billing_policies_environments_test.go`](diffhunk://#diff-eb0cbcf37001354e8d551603f376d7ba4459f0f87372f914c9d0e107f76394e1L37-R39): Updated `TestAccBillingPoliciesEnvironmentsDataSource_Validate_Read` to append a random number to the resource group name using `strconv.Itoa(rand.IntN(9999))`.
* [`internal/services/licensing/datasource_billing_policies_test.go`](diffhunk://#diff-8043b419b1dc2eedd0fecae65de70da19b8a2586ef5bf4c507473bb460e02616L37-R39): Updated `TestAccBillingPoliciesDataSource_Validate_Read` to append a random number to the resource group name.
* [`internal/services/licensing/resource_billing_policy_environment_test.go`](diffhunk://#diff-ec8182b39b46e318d6544bc6b0db0ba9537fdb8eb9c673caabd0679d6e1a7af6L38-R40): Updated several functions (`TestAccBillingPolicyResourceEnvironment_Validate_Create`, `TestAccBillingPolicyResourceEnvironment_Validate_Update`) to use a random number in the resource group name. [[1]](diffhunk://#diff-ec8182b39b46e318d6544bc6b0db0ba9537fdb8eb9c673caabd0679d6e1a7af6L38-R40) [[2]](diffhunk://#diff-ec8182b39b46e318d6544bc6b0db0ba9537fdb8eb9c673caabd0679d6e1a7af6L142-R145) [[3]](diffhunk://#diff-ec8182b39b46e318d6544bc6b0db0ba9537fdb8eb9c673caabd0679d6e1a7af6L194-R197) [[4]](diffhunk://#diff-ec8182b39b46e318d6544bc6b0db0ba9537fdb8eb9c673caabd0679d6e1a7af6L246-R249)
* [`internal/services/licensing/resource_billing_policy_test.go`](diffhunk://#diff-0c185e844934065a570a9b4e65c1e615a5ea22fd61556a46bae157084bac5f3eL38-R42): Updated multiple functions (`TestAccBillingPolicyResource_Validate_Create`, `TestAccBillingPolicy_Validate_Update`, `TestAccBillingPolicy_Validate_Update_ForceRecreate`) to use a random number in the resource group name. [[1]](diffhunk://#diff-0c185e844934065a570a9b4e65c1e615a5ea22fd61556a46bae157084bac5f3eL38-R42) [[2]](diffhunk://#diff-0c185e844934065a570a9b4e65c1e615a5ea22fd61556a46bae157084bac5f3eL140-R145) [[3]](diffhunk://#diff-0c185e844934065a570a9b4e65c1e615a5ea22fd61556a46bae157084bac5f3eL330-R336) [[4]](diffhunk://#diff-0c185e844934065a570a9b4e65c1e615a5ea22fd61556a46bae157084bac5f3eL386-R392)

### Package Imports:
* Added `math/rand/v2` and `strconv` imports to several test files to facilitate the generation of random numbers for resource group names. [[1]](diffhunk://#diff-eb0cbcf37001354e8d551603f376d7ba4459f0f87372f914c9d0e107f76394e1R7-R10) [[2]](diffhunk://#diff-8043b419b1dc2eedd0fecae65de70da19b8a2586ef5bf4c507473bb460e02616R7-R10) [[3]](diffhunk://#diff-ec8182b39b46e318d6544bc6b0db0ba9537fdb8eb9c673caabd0679d6e1a7af6R8-R11) [[4]](diffhunk://#diff-0c185e844934065a570a9b4e65c1e615a5ea22fd61556a46bae157084bac5f3eR8-R11)