### PR TITLE
Tool network tracing for debugging

### DIFF
--- a/.devcontainer/features/local_provider_dev/install.sh
+++ b/.devcontainer/features/local_provider_dev/install.sh
@@ -25,3 +25,18 @@ mv /tmp/gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin/
 chmod +x /usr/local/bin/gh
 rm -rf /tmp/gh_${GH_VERSION}_linux_amd64
 rm /tmp/ghcli.tgz
+
+# Install mitmproxy for inspecting HTTP traffic
+MITM_VERSION=11.1.3
+wget https://downloads.mitmproxy.org/${MITM_VERSION}/mitmproxy-${MITM_VERSION}-linux-x86_64.tar.gz
+tar -xf mitmproxy-${MITM_VERSION}-linux-x86_64.tar.gz
+mv mitmproxy mitmdump mitmweb /usr/local/bin/
+rm mitmproxy-${MITM_VERSION}-linux-x86_64.tar.gz
+
+mitmproxy --version
+echo "Start mitmdump so that it generates a client certificate, and kill it after 5 seconds with a successful return code"
+timeout 5s mitmdump -p 8080 || true
+
+install -D ~/.mitmproxy/mitmproxy-ca-cert.pem /usr/local/share/ca-certificates/mitmproxy-ca.crt
+cp /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt.bak
+sh -c 'cat ~/.mitmproxy/mitmproxy-ca-cert.pem >> /etc/ssl/certs/ca-certificates.crt'

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -189,6 +189,28 @@ terraform plan
 1. `cd` to a parent folder where main.tf exists
 1. Run `terraform apply`
 
+## Debugging network calls
+
+This devcontainer has `mitmproxy` preinstalled.  There are 3 versions available: `mitmproxy` a command line UI, `mitmweb` a web based UI, and `mitmdump` a headless command to dump network traffic to file.  For example, first run:
+
+```bash
+mitmproxy
+```
+
+Then in a **separate terminal** you can either launch acceptance tests with:
+
+```bash
+make acctest TEST=<test_name> USE_PROXY=1
+```
+
+or run an example with:
+
+```bash
+HTTP_PROXY=http://127.0.0.1:8080 HTTPS_PROXY=http://127.0.0.1:8080 terraform apply
+```
+
+Flip back to your `mitmproxy` terminal to inspect the network traffic.
+
 ## Testing Guidelines
 
 Quality tests are essential to ensure our provider works reliably across different environments and scenarios. As a contributor, you'll be expected to write comprehensive tests for any code you submit.

--- a/devdocs/adr/mitmproxy.md
+++ b/devdocs/adr/mitmproxy.md
@@ -1,0 +1,30 @@
+# ADR: Use of mitmproxy in the DevContainer for Network Debugging
+
+## Status
+
+Proposed
+
+## Context
+
+Debugging network traffic in the development environment is challenging. In the context of the Terraform Provider for Power Platform, rapid identification of issues related to API calls and server responses is essential. There are two significant upcoming benefits:
+
+- Capturing network traffic and converting the requests/responses into mock data for unit tests.
+- Simplifying the debugging process when building new resources or data sources by providing clear insights into server responses.
+
+## Decision
+
+We will integrate mitmproxy into the devcontainer. This setup allows developers to observe, intercept, and debug network traffic directly in the development environment. The primary focus will be on:
+
+- Enabling comprehensive visibility into API interactions.
+- Providing future capabilities to record and transform captured traffic into reusable mock scenarios for unit testing.
+- Offering a robust mechanism to troubleshoot issues arising from unpredictable server responses.
+
+## Consequences
+
+- **Enhanced Debugging:** Developers benefit from real-time insights into network traffic, which improves the speed and accuracy of debugging.
+- **Test Data Generation:** The recorded traffic has the potential to serve as a foundation for generating mock responses, thereby enhancing the unit testing framework.
+- **Development Overhead:** Initial setup and maintenance of mitmproxy may introduce complexity. However, this is offset by the long-term benefits in diagnostics and test automation.
+- **Security Considerations:** Care must be taken to ensure that sensitive information does not leak when capturing and storing network data.
+- **Provider Code Stability:** No changes have been made to the provider code to support mitmproxy, ensuring that there is no test-only code path.
+
+This ADR should be reviewed periodically. Future improvements may involve automating the conversion of captured data into unit test fixtures, thereby further streamlining the development process.

