### PR TITLE
Fix incorrect term 'hostheader' to 'User-Agent' in documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -226,7 +226,7 @@ In addition to the authentication options, the following options are also suppor
 
 | Name | Description | Default Value |
 |------|-------------|---------------|
-| `telemetry_optout` | Opting out of telemetry will remove the hostheader and session id headers from the requests made to the Power Platform service.  There is no other telemetry data collected by the provider.  This may affect the ability to identify and troubleshoot issues with the provider. | `false` |
+| `telemetry_optout` | Opting out of telemetry will remove the User-Agent and session id headers from the requests made to the Power Platform service.  There is no other telemetry data collected by the provider.  This may affect the ability to identify and troubleshoot issues with the provider. | `false` |
 
 ## Resources and Data Sources
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -226,7 +226,7 @@ In addition to the authentication options, the following options are also suppor
 
 | Name | Description | Default Value |
 |------|-------------|---------------|
-| `telemetry_optout` | Opting out of telemetry will remove the hostheader and session id headers from the requests made to the Power Platform service.  There is no other telemetry data collected by the provider.  This may affect the ability to identify and troubleshoot issues with the provider. | `false` |
+| `telemetry_optout` | Opting out of telemetry will remove the User-Agent and session id headers from the requests made to the Power Platform service.  There is no other telemetry data collected by the provider.  This may affect the ability to identify and troubleshoot issues with the provider. | `false` |
 
 ## Resources and Data Sources
 


### PR DESCRIPTION
Fixes #584

Update documentation to correctly refer to "User-Agent" instead of "hostheader".

* Replace "hostheader" with "User-Agent" in the description of the `telemetry_optout` option in `templates/index.md.tmpl`.
* Replace "hostheader" with "User-Agent" in the description of the `telemetry_optout` option in `docs/index.md`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/microsoft/terraform-provider-power-platform/issues/584?shareId=XXXX-XXXX-XXXX-XXXX).