### PR TITLE
powerplatform_environment: support service principal when creating dev environments "on behalf of" 

### DIFF
--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -1,12 +1,12 @@
 ---
 page_title: "powerplatform_environment Resource - powerplatform"
 description: |-
-  This resource manages a PowerPlatform environment. Known Issue: Creating developer environment by specifying `owner_id` attribute, only works with a user context and can not be used at this time with a service principal. This is a limitation of the underlying API.
+  This resource manages a PowerPlatform environment.
 ---
 
 # powerplatform_environment (Resource)
 
-This resource manages a PowerPlatform environment. Known Issue: Creating developer environment by specifying `owner_id` attribute, only works with a user context and can not be used at this time with a service principal. This is a limitation of the underlying API.
+This resource manages a PowerPlatform environment.
 
 A Power Platform environment is a space in which you can store, manage, and share your organization's business data, apps, chatbots, and flows. It also serves as a container to separate apps that may have different roles, security requirements, or target audiences. Each environment is created under an Azure Active Directory tenant and is bound to a geographic location. You can create different types of environments, such as production, sandbox, trial, or developer, depending on your license and permissions. You can also move resources between environments and set data loss prevention policies. A Power Platform environment can have zero or one Microsoft Dataverse database, which provides storage for your apps and chatbots. You can only connect to the data sources that are deployed in the same environment as your app or chatbot. For more information, you can check out the following links:
 

--- a/internal/services/environment/dto.go
+++ b/internal/services/environment/dto.go
@@ -169,10 +169,10 @@ type environmentCreatePropertiesDto struct {
 	EnvironmentSku            string                            `json:"environmentSku"`
 	LinkedEnvironmentMetadata *createLinkEnvironmentMetadataDto `json:"linkedEnvironmentMetadata,omitempty"`
 	ParentEnvironmentGroup    *ParentEnvironmentGroupDto        `json:"parentEnvironmentGroup,omitempty"`
-	UsedBy                    *usedBy                           `json:"usedBy,omitempty"`
+	UsedBy                    *usedByDto                        `json:"usedBy,omitempty"`
 }
 
-type usedBy struct {
+type usedByDto struct {
 	Id       string `json:"id"`
 	Type     int    `json:"type"`
 	TenantID string `json:"tenantID"`

--- a/internal/services/environment/models.go
+++ b/internal/services/environment/models.go
@@ -83,7 +83,7 @@ func isDataverseEnvironmentEmpty(ctx context.Context, environment *SourceModel) 
 	return dataverseSourceModel.CurrencyCode.IsNull() || dataverseSourceModel.CurrencyCode.ValueString() == ""
 }
 
-func convertCreateEnvironmentDtoFromSourceModel(ctx context.Context, environmentSource SourceModel) (*environmentCreateDto, error) {
+func convertCreateEnvironmentDtoFromSourceModel(ctx context.Context, r *Resource, environmentSource SourceModel) (*environmentCreateDto, error) {
 	environmentDto := &environmentCreateDto{
 		Location: environmentSource.Location.ValueString(),
 		Properties: environmentCreatePropertiesDto{
@@ -114,6 +114,18 @@ func convertCreateEnvironmentDtoFromSourceModel(ctx context.Context, environment
 
 	if !environmentSource.EnvironmentGroupId.IsNull() && !environmentSource.EnvironmentGroupId.IsUnknown() {
 		environmentDto.Properties.ParentEnvironmentGroup = &ParentEnvironmentGroupDto{Id: environmentSource.EnvironmentGroupId.ValueString()}
+	}
+
+	if !environmentSource.OwnerId.IsNull() && !environmentSource.OwnerId.IsUnknown() {
+		tenantId, err := r.EnvironmentClient.tenantClient.GetTenant(ctx)
+		if err != nil {
+			return nil, err
+		}
+		environmentDto.Properties.UsedBy = &usedByDto{
+			Id:       environmentSource.OwnerId.ValueString(),
+			Type:     1,
+			TenantID: tenantId.TenantId,
+		}
 	}
 
 	if !environmentSource.Dataverse.IsNull() && !environmentSource.Dataverse.IsUnknown() {

--- a/internal/services/environment/resource_environment.go
+++ b/internal/services/environment/resource_environment.go
@@ -350,7 +350,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		return
 	}
 
-	envToCreate, err := convertCreateEnvironmentDtoFromSourceModel(ctx, *plan)
+	envToCreate, err := convertCreateEnvironmentDtoFromSourceModel(ctx, r, *plan)
 	if err != nil {
 		resp.Diagnostics.AddError("Error when converting source model to create environment dto", err.Error())
 	}

--- a/internal/services/environment/resource_environment.go
+++ b/internal/services/environment/resource_environment.go
@@ -84,7 +84,7 @@ func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 	}
 
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "This resource manages a PowerPlatform environment. Known Issue: Creating developer environment by specifying `owner_id` attribute, only works with a user context and can not be used at this time with a service principal. This is a limitation of the underlying API.",
+		MarkdownDescription: "This resource manages a PowerPlatform environment.",
 
 		Attributes: map[string]schema.Attribute{
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{


### PR DESCRIPTION
This pull request introduces several changes to the `internal/services/environment` module, focusing on refactoring data transfer objects and enhancing the `convertCreateEnvironmentDtoFromSourceModel` function. The most important changes include updating the `usedBy` struct to `usedByDto`, modifying function signatures to include a new parameter, and adding logic to handle the `OwnerId` field.

Refactoring data transfer objects:

* [`internal/services/environment/dto.go`](diffhunk://#diff-29db28f0e3bf93f9d3a7c0ced4207a58b561a2f259cd1c992d4da5cdf91c8462L172-R175): Changed the `usedBy` struct to `usedByDto` in the `environmentCreatePropertiesDto` struct.

Enhancements to `convertCreateEnvironmentDtoFromSourceModel` function:

* [`internal/services/environment/models.go`](diffhunk://#diff-ef37baa5b95b25135d450c3be2dab79d289089dba1455b85425bbc27a6fcfbfeL86-R86): Updated the function signature of `convertCreateEnvironmentDtoFromSourceModel` to include a new `Resource` parameter.
* [`internal/services/environment/models.go`](diffhunk://#diff-ef37baa5b95b25135d450c3be2dab79d289089dba1455b85425bbc27a6fcfbfeR119-R130): Added logic to handle the `OwnerId` field and populate the `UsedBy` property in the `environmentCreatePropertiesDto` struct, including fetching the tenant ID.
* [`internal/services/environment/resource_environment.go`](diffhunk://#diff-f5dfd8b19cc74212734109f64e3404cb525bb247f0786830e21096a996c9e9adL353-R353): Updated the call to `convertCreateEnvironmentDtoFromSourceModel` to pass the new `Resource` parameter.