### PR TITLE
Refactor environment API methods for create and update

### DIFF
--- a/.changes/unreleased/fixed-20241024-142026.yaml
+++ b/.changes/unreleased/fixed-20241024-142026.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: powerplatform_environment fixed error during environment update when a custom domain is set
+time: 2024-10-24T14:20:26.015364964Z
+custom:
+    Issue: "502"

--- a/internal/services/environment/dto.go
+++ b/internal/services/environment/dto.go
@@ -188,9 +188,14 @@ type transactionCurrencyArrayDto struct {
 	Value []TransactionCurrencyDto `json:"value"`
 }
 
-type validateEnvironmentDetailsDto struct {
+type validateCreateEnvironmentDetailsDto struct {
 	DomainName          string `json:"domainName"`
 	EnvironmentLocation string `json:"environmentLocation"`
+}
+
+type validateUpdateEnvironmentDetailsDto struct {
+	DomainName      string `json:"domainName"`
+	EnvironmentName string `json:"environmentName"`
 }
 
 type LocationArrayDto struct {

--- a/internal/services/environment/resource_environment_test.go
+++ b/internal/services/environment/resource_environment_test.go
@@ -88,6 +88,62 @@ func TestAccEnvironmentsResource_Validate_Update(t *testing.T) {
 	})
 }
 
+func TestAccEnvironmentsResource_Validate_Domain_Uniqueness_On_Update(t *testing.T) {
+	domainName := fmt.Sprintf("terraformprovidertest%d", rand.Intn(100000))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				resource "powerplatform_environment" "development" {
+					display_name                              = "` + mocks.TestName() + `"
+					description                               = "desc"
+					cadence								   	  = "Moderate"
+					location                                  = "unitedstates"
+					environment_type                       	  = "Sandbox"
+					dataverse = {
+						language_code                             = "1033"
+						currency_code                             = "USD"
+						security_group_id 						  = "00000000-0000-0000-0000-000000000000"
+						domain									  =  "` + domainName + `"
+					}
+				}`,
+
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "description", "desc"),
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "dataverse.domain", domainName),
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "dataverse.security_group_id", "00000000-0000-0000-0000-000000000000"),
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "dataverse.url", "https://"+domainName+".crm.dynamics.com/"),
+				),
+			},
+			{
+				Config: `
+				resource "powerplatform_environment" "development" {
+					display_name                              = "` + mocks.TestName() + `"
+					description                               = "desc test"
+					cadence								   	  = "Moderate"
+					location                                  = "unitedstates"
+					environment_type                       	  = "Sandbox"
+					dataverse = {
+						language_code                             = "1033"
+						currency_code                             = "USD"
+						security_group_id 						  = "00000000-0000-0000-0000-000000000000"
+						domain									  =  "` + domainName + `"
+					}
+				}`,
+
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "description", "desc test"),
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "dataverse.domain", domainName),
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "dataverse.security_group_id", "00000000-0000-0000-0000-000000000000"),
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "dataverse.url", "https://"+domainName+".crm.dynamics.com/"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccEnvironmentsResource_Validate_Create(t *testing.T) {
 	domainName := fmt.Sprintf("orgtest%d", rand.Intn(100000))
 


### PR DESCRIPTION
This pull request to the `internal/services/environment` package introduces changes to improve the validation of environment details during creation and update operations. The most important changes include renaming existing validation methods for clarity, adding new methods for update validation, and updating the corresponding data transfer objects (DTOs) and tests.

### Improvements to validation methods:

* [`internal/services/environment/api_environment.go`](diffhunk://#diff-6939b69029f482f476bfc737204e004670b40a16e4a3a6c3af61eb9efb8244afL393-R393): Renamed `ValidateEnvironmentDetails` to `ValidateCreateEnvironmentDetails` to better reflect its purpose. [[1]](diffhunk://#diff-6939b69029f482f476bfc737204e004670b40a16e4a3a6c3af61eb9efb8244afL393-R393) [[2]](diffhunk://#diff-6939b69029f482f476bfc737204e004670b40a16e4a3a6c3af61eb9efb8244afL548-R548) [[3]](diffhunk://#diff-6939b69029f482f476bfc737204e004670b40a16e4a3a6c3af61eb9efb8244afL558-R558)
* [`internal/services/environment/api_environment.go`](diffhunk://#diff-6939b69029f482f476bfc737204e004670b40a16e4a3a6c3af61eb9efb8244afR569-R590): Added a new method `ValidateUpdateEnvironmentDetails` for validating environment details during updates.

### Updates to DTOs:

* [`internal/services/environment/dto.go`](diffhunk://#diff-29db28f0e3bf93f9d3a7c0ced4207a58b561a2f259cd1c992d4da5cdf91c8462L191-R200): Renamed `validateEnvironmentDetailsDto` to `validateCreateEnvironmentDetailsDto` and added a new `validateUpdateEnvironmentDetailsDto` for update validation.

### Test enhancements:

* [`internal/services/environment/resource_environment_test.go`](diffhunk://#diff-07ad5067382ca0f319e0f77b1f72649a105aa53a05b7231cb67b9249f2bad472R91-R146): Added a new test `TestAccEnvironmentsResource_Validate_Domain_Uniqueness_On_Update` to validate domain uniqueness during environment updates.