### PR TITLE
Edsanche/431 add retention policy duration to powerplatform environment settings

### DIFF
--- a/internal/services/environment_settings/datasource_environment_settings.go
+++ b/internal/services/environment_settings/datasource_environment_settings.go
@@ -147,13 +147,10 @@ func (d *EnvironmentSettingsDataSource) Schema(ctx context.Context, req datasour
 								MarkdownDescription: "Is read audit enabled",
 								Optional:            true,
 							},
-							"log_retention_period_in_days" : schema.Int64Attribute{
+							"log_retention_period_in_days": schema.Int64Attribute{
 								Description:         "log_retention_period_in_days",
 								MarkdownDescription: "log_retention_period_in_days",
 								Optional:            true, Computed: true,
-								PlanModifiers: []planmodifier.Int64{
-									int64planmodifier.UseStateForUnknown(),
-								}
 							},
 						},
 					},

--- a/internal/services/environment_settings/datasource_environment_settings.go
+++ b/internal/services/environment_settings/datasource_environment_settings.go
@@ -147,9 +147,9 @@ func (d *EnvironmentSettingsDataSource) Schema(ctx context.Context, req datasour
 								MarkdownDescription: "Is read audit enabled",
 								Optional:            true,
 							},
-							"is_audit_retention_period_v2" : schema.Int64Attribute{
-								Description:         "Is audit retention period v2",
-								MarkdownDescription: "Is audit retention period v2",
+							"log_retention_period_in_days" : schema.Int64Attribute{
+								Description:         "log_retention_period_in_days",
+								MarkdownDescription: "log_retention_period_in_days",
 								Optional:            true, Computed: true,
 								PlanModifiers: []planmodifier.Int64{
 									int64planmodifier.UseStateForUnknown(),

--- a/internal/services/environment_settings/datasource_environment_settings.go
+++ b/internal/services/environment_settings/datasource_environment_settings.go
@@ -147,6 +147,14 @@ func (d *EnvironmentSettingsDataSource) Schema(ctx context.Context, req datasour
 								MarkdownDescription: "Is read audit enabled",
 								Optional:            true,
 							},
+							"is_audit_retention_period_v2" : schema.Int64Attribute{
+								Description:         "Is audit retention period v2",
+								MarkdownDescription: "Is audit retention period v2",
+								Optional:            true, Computed: true,
+								PlanModifiers: []planmodifier.Int64{
+									int64planmodifier.UseStateForUnknown(),
+								}
+							},
 						},
 					},
 				},