--- a/devdocs/testing_guidelines.md
+++ b/devdocs/testing_guidelines.md
@@ -73,6 +73,12 @@ To run a single acceptance test:
 make acctest TEST=<test_name>
 ```
 
+To run a single test with network tracing on:
+
+```bash
+make acctest TEST=<test_name> USE_PROXY=1
+```
+
 ### Test Coverage
 
 The project expects **high test coverage (80% or more)** for new contributions.

--- a/makefile
+++ b/makefile
@@ -46,8 +46,7 @@ test:
 	TF_ACC=1 go test -p 10 -timeout 300m -v ./...
 
 netdump:
-	mitmdump -p 8080 -w /tmp/mitmproxy.dump &
-	@echo "Started mitmdump in background"
+	mitmdump -p 8080 -w /tmp/mitmproxy.dump
 
 lint:
 	clear

--- a/makefile
+++ b/makefile
@@ -33,13 +33,21 @@ acctest:
 	clear
 	$(MAKE) clean
 	$(MAKE) install
+ifeq ($(USE_PROXY),1)
+	HTTP_PROXY=http://127.0.0.1:8080 HTTPS_PROXY=http://127.0.0.1:8080 TF_ACC=1 go test -p 10 -timeout 300m -v ./... -run "^TestAcc$(TEST)"
+else
 	TF_ACC=1 go test -p 10 -timeout 300m -v ./... -run "^TestAcc$(TEST)"
+endif
 
 test:
 	clear
 	$(MAKE) clean
 	$(MAKE) install
 	TF_ACC=1 go test -p 10 -timeout 300m -v ./...
+
+netdump:
+	mitmdump -p 8080 -w /tmp/mitmproxy.dump &
+	@echo "Started mitmdump in background"
 
 lint:
 	clear


### PR DESCRIPTION
This pull request introduces the integration of `mitmproxy` into the development environment to facilitate network traffic debugging. The changes include installing `mitmproxy`, updating documentation to guide its usage, and modifying the `Makefile` to support running tests with network tracing.

Key changes include:

### Installation and Setup:
* [`.devcontainer/features/local_provider_dev/install.sh`](diffhunk://#diff-1ebc449e79360c39de724e0cee348d9bba624803cf23cd357b86970a3d1bd56bR28-R42): Added installation steps for `mitmproxy` and configured it to generate a client certificate.

### Documentation Updates:
* [`DEVELOPER.md`](diffhunk://#diff-35ea617bfbf0780bfbc554348314c5b11ba478a4d98fd92d33d45cdd54bf326aR192-R213): Added a new section on debugging network calls using `mitmproxy`, including instructions on running acceptance tests and examples with network tracing.
* [`devdocs/adr/mitmproxy.md`](diffhunk://#diff-be00f877ef1b51a3912c3a599b3dffbf9027ba20e3af1aa99b512d4130f4c5d9R1-R30): Added an Architectural Decision Record (ADR) detailing the rationale, decision, and consequences of integrating `mitmproxy` into the devcontainer.
* [`devdocs/testing_guidelines.md`](diffhunk://#diff-22da46f7afd72f2d03b343f1155945d1ecece19929ed7f299e9a8c0a6a1d1a2aR76-R81): Updated testing guidelines to include instructions for running tests with network tracing enabled.

### Makefile Modifications:
* [`makefile`](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0R36-R50): Modified the `acctest` target to conditionally set proxy environment variables if `USE_PROXY` is enabled, and added a new `netdump` target to capture network traffic.This pull request includes changes to the `.devcontainer/features/local_provider_dev/install.sh` and `makefile` to add support for `mitmproxy` and enable HTTP traffic inspection during tests.

### Added support for `mitmproxy`:

* [`.devcontainer/features/local_provider_dev/install.sh`](diffhunk://#diff-1ebc449e79360c39de724e0cee348d9bba624803cf23cd357b86970a3d1bd56bR28-R42): Added installation steps for `mitmproxy`, including downloading, extracting, and moving the binaries to `/usr/local/bin/`. Also included steps to generate a client certificate and update the system's certificate store.

### Updated `makefile` for proxy support:

* [`makefile`](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0R36-R50): Added conditional logic to use `HTTP_PROXY` and `HTTPS_PROXY` environment variables for tests when `USE_PROXY` is set to 1. Introduced a new `netdump` target to capture network traffic using `mitmdump`.