### PR TITLE
Mawasile/548 error creating sbx and prod environments azure region was ctystringvaleastus but now ctystringvalwestus

### DIFF
--- a/internal/services/environment/resource_environment.go
+++ b/internal/services/environment/resource_environment.go
@@ -374,7 +374,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 
 	newState, err := convertSourceModelFromEnvironmentDto(*envDto, &currencyCode, templateMetadata, templates, plan.Timeouts)
 
-	if plan.AzureRegion.ValueString() != newState.AzureRegion.ValueString() {
+	if !plan.AzureRegion.IsNull() && plan.AzureRegion.ValueString() != "" && (plan.AzureRegion.ValueString() != newState.AzureRegion.ValueString()) {
 		resp.Diagnostics.AddAttributeError(path.Root("azure_region"), fmt.Sprintf("Provisioning environment in azure region '%s' failed", plan.AzureRegion.ValueString()), "Provisioning environment in azure region was not successful, please try other region in that location or try again later")
 		return
 	}

--- a/internal/services/environment/resource_environment.go
+++ b/internal/services/environment/resource_environment.go
@@ -373,6 +373,11 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	}
 
 	newState, err := convertSourceModelFromEnvironmentDto(*envDto, &currencyCode, templateMetadata, templates, plan.Timeouts)
