### PR TITLE
Update GitHub workflows to use GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/check_changie_comment_on_pr.yml
+++ b/.github/workflows/check_changie_comment_on_pr.yml
@@ -52,12 +52,14 @@
           - name: Pass if changelog entry exists
             if: steps.changelog_check.outputs.exists == 'true'
             run: |
+              echo "changelog_check.exists=true" >> $GITHUB_OUTPUT
               echo "Changelog entry exists."
               exit 0
     
           - name: Fail if changelog entry is missing and required
             if: steps.changelog_check.outputs.exists == 'false'
             run: |
+              echo "changelog_check.exists=false" >> $GITHUB_OUTPUT
               echo "🛑 Changelog entry required to merge."
               exit 1
     

--- a/.github/workflows/check_changie_comment_on_pr.yml
+++ b/.github/workflows/check_changie_comment_on_pr.yml
@@ -52,14 +52,12 @@
           - name: Pass if changelog entry exists
             if: steps.changelog_check.outputs.exists == 'true'
             run: |
-              echo "changelog_check.exists=true" >> $GITHUB_OUTPUT
               echo "Changelog entry exists."
               exit 0
     
           - name: Fail if changelog entry is missing and required
             if: steps.changelog_check.outputs.exists == 'false'
             run: |
-              echo "changelog_check.exists=false" >> $GITHUB_OUTPUT
               echo "🛑 Changelog entry required to merge."
               exit 1
     

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - id: set_acceptance_tests
         name: Only run acceptance tests if necessary
-        run: echo "::set-output name=acceptance_tests::true"
+        run: echo "acceptance_tests=true" >> $GITHUB_OUTPUT
   # ensure go.mod and go.sum are updated
   depscheck:
     name: Check Dependencies


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/run_tests.yml` file. The change updates the method used to set the output for acceptance tests.

* [`.github/workflows/run_tests.yml`](diffhunk://#diff-c2e9f7c1bfaf65da79bbd29ed3ce389b2acc8b4099a257914a7292a66e6b9bc9L30-R30): Changed the method of setting the `acceptance_tests` output to use `$GITHUB_OUTPUT` instead of `::set-output`.