### PR TITLE
Add documentation to environment_settings on using data_record to manage setttings

### DIFF
--- a/docs/data-sources/environment_settings.md
+++ b/docs/data-sources/environment_settings.md
@@ -3,12 +3,12 @@
 page_title: "powerplatform_environment_settings Data Source - powerplatform"
 subcategory: ""
 description: |-
-  Power Platform Environment Settings Data Source. Power Platform Settings are configuration options that apply to a specific environment. They control various aspects of Power Platform features and behaviors, See Environment Settings Overview https://learn.microsoft.com/power-platform/admin/admin-settings for more details.
+  Power Platform Environment Settings Data Source. Power Platform Settings are configuration options that apply to a specific environment. They control various aspects of Power Platform features and behaviors, See Environment Settings Overview https://learn.microsoft.com/power-platform/admin/admin-settings for more details.  While this data source provides access to some specific environment settings, many environment settings are stored as records in Dataverse.  You may be able to read those settings using the powerplatform_data_records resource ./data_records.
 ---
 
 # powerplatform_environment_settings (Data Source)
 
-Power Platform Environment Settings Data Source. Power Platform Settings are configuration options that apply to a specific environment. They control various aspects of Power Platform features and behaviors, See [Environment Settings Overview](https://learn.microsoft.com/power-platform/admin/admin-settings) for more details.
+Power Platform Environment Settings Data Source. Power Platform Settings are configuration options that apply to a specific environment. They control various aspects of Power Platform features and behaviors, See [Environment Settings Overview](https://learn.microsoft.com/power-platform/admin/admin-settings) for more details.  While this data source provides access to some specific environment settings, many environment settings are stored as records in Dataverse.  You may be able to read those settings using the [`powerplatform_data_records` resource](./data_records).
 
 
 

--- a/docs/resources/environment_settings.md
+++ b/docs/resources/environment_settings.md
@@ -3,12 +3,12 @@
 page_title: "powerplatform_environment_settings Resource - powerplatform"
 subcategory: ""
 description: |-
-  Manages Power Platform Settings for a given environment. They control various aspects of Power Platform features and behaviors, See Environment Settings Overview https://learn.microsoft.com/power-platform/admin/admin-settings for more details.
+  Manages Power Platform Settings for a given environment. They control various aspects of Power Platform features and behaviors, See Environment Settings Overview https://learn.microsoft.com/power-platform/admin/admin-settings for more details.  While this resource provides a limited set of settings, many of the settings in an environment are stored as Dataverse records and can be managed using powerplatform_data_record resource.  See the data record resource documentation ./data_record for examples of how to manage more environment settings like business units, roles, and more.
 ---
 
 # powerplatform_environment_settings (Resource)
 
-Manages Power Platform Settings for a given environment. They control various aspects of Power Platform features and behaviors, See [Environment Settings Overview](https://learn.microsoft.com/power-platform/admin/admin-settings) for more details.
+Manages Power Platform Settings for a given environment. They control various aspects of Power Platform features and behaviors, See [Environment Settings Overview](https://learn.microsoft.com/power-platform/admin/admin-settings) for more details.  While this resource provides a limited set of settings, many of the settings in an environment are stored as Dataverse records and can be managed using `powerplatform_data_record` resource.  See the [data record resource documentation](./data_record) for examples of how to manage more environment settings like business units, roles, and more.
 
 ## Example Usage
 

--- a/internal/services/environment_settings/datasource_environment_settings.go
+++ b/internal/services/environment_settings/datasource_environment_settings.go
@@ -101,7 +101,7 @@ func (d *EnvironmentSettingsDataSource) Schema(ctx context.Context, req datasour
 	defer exitContext()
 	resp.Schema = schema.Schema{
 		Description:         "Power Platform Environment Settings Data Source",
-		MarkdownDescription: "Power Platform Environment Settings Data Source. Power Platform Settings are configuration options that apply to a specific environment. They control various aspects of Power Platform features and behaviors, See [Environment Settings Overview](https://learn.microsoft.com/power-platform/admin/admin-settings) for more details.",
+		MarkdownDescription: "Power Platform Environment Settings Data Source. Power Platform Settings are configuration options that apply to a specific environment. They control various aspects of Power Platform features and behaviors, See [Environment Settings Overview](https://learn.microsoft.com/power-platform/admin/admin-settings) for more details.  While this data source provides access to some specific environment settings, many environment settings are stored as records in Dataverse.  You may be able to read those settings using the [`powerplatform_data_records` resource](./data_records).",
 		Attributes: map[string]schema.Attribute{
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
 				Create: false,

--- a/internal/services/environment_settings/resources_environment_settings.go
+++ b/internal/services/environment_settings/resources_environment_settings.go
@@ -51,7 +51,7 @@ func (r *EnvironmentSettingsResource) Schema(ctx context.Context, req resource.S
 	defer exitContext()
 	resp.Schema = schema.Schema{
 		Description:         "Manages Power Platform Settings for a given environment.",
-		MarkdownDescription: "Manages Power Platform Settings for a given environment. They control various aspects of Power Platform features and behaviors, See [Environment Settings Overview](https://learn.microsoft.com/power-platform/admin/admin-settings) for more details.",
+		MarkdownDescription: "Manages Power Platform Settings for a given environment. They control various aspects of Power Platform features and behaviors, See [Environment Settings Overview](https://learn.microsoft.com/power-platform/admin/admin-settings) for more details.  While this resource provides a limited set of settings, many of the settings in an environment are stored as Dataverse records and can be managed using `powerplatform_data_record` resource.  See the [data record resource documentation](./data_record) for examples of how to manage more environment settings like business units, roles, and more.",
 		Attributes: map[string]schema.Attribute{
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
 				Create: true,


### PR DESCRIPTION
This pull request enhances the documentation and schema descriptions for Power Platform Environment Settings by adding information about accessing and managing additional environment settings stored as Dataverse records. 

Documentation updates:

* [`docs/data-sources/environment_settings.md`](diffhunk://#diff-e4c58d8d2580331f670ca67c4ba98057df71f28657d7d3c5594694c15a956868L6-R11): Added details on accessing additional environment settings stored in Dataverse and referenced the `powerplatform_data_records` resource.
* [`docs/resources/environment_settings.md`](diffhunk://#diff-f4486b835c144e2b62d84806615d58d06c11ed892d790cb6d850a26473fcddbaL6-R11): Updated to include information on managing additional environment settings using the `powerplatform_data_record` resource.

Schema description updates:

* [`internal/services/environment_settings/datasource_environment_settings.go`](diffhunk://#diff-e33ed9cd7ddc8d473fa2479ea05353c040c28285801744918096df6cb66bb1fcL104-R104): Enhanced the `MarkdownDescription` for the `EnvironmentSettingsDataSource` schema to mention Dataverse records and the `powerplatform_data_records` resource.
* [`internal/services/environment_settings/resources_environment_settings.go`](diffhunk://#diff-500ebc70ca9c44fe75bc05abc6d2f33fc681e46f9d075622db2c2c8e59424d69L54-R54): Improved the `MarkdownDescription` for the `EnvironmentSettingsResource` schema to include information on managing additional settings via the `powerplatform_data_record` resource.