--- a/internal/services/environment_settings/datasource_environment_settings_test.go
+++ b/internal/services/environment_settings/datasource_environment_settings_test.go
@@ -40,6 +40,7 @@ func TestAccTestEnvironmentSettingsDataSource_Validate_Read(t *testing.T) {
 					resource.TestCheckResourceAttr("data.powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_audit_enabled", "false"),
 					resource.TestCheckResourceAttr("data.powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_read_audit_enabled", "false"),
 					resource.TestCheckResourceAttr("data.powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_user_access_audit_enabled", "false"),
+					resource.TestCheckResourceAttr("data.powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_audit_retention_period_v2", "false"),
 					resource.TestCheckResourceAttr("data.powerplatform_environment_settings.settings", "email.email_settings.max_upload_file_size_in_bytes", "5242880"),
 					resource.TestCheckResourceAttr("data.powerplatform_environment_settings.settings", "audit_and_logs.plugin_trace_log_setting", "Off"),
 					resource.TestCheckResourceAttr("data.powerplatform_environment_settings.settings", "product.behavior_settings.show_dashboard_cards_in_expanded_state", "false"),

--- a/internal/services/environment_settings/datasource_environment_settings_test.go
+++ b/internal/services/environment_settings/datasource_environment_settings_test.go
@@ -40,7 +40,7 @@ func TestAccTestEnvironmentSettingsDataSource_Validate_Read(t *testing.T) {
 					resource.TestCheckResourceAttr("data.powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_audit_enabled", "false"),
 					resource.TestCheckResourceAttr("data.powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_read_audit_enabled", "false"),
 					resource.TestCheckResourceAttr("data.powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_user_access_audit_enabled", "false"),
-					resource.TestCheckResourceAttr("data.powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_audit_retention_period_v2", "false"),
+					resource.TestCheckResourceAttr("data.powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.log_retention_period_in_days", "null"),
 					resource.TestCheckResourceAttr("data.powerplatform_environment_settings.settings", "email.email_settings.max_upload_file_size_in_bytes", "5242880"),
 					resource.TestCheckResourceAttr("data.powerplatform_environment_settings.settings", "audit_and_logs.plugin_trace_log_setting", "Off"),
 					resource.TestCheckResourceAttr("data.powerplatform_environment_settings.settings", "product.behavior_settings.show_dashboard_cards_in_expanded_state", "false"),

--- a/internal/services/environment_settings/dto.go
+++ b/internal/services/environment_settings/dto.go
@@ -13,7 +13,7 @@ type environmentSettingsDto struct {
 	IsAuditEnabled                           *bool   `json:"isauditenabled,omitempty"`
 	IsUserAccessAuditEnabled                 *bool   `json:"isuseraccessauditenabled,omitempty"`
 	IsReadAuditEnabled                       *bool   `json:"isreadauditenabled,omitempty"`
-	Auditretentionperiodv2                   *bool   `json:"auditretentionperiodv2,omitempty"`
+	AuditRetentionPeriodV2                   *int64  `json:"auditRetentionPeriodV2,omitempty"`
 	BoundDashboardDefaultCardExpanded        *bool   `json:"bounddashboarddefaultcardexpanded,omitempty"`
 	OrganizationId                           *string `json:"organizationid,omitempty"`
 	PowerAppsComponentFrameworkForCanvasApps *bool   `json:"iscustomcontrolsincanvasappsenabled,omitempty"`

--- a/internal/services/environment_settings/dto.go
+++ b/internal/services/environment_settings/dto.go
@@ -13,7 +13,7 @@ type environmentSettingsDto struct {
 	IsAuditEnabled                           *bool   `json:"isauditenabled,omitempty"`
 	IsUserAccessAuditEnabled                 *bool   `json:"isuseraccessauditenabled,omitempty"`
 	IsReadAuditEnabled                       *bool   `json:"isreadauditenabled,omitempty"`
-	IsAuditRetentionPeriodV2                 *bool   `json:"isauditretentionperiodv2,omitempty"`
+	Auditretentionperiodv2                   *bool   `json:"auditretentionperiodv2,omitempty"`
 	BoundDashboardDefaultCardExpanded        *bool   `json:"bounddashboarddefaultcardexpanded,omitempty"`
 	OrganizationId                           *string `json:"organizationid,omitempty"`
 	PowerAppsComponentFrameworkForCanvasApps *bool   `json:"iscustomcontrolsincanvasappsenabled,omitempty"`

--- a/internal/services/environment_settings/dto.go
+++ b/internal/services/environment_settings/dto.go
@@ -13,6 +13,7 @@ type environmentSettingsDto struct {
 	IsAuditEnabled                           *bool   `json:"isauditenabled,omitempty"`
 	IsUserAccessAuditEnabled                 *bool   `json:"isuseraccessauditenabled,omitempty"`
 	IsReadAuditEnabled                       *bool   `json:"isreadauditenabled,omitempty"`
+	IsAuditRetentionPeriodV2                 *bool   `json:"isauditretentionperiodv2,omitempty"`
 	BoundDashboardDefaultCardExpanded        *bool   `json:"bounddashboarddefaultcardexpanded,omitempty"`
 	OrganizationId                           *string `json:"organizationid,omitempty"`
 	PowerAppsComponentFrameworkForCanvasApps *bool   `json:"iscustomcontrolsincanvasappsenabled,omitempty"`

--- a/internal/services/environment_settings/models..go
+++ b/internal/services/environment_settings/models..go
@@ -47,9 +47,10 @@ type AuditAndLogsSourceModel struct {
 }
 
 type AuditSettingsSourceModel struct {
-	IsAuditEnabled           types.Bool `tfsdk:"is_audit_enabled"`
-	IsUserAccessAuditEnabled types.Bool `tfsdk:"is_user_access_audit_enabled"`
-	IsReadAuditEnabled       types.Bool `tfsdk:"is_read_audit_enabled"`
+	IsAuditEnabled           types.Bool  `tfsdk:"is_audit_enabled"`
+	IsUserAccessAuditEnabled types.Bool  `tfsdk:"is_user_access_audit_enabled"`
+	IsReadAuditEnabled       types.Bool  `tfsdk:"is_read_audit_enabled"`
+	AuditRetentionPeriodV2   types.Int64 `tfsdk:"log_retention_period_in_days"`
 }
 
 type EmailSourceModel struct {
@@ -88,6 +89,9 @@ func convertFromEnvironmentSettingsModel(ctx context.Context, environmentSetting
 		}
 		if !auditAndLogsSourceModel.IsReadAuditEnabled.IsNull() && !auditAndLogsSourceModel.IsReadAuditEnabled.IsUnknown() {
 			environmentSettingsDto.IsReadAuditEnabled = auditAndLogsSourceModel.IsReadAuditEnabled.ValueBoolPointer()
+		}
+		if !auditAndLogsSourceModel.AuditRetentionPeriodV2.IsNull() && !auditAndLogsSourceModel.AuditRetentionPeriodV2.IsUnknown() {
+			environmentSettingsDto.AuditRetentionPeriodV2 = auditAndLogsSourceModel.AuditRetentionPeriodV2.ValueInt64Pointer()
 		}
 
 		pluginSettings := environmentSettings.AuditAndLogs.Attributes()["plugin_trace_log_setting"]
@@ -167,14 +171,14 @@ func convertFromEnvironmentSettingsDto[T EnvironmentSettingsResourceModel | Envi
 		"is_audit_enabled":             types.BoolValue(*environmentSettingsDto.IsAuditEnabled),
 		"is_user_access_audit_enabled": types.BoolValue(*environmentSettingsDto.IsUserAccessAuditEnabled),
 		"is_read_audit_enabled":        types.BoolValue(*environmentSettingsDto.IsReadAuditEnabled),
-		"is_audit_retention_period_v2": types.Int64Value(*environmentSettingsDto.IsAuditRetentionPeriodV2),
+		"log_retention_period_in_days": types.Int64Value(*environmentSettingsDto.AuditRetentionPeriodV2),
 	}
 
 	attrAuditSettingsObject := map[string]attr.Type{
 		"is_audit_enabled":             types.BoolType,
 		"is_user_access_audit_enabled": types.BoolType,
 		"is_read_audit_enabled":        types.BoolType,
-		"is_audit_retention_period_v2": types.Int64Type,
+		"log_retention_period_in_days": types.Int64Type,
 	}
 
 	attrTypesAuditAndLogsObject := map[string]attr.Type{

--- a/internal/services/environment_settings/models..go
+++ b/internal/services/environment_settings/models..go
@@ -167,12 +167,14 @@ func convertFromEnvironmentSettingsDto[T EnvironmentSettingsResourceModel | Envi
 		"is_audit_enabled":             types.BoolValue(*environmentSettingsDto.IsAuditEnabled),
 		"is_user_access_audit_enabled": types.BoolValue(*environmentSettingsDto.IsUserAccessAuditEnabled),
 		"is_read_audit_enabled":        types.BoolValue(*environmentSettingsDto.IsReadAuditEnabled),
+		"is_audit_retention_period_v2": types.Int64Value(*environmentSettingsDto.IsAuditRetentionPeriodV2),
 	}
 
 	attrAuditSettingsObject := map[string]attr.Type{
 		"is_audit_enabled":             types.BoolType,
 		"is_user_access_audit_enabled": types.BoolType,
 		"is_read_audit_enabled":        types.BoolType,
+		"is_audit_retention_period_v2": types.Int64Type,
 	}
 
 	attrTypesAuditAndLogsObject := map[string]attr.Type{

--- a/internal/services/environment_settings/resource_environment_settings_test.go
+++ b/internal/services/environment_settings/resource_environment_settings_test.go
@@ -40,7 +40,7 @@ func TestAccTestEnvironmentSettingsResource_Validate_Read(t *testing.T) {
 						  is_audit_enabled             = true
 						  is_user_access_audit_enabled = true
 						  is_read_audit_enabled        = true
-						  is_audit_retention_period_v2 = true
+						  log_retention_period_in_days = null
 						}
 					}
 					email = {
@@ -62,7 +62,7 @@ func TestAccTestEnvironmentSettingsResource_Validate_Read(t *testing.T) {
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_audit_enabled", "true"),
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_read_audit_enabled", "true"),
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_user_access_audit_enabled", "true"),
-					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_audit_retention_period_v2", "true"),
+					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.log_retention_period_in_days", "null"),
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "email.email_settings.max_upload_file_size_in_bytes", "100"),
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.plugin_trace_log_setting", "All"),
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "product.behavior_settings.show_dashboard_cards_in_expanded_state", "true"),
@@ -93,7 +93,7 @@ func TestAccTestEnvironmentSettingsResource_Validate_No_Dataverse(t *testing.T) 
 						  is_audit_enabled             = true
 						  is_user_access_audit_enabled = true
 						  is_read_audit_enabled        = true
-						  is_audit_retention_period_v2 = true
+						  log_retention_period_in_days = null
 						}
 					  }
 					  email = {
@@ -154,7 +154,7 @@ func TestUnitTestEnvironmentSettingsResource_Validate_Read(t *testing.T) {
 						  is_audit_enabled             = true
 						  is_user_access_audit_enabled = true
 						  is_read_audit_enabled        = true
-						  is_audit_retention_period_v2 = true
+						  log_retention_period_in_days = null
 						}
 					  }
 					  email = {
@@ -176,7 +176,7 @@ func TestUnitTestEnvironmentSettingsResource_Validate_Read(t *testing.T) {
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_audit_enabled", "true"),
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_read_audit_enabled", "true"),
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_user_access_audit_enabled", "true"),
-					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_audit_retention_period_v2", "true"),
+					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.log_retention_period_in_days", "null"),
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "email.email_settings.max_upload_file_size_in_bytes", "100"),
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.plugin_trace_log_setting", "All"),
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "product.behavior_settings.show_dashboard_cards_in_expanded_state", "true"),
@@ -261,7 +261,7 @@ func TestUnitTestEnvironmentSettingsResource_Validate_No_Dataverse(t *testing.T)
 						  is_audit_enabled             = true
 						  is_user_access_audit_enabled = true
 						  is_read_audit_enabled        = true
-						  is_audit_retention_period_v2 = true
+						  log_retention_period_in_days = null
 						}
 					  }
 					  email = {

--- a/internal/services/environment_settings/resource_environment_settings_test.go
+++ b/internal/services/environment_settings/resource_environment_settings_test.go
@@ -40,6 +40,7 @@ func TestAccTestEnvironmentSettingsResource_Validate_Read(t *testing.T) {
 						  is_audit_enabled             = true
 						  is_user_access_audit_enabled = true
 						  is_read_audit_enabled        = true
+						  is_audit_retention_period_v2 = true
 						}
 					}
 					email = {
@@ -61,6 +62,7 @@ func TestAccTestEnvironmentSettingsResource_Validate_Read(t *testing.T) {
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_audit_enabled", "true"),
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_read_audit_enabled", "true"),
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_user_access_audit_enabled", "true"),
+					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_audit_retention_period_v2", "true"),
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "email.email_settings.max_upload_file_size_in_bytes", "100"),
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.plugin_trace_log_setting", "All"),
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "product.behavior_settings.show_dashboard_cards_in_expanded_state", "true"),
@@ -91,6 +93,7 @@ func TestAccTestEnvironmentSettingsResource_Validate_No_Dataverse(t *testing.T) 
 						  is_audit_enabled             = true
 						  is_user_access_audit_enabled = true
 						  is_read_audit_enabled        = true
+						  is_audit_retention_period_v2 = true
 						}
 					  }
 					  email = {
@@ -151,6 +154,7 @@ func TestUnitTestEnvironmentSettingsResource_Validate_Read(t *testing.T) {
 						  is_audit_enabled             = true
 						  is_user_access_audit_enabled = true
 						  is_read_audit_enabled        = true
+						  is_audit_retention_period_v2 = true
 						}
 					  }
 					  email = {
@@ -172,6 +176,7 @@ func TestUnitTestEnvironmentSettingsResource_Validate_Read(t *testing.T) {
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_audit_enabled", "true"),
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_read_audit_enabled", "true"),
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_user_access_audit_enabled", "true"),
+					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.audit_settings.is_audit_retention_period_v2", "true"),
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "email.email_settings.max_upload_file_size_in_bytes", "100"),
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "audit_and_logs.plugin_trace_log_setting", "All"),
 					resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "product.behavior_settings.show_dashboard_cards_in_expanded_state", "true"),
