### PR TITLE
Fix powerplatform_dlp_policies

### DIFF
--- a/internal/services/dlp_policy/api_dlp_policy.go
+++ b/internal/services/dlp_policy/api_dlp_policy.go
@@ -30,7 +30,7 @@ func (client *client) GetPolicies(ctx context.Context) ([]dlpPolicyModelDto, err
 	apiUrl := &url.URL{
 		Scheme: constants.HTTPS,
 		Host:   client.Api.GetConfig().Urls.BapiUrl,
-		Path:   "providers/PowerPlatform.Governance/v2/policies",
+		Path:   "providers/PowerPlatform.Governance/v1/policies",
 	}
 	policiesArray := dlpPolicyDefinitionArrayDto{}
 	_, err := client.Api.Execute(ctx, nil, "GET", apiUrl.String(), nil, nil, []int{http.StatusOK}, &policiesArray)


### PR DESCRIPTION
This pull request includes a small but significant change to the `GetPolicies` function in the `internal/services/dlp_policy/api_dlp_policy.go` file. The change updates the API path to use the correct version.

* [`internal/services/dlp_policy/api_dlp_policy.go`](diffhunk://#diff-7a5f1be55057b8a44b869242e9b5768dc1892ba81867e2724d8ff5afb411f7edL33-R33): Updated the API path from `v2` to `v1` to ensure the correct endpoint is used in the `GetPolicies` function.