### PR TITLE
Fix invalid character error in powerplatform_data_record conversion

### DIFF
--- a/.changes/unreleased/fixed-20241003-125837.yaml
+++ b/.changes/unreleased/fixed-20241003-125837.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: powerplatform_data_record invalid character '<' error when running apply
+time: 2024-10-03T12:58:37.265266925Z
+custom:
+    Issue: "474"

--- a/internal/services/data_record/resource_data_record.go
+++ b/internal/services/data_record/resource_data_record.go
@@ -298,6 +298,9 @@ func convertResourceModelToMap(columnsAsString *string) (mapColumns map[string]a
 		return nil, nil
 	}
 
+	replacedColumns := strings.ReplaceAll(*columnsAsString, `<null>`, `""`)
+	columnsAsString = &replacedColumns
+
 	jsonColumns, err := json.Marshal(columnsAsString)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This pull request includes a fix for the `powerplatform_data_record` invalid character error and an update to the `convertResourceModelToMap` function to handle null values properly.

Bug Fix:

* [`.changes/unreleased/fixed-20241003-125837.yaml`](diffhunk://#diff-e19f1c7561cca7b014ec371361d951658e1851e6f5c24c8b234df4238658b727R1-R5): Added a new entry to document the fix for the `powerplatform_data_record` invalid character '<' error when running apply.

Code Update:

* [`internal/services/data_record/resource_data_record.go`](diffhunk://#diff-367498b2e3d4a6fc20006215312a73f0e8ee0771ce511c043f994767bedcbabdR301-R303): Updated the `convertResourceModelToMap` function to replace `<null>` with `""` in the `columnsAsString` variable to handle null values correctly.