@@ -256,6 +261,7 @@ func TestUnitTestEnvironmentSettingsResource_Validate_No_Dataverse(t *testing.T)
 						  is_audit_enabled             = true
 						  is_user_access_audit_enabled = true
 						  is_read_audit_enabled        = true
+						  is_audit_retention_period_v2 = true
 						}
 					  }
 					  email = {

--- a/internal/services/environment_settings/resources_environment_settings.go
+++ b/internal/services/environment_settings/resources_environment_settings.go
@@ -118,7 +118,14 @@ func (r *EnvironmentSettingsResource) Schema(ctx context.Context, req resource.S
 									boolplanmodifier.UseStateForUnknown(),
 								},
 							},
-						},
+							"is_audit_retention_period_v2" : schema.Int64Attribute{
+								Description:         "Is audit retention period v2",
+								MarkdownDescription: "Is audit retention period v2",
+								Optional:            true, Computed: true,
+								PlanModifiers: []planmodifier.Int64{
+									int64planmodifier.UseStateForUnknown(),
+								}
+							},
 					},
 				},
 			},

--- a/internal/services/environment_settings/resources_environment_settings.go
+++ b/internal/services/environment_settings/resources_environment_settings.go
@@ -118,14 +118,15 @@ func (r *EnvironmentSettingsResource) Schema(ctx context.Context, req resource.S
 									boolplanmodifier.UseStateForUnknown(),
 								},
 							},