+
+	if plan.AzureRegion.ValueString() != newState.AzureRegion.ValueString() {
+		resp.Diagnostics.AddAttributeError(path.Root("azure_region"), fmt.Sprintf("Provisioning environment in azure region '%s' failed", plan.AzureRegion.ValueString()), "Provisioning environment in azure region was not successful, please try other region in that location or try again later")
+		return
+	}
 	if err != nil {
 		resp.Diagnostics.AddError("Error when converting environment to source model", err.Error())
 		return

--- a/internal/services/environment/resource_environment_test.go
+++ b/internal/services/environment/resource_environment_test.go
@@ -2292,6 +2292,7 @@ func TestUnitEnvironmentsResource_Validate_Create_No_Dataverse_Region_Not_Availa
 		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				ExpectError: regexp.MustCompile(".*Provisioning environment in azure region .* failed"),
 				Config: `
 				resource "powerplatform_environment" "development" {
 					display_name                              = "displayname"
@@ -2304,8 +2305,6 @@ func TestUnitEnvironmentsResource_Validate_Create_No_Dataverse_Region_Not_Availa
 
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("powerplatform_environment.development", "id", "00000000-0000-0000-0000-000000000001"),
-					resource.TestCheckResourceAttr("powerplatform_environment.development", "location", "europe"),
-					resource.TestCheckResourceAttr("powerplatform_environment.development", "azure_region", "westeurope"),
 				),
 			},
 		},

--- a/internal/services/environment/resource_environment_test.go
+++ b/internal/services/environment/resource_environment_test.go
@@ -2250,3 +2250,64 @@ func TestAccEnvironmentsResource_Validate_Update_Environment_Type(t *testing.T) 
 		},
 	})
 }
+
+func TestUnitEnvironmentsResource_Validate_Create_No_Dataverse_Region_Not_Available(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	mocks.ActivateEnvironmentHttpMocks()
+
+	httpmock.RegisterResponder("GET", "https://europe.api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/00000000-0000-0000-0000-000000000001?api-version=2023-06-01",
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(http.StatusOK, httpmock.File("tests/resource/Validate_Create_No_Dataverse_Region_Not_Available/get_lifecycle_delete.json").String()), nil
+		})
+
+	httpmock.RegisterResponder("GET", `=~^https://api\.bap\.microsoft\.com/providers/Microsoft\.BusinessAppPlatform/scopes/admin/environments/([\d-]+)\z`,
+		func(req *http.Request) (*http.Response, error) {
+			id := httpmock.MustGetSubmatch(req, 1)
+			return httpmock.NewStringResponse(http.StatusOK, httpmock.File(fmt.Sprintf("tests/resource/Validate_Create_No_Dataverse_Region_Not_Available/get_environment_%s.json", id)).String()), nil
+		})
+
+	httpmock.RegisterResponder("DELETE", `=~^https://api\.bap\.microsoft\.com/providers/Microsoft\.BusinessAppPlatform/scopes/admin/environments/([\d-]+)\z`,
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(http.StatusAccepted, "")
+			resp.Header.Add("Location", "https://europe.api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/00000000-0000-0000-0000-000000000001?api-version=2023-06-01")
+			return resp, nil
+		})
+
+	httpmock.RegisterResponder("GET", "https://europe.api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/b03e1e6d-73db-4367-90e1-2e378bf7e2fc?api-version=2023-06-01",
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(http.StatusOK, httpmock.File("tests/resource/Validate_Create_No_Dataverse_Region_Not_Available/get_lifecycle.json").String()), nil
+		})
+
+	httpmock.RegisterResponder("POST", "https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/environments?api-version=2023-06-01",
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(http.StatusAccepted, "")
+			resp.Header.Add("Location", "https://europe.api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/b03e1e6d-73db-4367-90e1-2e378bf7e2fc?api-version=2023-06-01")
+			return resp, nil
+		})
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				resource "powerplatform_environment" "development" {
+					display_name                              = "displayname"
+					description                               = "description"
+					cadence								      = "Frequent"
+					location                                  = "europe"
+					azure_region 							  = "northeurope"
+					environment_type                          = "Sandbox"
+				}`,
+
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "id", "00000000-0000-0000-0000-000000000001"),
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "location", "europe"),
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "azure_region", "westeurope"),
+				),
+			},
+		},
+	})
+}

--- a/internal/services/environment/tests/resource/Validate_Create_No_Dataverse_Region_Not_Available/get_environment_00000000-0000-0000-0000-000000000001.json
+++ b/internal/services/environment/tests/resource/Validate_Create_No_Dataverse_Region_Not_Available/get_environment_00000000-0000-0000-0000-000000000001.json
@@ -1,0 +1,144 @@
+{
+    "id": "/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/00000000-0000-0000-0000-000000000001",
+    "type": "Microsoft.BusinessAppPlatform/scopes/environments",
+    "location": "europe",
+    "name": "00000000-0000-0000-0000-000000000001",
+    "properties": {
+        "tenantId": "123",
+        "azureRegion": "westeurope",
+        "displayName": "displayname",
+        "description": "description",
+        "createdTime": "2023-09-27T07:08:27.6057592Z",
+        "createdBy": {
+            "id": "f99f844b-ce3b-49ae-86f3-e374ecae789c",
+            "displayName": "admin",
+            "email": "admin",
+            "type": "User",
+            "tenantId": "123",
+            "userPrincipalName": "admin"
+        },
+        "billingPolicy": {
+            "id": ""
+        },
+        "lastModifiedTime": "2023-09-27T07:08:34.9205145Z",
+        "provisioningState": "Succeeded",
+        "creationType": "User",
+        "environmentSku": "Sandbox",
+        "isDefault": false,
+        "capacity": [
+            {
+                "capacityType": "Database",
+                "actualConsumption": 885.0391,
+                "ratedConsumption": 1024.0,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            },
+            {
+                "capacityType": "File",
+                "actualConsumption": 1187.142,
+                "ratedConsumption": 1187.142,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            },
+            {
+                "capacityType": "Log",
+                "actualConsumption": 0.0,
+                "ratedConsumption": 0.0,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            },
+            {
+                "capacityType": "FinOpsDatabase",
+                "actualConsumption": 0.0,
+                "ratedConsumption": 0.0,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            },
+            {
+                "capacityType": "FinOpsFile",
+                "actualConsumption": 0.0,
+                "ratedConsumption": 0.0,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            }
+        ],
+        "addons": [],
+        "clientUris": {
+            "admin": "https://admin.powerplatform.microsoft.com/environments/environment/456/hub",
+            "maker": "https://make.powerapps.com/environments/456/home"
+        },
+        "runtimeEndpoints": {
+            "microsoft.BusinessAppPlatform": "https://europe.api.bap.microsoft.com",
+            "microsoft.CommonDataModel": "https://europe.api.cds.microsoft.com",
+            "microsoft.PowerApps": "https://europe.api.powerapps.com",
+            "microsoft.PowerAppsAdvisor": "https://europe.api.advisor.powerapps.com",
+            "microsoft.PowerVirtualAgents": "https://powervamg.eu-il107.gateway.prod.island.powerapps.com",
+            "microsoft.ApiManagement": "https://management.EUROPE.azure-apihub.net",
+            "microsoft.Flow": "https://emea.api.flow.microsoft.com"
+        },
+        "databaseType": "CommonDataService",
+        "linkedEnvironmentMetadata": null,
+        "trialScenarioType": "None",
+        "notificationMetadata": {
+            "state": "NotSpecified",
+            "branding": "NotSpecific"
+        },
+        "retentionPeriod": "P7D",
+        "states": {
+            "management": {
+                "id": "Ready"
+            },
+            "runtime": {
+                "runtimeReasonCode": "NotSpecified",
+                "requestedBy": {
+                    "displayName": "SYSTEM",
+                    "type": "NotSpecified"
+                },
+                "id": "Enabled"
+            }
+        },
+        "updateCadence": {
+            "id": "Frequent"
+        },
+        "retentionDetails": {
+            "retentionPeriod": "P7D",
+            "backupsAvailableFromDateTime": "2023-10-03T09:23:06.1717665Z"
+        },
+        "protectionStatus": {
+            "keyManagedBy": "Microsoft"
+        },
+        "cluster": {
+            "category": "Prod",
+            "number": "107",
+            "uriSuffix": "eu-il107.gateway.prod.island",
+            "geoShortName": "EU",
+            "environment": "Prod"
+        },
+        "connectedGroups": [],
+        "lifecycleOperationsEnforcement": {
+            "allowedOperations": [
+                {
+                    "type": {
+                        "id": "DisableGovernanceConfiguration"
+                    },
+                    "reason": {
+                        "message": "DisableGovernanceConfiguration cannot be performed on Power Platform environment because of the governance configuration.",
+                        "type": "GovernanceConfig"
+                    }
+                },
+                {
+                    "type": {
+                        "id": "UpdateGovernanceConfiguration"
+                    },
+                    "reason": {
+                        "message": "UpdateGovernanceConfiguration cannot be performed on Power Platform environment because of the governance configuration.",
+                        "type": "GovernanceConfig"
+                    }
+                }
+            ]
+        },
+        "governanceConfiguration": {
+            "protectionLevel": "Basic"
+        }
+    }
+}

--- a/internal/services/environment/tests/resource/Validate_Create_No_Dataverse_Region_Not_Available/get_lifecycle.json
+++ b/internal/services/environment/tests/resource/Validate_Create_No_Dataverse_Region_Not_Available/get_lifecycle.json
@@ -1,0 +1,64 @@
+{
+    "id": "b03e1e6d-73db-4367-90e1-2e378bf7e2fc",
+    "links": {
+        "self": {
+            "path": "/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/b03e1e6d-73db-4367-90e1-2e378bf7e2fc"
+        },
+        "environment": {
+            "path": "/providers/Microsoft.BusinessAppPlatform/environments/00000000-0000-0000-0000-000000000001"
+        }
+    },
+    "type": {
+        "id": "Create"
+    },
+    "typeDisplayName": "Create",
+    "state": {
+        "id": "Succeeded"
+    },
+    "createdDateTime": "2023-10-11T07:45:25.3761337Z",
+    "lastActionDateTime": "2023-10-11T07:45:43.4915067Z",
+    "requestedBy": {
+        "id": "8784d9fb-deb0-4811-96ce-fbf21cf3a1fc",
+        "displayName": "ServicePrincipal",
+        "type": "ServicePrincipal",
+        "tenantId": "123"
+    },
+    "stages": [
+        {
+            "id": "Validate",
+            "name": "Validate",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:25.9230185Z",
+            "lastActionDateTime": "2023-10-11T07:45:25.9230185Z"
+        },
+        {
+            "id": "Prepare",
+            "name": "Prepare",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:25.9230185Z",
+            "lastActionDateTime": "2023-10-11T07:45:25.9230185Z"
+        },
+        {
+            "id": "Run",
+            "name": "Run",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:26.0011473Z",
+            "lastActionDateTime": "2023-10-11T07:45:33.2570938Z"
+        },
+        {
+            "id": "Finalize",
+            "name": "Finalize",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:33.3352196Z",
+            "lastActionDateTime": "2023-10-11T07:45:43.4915067Z"
+        }
+    ]
+}

--- a/internal/services/environment/tests/resource/Validate_Create_No_Dataverse_Region_Not_Available/get_lifecycle_delete.json
+++ b/internal/services/environment/tests/resource/Validate_Create_No_Dataverse_Region_Not_Available/get_lifecycle_delete.json
@@ -1,0 +1,64 @@
+{
+    "id": "b03e1e6d-73db-4367-90e1-2e378bf7e2fc",
+    "links": {
+        "self": {
+            "path": "/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/b03e1e6d-73db-4367-90e1-2e378bf7e2fc"
+        },
+        "environment": {
+            "path": "/providers/Microsoft.BusinessAppPlatform/environments/123"
+        }
+    },
+    "type": {
+        "id": "Create"
+    },
+    "typeDisplayName": "Create",
+    "state": {
+        "id": "Succeeded"
+    },
+    "createdDateTime": "2023-10-11T07:45:25.3761337Z",
+    "lastActionDateTime": "2023-10-11T07:45:43.4915067Z",
+    "requestedBy": {
+        "id": "8784d9fb-deb0-4811-96ce-fbf21cf3a1fc",
+        "displayName": "ServicePrincipal",
+        "type": "ServicePrincipal",
+        "tenantId": "123"
+    },
+    "stages": [
+        {
+            "id": "Validate",
+            "name": "Validate",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:25.9230185Z",
+            "lastActionDateTime": "2023-10-11T07:45:25.9230185Z"
+        },
+        {
+            "id": "Prepare",
+            "name": "Prepare",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:25.9230185Z",
+            "lastActionDateTime": "2023-10-11T07:45:25.9230185Z"
+        },
+        {
+            "id": "Run",
+            "name": "Run",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:26.0011473Z",
+            "lastActionDateTime": "2023-10-11T07:45:33.2570938Z"
+        },
+        {
+            "id": "Finalize",
+            "name": "Finalize",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:33.3352196Z",
+            "lastActionDateTime": "2023-10-11T07:45:43.4915067Z"
+        }
+    ]
+}


### PR DESCRIPTION
This pull request introduces a new validation for Azure region provisioning and adds a corresponding unit test to ensure that the changes work as expected. Additionally, it includes new mock data files to support the unit test.

Validation for Azure region provisioning:

* [`internal/services/environment/resource_environment.go`](diffhunk://#diff-f5dfd8b19cc74212734109f64e3404cb525bb247f0786830e21096a996c9e9adR376-R380): Added a check to ensure that the specified Azure region is available before proceeding with environment provisioning. If the region is not available, an error is added to the diagnostics and the process is halted.

Unit test for Azure region validation:

* [`internal/services/environment/resource_environment_test.go`](diffhunk://#diff-07ad5067382ca0f319e0f77b1f72649a105aa53a05b7231cb67b9249f2bad472R2253-R2312): Introduced a new unit test `TestUnitEnvironmentsResource_Validate_Create_No_Dataverse_Region_Not_Available` to validate the behavior when the specified Azure region is not available. This test uses `httpmock` to simulate API responses and verifies that the appropriate error is returned.

Supporting mock data files:

* [`internal/services/environment/tests/resource/Validate_Create_No_Dataverse_Region_Not_Available/get_environment_00000000-0000-0000-0000-000000000001.json`](diffhunk://#diff-062a7f4b345da6d26071ada4f407455c5565c4c8233727286bf0ab6490d4b931R1-R144): Added mock data for an environment in the "westeurope" region.
* [`internal/services/environment/tests/resource/Validate_Create_No_Dataverse_Region_Not_Available/get_lifecycle.json`](diffhunk://#diff-f39d6315a78d146c490d205da1b95e8d8045304b5e5ea0f7cf7cfddaf93f52d0R1-R64): Added mock data for a successful lifecycle operation.
* [`internal/services/environment/tests/resource/Validate_Create_No_Dataverse_Region_Not_Available/get_lifecycle_delete.json`](diffhunk://#diff-7bcdfb6b46207c03a7ffcf0acaf48f4d1fae008102f34017db108479e9badfb6R1-R64): Added mock data for a successful lifecycle delete operation.