-							"log_retention_period_in_days" : schema.Int64Attribute{
+							"log_retention_period_in_days": schema.Int64Attribute{
 								Description:         "Is audit retention period v2",
 								MarkdownDescription: "Is audit retention period v2",
 								Optional:            true, Computed: true,
 								PlanModifiers: []planmodifier.Int64{
 									int64planmodifier.UseStateForUnknown(),
-								}
+								},
 							},
+						},
 					},
 				},
 			},

--- a/internal/services/environment_settings/resources_environment_settings.go
+++ b/internal/services/environment_settings/resources_environment_settings.go
@@ -118,7 +118,7 @@ func (r *EnvironmentSettingsResource) Schema(ctx context.Context, req resource.S
 									boolplanmodifier.UseStateForUnknown(),
 								},
 							},
-							"is_audit_retention_period_v2" : schema.Int64Attribute{
+							"log_retention_period_in_days" : schema.Int64Attribute{
 								Description:         "Is audit retention period v2",
 								MarkdownDescription: "Is audit retention period v2",
 								Optional:            true, Computed: true,


### PR DESCRIPTION
This pull request introduces a new attribute, `log_retention_period_in_days`, to the environment settings data source, DTO, and models, along with corresponding test updates. The changes ensure that the retention period for audit logs can be optionally specified and computed.

Key changes include:

### Schema and Models Updates:
* Added `log_retention_period_in_days` attribute to the `EnvironmentSettingsDataSource` schema in `datasource_environment_settings.go`.
* Added `AuditRetentionPeriodV2` field to the `environmentSettingsDto` struct in `dto.go`.
* Updated `AuditSettingsSourceModel` to include `log_retention_period_in_days` in `models.go`.

### Conversion Functions:
* Modified `convertFromEnvironmentSettingsModel` to handle `AuditRetentionPeriodV2` in `models.go`.
* Updated `convertFromEnvironmentSettingsDto` to map `AuditRetentionPeriodV2` to `log_retention_period_in_days` in `models.go`.

### Test Updates:
* Added checks for `log_retention_period_in_days` in various test functions in `datasource_environment_settings_test.go` [[1]](diffhunk://#diff-3182f7ea35022ae0884bc6f391b514f7b133d81482606abc0c69d887a4dc2ee2R43) and `resource_environment_settings_test.go` [[2]](diffhunk://#diff-8867c8b3442a7d964d9c5412afa4cb3e6ce5d62aa7cd861bb4ca75c523ecf157R43) [[3]](diffhunk://#diff-8867c8b3442a7d964d9c5412afa4cb3e6ce5d62aa7cd861bb4ca75c523ecf157R65) [[4]](diffhunk://#diff-8867c8b3442a7d964d9c5412afa4cb3e6ce5d62aa7cd861bb4ca75c523ecf157R96) [[5]](diffhunk://#diff-8867c8b3442a7d964d9c5412afa4cb3e6ce5d62aa7cd861bb4ca75c523ecf157R157) [[6]](diffhunk://#diff-8867c8b3442a7d964d9c5412afa4cb3e6ce5d62aa7cd861bb4ca75c523ecf157R179) [[7]](diffhunk://#diff-8867c8b3442a7d964d9c5412afa4cb3e6ce5d62aa7cd861bb4ca75c523ecf157R264).