### PR TITLE
Refactor error handling to use errors.New to fix linter errors

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -142,16 +142,16 @@ func (client *Auth) NewOidcCredential(options *OidcCredentialOptions) (*OidcCred
 	}
 
 	if c.requestToken == "" {
-		return nil, fmt.Errorf("request Token is required for OIDC credential")
+		return nil, errors.New("request Token is required for OIDC credential")
 	}
 	if c.requestUrl == "" {
-		return nil, fmt.Errorf("request URL is required for OIDC credential")
+		return nil, errors.New("request URL is required for OIDC credential")
 	}
 	if options.TenantID == "" {
-		return nil, fmt.Errorf("tenant is required for OIDC credential")
+		return nil, errors.New("tenant is required for OIDC credential")
 	}
 	if options.ClientID == "" {
-		return nil, fmt.Errorf("client is required for OIDC credential")
+		return nil, errors.New("client is required for OIDC credential")
 	}
 
 	cred, err := azidentity.NewClientAssertionCredential(options.TenantID, options.ClientID, c.getAssertion,
@@ -246,16 +246,16 @@ func (client *Auth) AuthenticateSystemManagedIdentity(ctx context.Context, scope
 
 func (client *Auth) AuthenticateAzDOWorkloadIdentityFederation(ctx context.Context, scopes []string) (string, time.Time, error) {
 	if client.config.TenantId == "" {
-		return "", time.Time{}, fmt.Errorf("tenant ID must be provided to use Azure DevOps Workload Identity Federation")
+		return "", time.Time{}, errors.New("tenant ID must be provided to use Azure DevOps Workload Identity Federation")
 	}
 	if client.config.ClientId == "" {
-		return "", time.Time{}, fmt.Errorf("client ID must be provided to use Azure DevOps Workload Identity Federation")
+		return "", time.Time{}, errors.New("client ID must be provided to use Azure DevOps Workload Identity Federation")
 	}
 	if client.config.AzDOServiceConnectionID == "" {
-		return "", time.Time{}, fmt.Errorf("the Azure DevOps service connection ID could not be found")
+		return "", time.Time{}, errors.New("the Azure DevOps service connection ID could not be found")
 	}
 	if client.config.OidcRequestToken == "" {
-		return "", time.Time{}, fmt.Errorf("could not obtain an OIDC request token for Azure DevOps Workload Identity Federation")
+		return "", time.Time{}, errors.New("could not obtain an OIDC request token for Azure DevOps Workload Identity Federation")
 	}
 
 	azdoWorkloadIdentityCredential, err := azidentity.NewAzurePipelinesCredential(
@@ -295,12 +295,12 @@ func (w *OidcCredential) getAssertion(ctx context.Context) (string, error) {
 
 	req, err := http.NewRequestWithContext(ctx, "GET", w.requestUrl, http.NoBody)
 	if err != nil {
-		return "", fmt.Errorf("getAssertion: failed to build request")
+		return "", errors.New("getAssertion: failed to build request")
 	}
 
 	query, err := url.ParseQuery(req.URL.RawQuery)
 	if err != nil {
-		return "", fmt.Errorf("getAssertion: cannot parse URL query")
+		return "", errors.New("getAssertion: cannot parse URL query")
 	}
 
 	if query.Get("audience") == "" {
@@ -336,7 +336,7 @@ func (w *OidcCredential) getAssertion(ctx context.Context) (string, error) {
 	}
 
 	if tokenRes.Value == nil {
-		return "", fmt.Errorf("getAssertion: nil JWT assertion received from OIDC provider")
+		return "", errors.New("getAssertion: nil JWT assertion received from OIDC provider")
 	}
 
 	return *tokenRes.Value, nil

--- a/internal/helpers/array/array.go
+++ b/internal/helpers/array/array.go
@@ -5,32 +5,27 @@ package array
 
 // DiffArrays returns the added and removed items between two string arrays.
 // This can be useful for comparing plan vs state arrays.
-func Diff(newArr, oldArr []string) ([]string, []string) {
-	added := make([]string, 0)
-	removed := make([]string, 0)
-
+func Diff(newArr, oldArr []string) (added []string, removed []string) {
+	added = make([]string, 0)
+	removed = make([]string, 0)
 	oldMap := make(map[string]bool)
 	for _, item := range oldArr {
 		oldMap[item] = true
 	}
-
 	newMap := make(map[string]bool)
 	for _, item := range newArr {
 		newMap[item] = true
 	}
-
 	for _, item := range newArr {
 		if _, found := oldMap[item]; !found {
 			added = append(added, item)
 		}
 	}
-
 	for _, item := range oldArr {
 		if _, found := newMap[item]; !found {
 			removed = append(removed, item)
 		}
 	}
-
 	return added, removed
 }
 

--- a/internal/services/authorization/api_user.go
+++ b/internal/services/authorization/api_user.go
@@ -297,7 +297,7 @@ func (client *client) CreateDataverseUser(ctx context.Context, environmentId, aa
 
 	// 9 minutes of retries.
 	retryCount := 6 * 9
-	err := fmt.Errorf("")
+	var err error
 	for retryCount > 0 {
 		_, err = client.Api.Execute(ctx, nil, "POST", apiUrl.String(), nil, userToCreate, []int{http.StatusOK}, nil)
 		// the license assignment in Entra is async, so we need to wait for that to happen if a user is created in the same terraform run.

--- a/internal/services/copilot_studio_application_insights/api_copilot_studio_application_insights.go
+++ b/internal/services/copilot_studio_application_insights/api_copilot_studio_application_insights.go
@@ -5,6 +5,7 @@ package copilot_studio_application_insights
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -33,7 +34,7 @@ func (client *client) getCopilotStudioEndpoint(ctx context.Context, environmentI
 		return "", err
 	}
 	if env == nil || env.Properties == nil || env.Properties.RuntimeEndpoints == nil || env.Properties.RuntimeEndpoints.PowerVirtualAgents == "" {
-		return "", fmt.Errorf("Power Virtual Agents runtime endpoint is not available in the environment")
+		return "", errors.New("Power Virtual Agents runtime endpoint is not available in the environment")
 	}
 
 	u, err := url.Parse(env.Properties.RuntimeEndpoints.PowerVirtualAgents)
@@ -47,7 +48,7 @@ func (client *client) getCopilotStudioEndpoint(ctx context.Context, environmentI
 func parseImportId(importId string) (envId string, botId string, err error) {
 	parts := strings.Split(importId, "_")
 	if len(parts) != 2 {
-		return "", "", fmt.Errorf("invalid import id format")
+		return "", "", errors.New("invalid import id format")
 	}
 	return parts[0], parts[1], nil
 }
@@ -68,7 +69,7 @@ func (client *client) getCopilotStudioAppInsightsConfiguration(ctx context.Conte
 	}
 
 	if env == nil || env.Properties == nil || env.Properties.TenantId == "" {
-		return nil, fmt.Errorf("TenantId value is not available in the environment properties")
+		return nil, errors.New("TenantId value is not available in the environment properties")
 	}
 
 	apiUrl := &url.URL{
@@ -101,7 +102,7 @@ func (client *client) updateCopilotStudioAppInsightsConfiguration(ctx context.Co
 	}
 
 	if env == nil || env.Properties == nil || env.Properties.TenantId == "" {
-		return nil, fmt.Errorf("TenantId value is not available in the environment properties")
+		return nil, errors.New("TenantId value is not available in the environment properties")
 	}
 
 	apiUrl := &url.URL{

--- a/internal/services/data_record/api_data_record.go
+++ b/internal/services/data_record/api_data_record.go
@@ -120,12 +120,12 @@ func (client *client) GetDataRecordsByODataQuery(ctx context.Context, environmen
 	if response["value"] != nil {
 		valueSlice, ok := response["value"].([]any)
 		if !ok {
-			return nil, fmt.Errorf("value field is not of type []any")
+			return nil, errors.New("value field is not of type []any")
 		}
 		for _, item := range valueSlice {
 			value, ok := item.(map[string]any)
 			if !ok {
-				return nil, fmt.Errorf("item is not of type map[string]any")
+				return nil, errors.New("item is not of type map[string]any")
 			}
 			records = append(records, value)
 		}
@@ -214,12 +214,12 @@ func (client *client) GetRelationData(ctx context.Context, environmentId, tableN
 
 	field, ok := result["value"]
 	if !ok {
-		return nil, fmt.Errorf("value field not found in result when retrieving relational data")
+		return nil, errors.New("value field not found in result when retrieving relational data")
 	}
 
 	value, ok := field.([]any)
 	if !ok {
-		return nil, fmt.Errorf("value field is not of type []any in relational data")
+		return nil, errors.New("value field is not of type []any in relational data")
 	}
 
 	return value, nil
@@ -262,7 +262,7 @@ func (client *client) GetTableSingularNameFromPlural(ctx context.Context, enviro
 	} else if logicalName, ok := mapResponse["LogicalName"].(string); ok {
 		result = logicalName
 	} else {
-		return nil, fmt.Errorf("logicalName field not found in result when retrieving table singular name")
+		return nil, errors.New("logicalName field not found in result when retrieving table singular name")
 	}
 	return &result, nil
 }
@@ -271,18 +271,18 @@ func getEntityRelationDefinitionOneToMany(mapResponse map[string]any, entityLogi
 	var tableName string
 	oneToMany, ok := mapResponse["OneToManyRelationships"].([]any)
 	if !ok {
-		return "", fmt.Errorf("OneToManyRelationships field is not of type []any")
+		return "", errors.New("OneToManyRelationships field is not of type []any")
 	}
 	for _, list := range oneToMany {
 		item, ok := list.(map[string]any)
 		if !ok {
-			return "", fmt.Errorf("item is not of type map[string]any")
+			return "", errors.New("item is not of type map[string]any")
 		}
 		if item["ReferencingEntityNavigationPropertyName"] == relationLogicalName && item["Entity1LogicalName"] != entityLogicalName {
 			var ok bool
 			tableName, ok = item["ReferencedEntity"].(string)
 			if !ok {
-				return "", fmt.Errorf("ReferencedEntity field is not of type string")
+				return "", errors.New("ReferencedEntity field is not of type string")
 			}
 			break
 		}
@@ -290,7 +290,7 @@ func getEntityRelationDefinitionOneToMany(mapResponse map[string]any, entityLogi
 			var ok bool
 			tableName, ok = item["ReferencingEntity"].(string)
 			if !ok {
-				return "", fmt.Errorf("ReferencedEntity field is not of type string")
+				return "", errors.New("ReferencedEntity field is not of type string")
 			}
 			break
 		}
@@ -302,18 +302,18 @@ func getEntityRelationDefinitionManyToOne(mapResponse map[string]any, relationLo
 	var tableName string
 	manyToOne, ok := mapResponse["ManyToOneRelationships"].([]any)
 	if !ok {
-		return "", fmt.Errorf("ManyToOneRelationships field is not of type []any")
+		return "", errors.New("ManyToOneRelationships field is not of type []any")
 	}
 	for _, list := range manyToOne {
 		item, ok := list.(map[string]any)
 		if !ok {
-			return "", fmt.Errorf("item is not of type map[string]any")
+			return "", errors.New("item is not of type map[string]any")
 		}
 		if item["ReferencingEntityNavigationPropertyName"] == relationLogicalName {
 			var ok bool
 			tableName, ok = item["ReferencedEntity"].(string)
 			if !ok {
-				return "", fmt.Errorf("ReferencedEntity field is not of type string")
+				return "", errors.New("ReferencedEntity field is not of type string")
 			}
 			break
 		}
@@ -321,7 +321,7 @@ func getEntityRelationDefinitionManyToOne(mapResponse map[string]any, relationLo
 			var ok bool
 			tableName, ok = item["ReferencingEntity"].(string)
 			if !ok {
-				return "", fmt.Errorf("ReferencedEntity field is not of type string")
+				return "", errors.New("ReferencedEntity field is not of type string")
 			}
 			break
 		}
@@ -333,24 +333,24 @@ func getEntityRelationDefinitionManyToMany(mapResponse map[string]any, entityLog
 	var tableName string
 	manyToMany, ok := mapResponse["ManyToManyRelationships"].([]any)
 	if !ok {
-		return "", fmt.Errorf("ManyToManyRelationships field is not of type []any")
+		return "", errors.New("ManyToManyRelationships field is not of type []any")
 	}
 	for _, list := range manyToMany {
 		item, ok := list.(map[string]any)
 		if !ok {
-			return "", fmt.Errorf("item is not of type map[string]any")
+			return "", errors.New("item is not of type map[string]any")
 		}
 		if item["Entity1NavigationPropertyName"] == relationLogicalName && item["Entity1LogicalName"] != entityLogicalName {
 			tableName, ok = item["Entity1LogicalName"].(string)
 			if !ok {
-				return "", fmt.Errorf("Entity1LogicalName field is not of type string")
+				return "", errors.New("Entity1LogicalName field is not of type string")
 			}
 			break
 		}
 		if item["Entity2NavigationPropertyName"] == relationLogicalName && item["Entity2LogicalName"] != entityLogicalName {
 			tableName, ok = item["Entity2LogicalName"].(string)
 			if !ok {
-				return "", fmt.Errorf("Entity2LogicalName field is not of type string")
+				return "", errors.New("Entity2LogicalName field is not of type string")
 			}
 			break
 		}
@@ -482,7 +482,7 @@ func (client *client) ApplyDataRecord(ctx context.Context, recordId, environment
 		response, err = client.Api.Execute(ctx, nil, "PATCH", apiUrl.String(), nil, columns, []int{http.StatusOK, http.StatusNoContent}, nil)
 		// if the PATCH URL is not pointing to specific recording using PrimaryIDAttribute then we have to inform a user about it.
 		if response.HttpResponse.StatusCode == http.StatusMethodNotAllowed {
-			return nil, fmt.Errorf("record already exists. To update an existing record, primaryId must be provided in the columns attribute")
+			return nil, errors.New("record already exists. To update an existing record, primaryId must be provided in the columns attribute")
 		}
 		if err != nil {
 			return nil, err
@@ -498,11 +498,11 @@ func (client *client) ApplyDataRecord(ctx context.Context, recordId, environment
 		re := regexp.MustCompile("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
 		match := re.FindAllStringSubmatch(response.HttpResponse.Header.Get(constants.HEADER_ODATA_ENTITY_ID), -1)
 		if len(match) == 0 {
-			return nil, fmt.Errorf("no entity record id returned from the odata-entityid header")
+			return nil, errors.New("no entity record id returned from the odata-entityid header")
 		}
 		result.Id = match[len(match)-1][0]
 	} else {
-		return nil, fmt.Errorf("no entity record id returned from the API")
+		return nil, errors.New("no entity record id returned from the API")
 	}
 
 	err = applyRelations(ctx, client, relations, environmentId, result.Id, entityDefinition)
@@ -535,12 +535,12 @@ func (client *client) DeleteDataRecord(ctx context.Context, recordId string, env
 			for _, nestedItem := range nestedMapList {
 				nestedMap, ok := nestedItem.(map[string]any)
 				if !ok {
-					return fmt.Errorf("nestedItem is not of type map[string]any")
+					return errors.New("nestedItem is not of type map[string]any")
 				}
 
 				dataRecordId, ok := nestedMap["data_record_id"].(string)
 				if !ok {
-					return fmt.Errorf("data_record_id field is missing or not a string")
+					return errors.New("data_record_id field is missing or not a string")
 				}
 
 				apiUrl := &url.URL{
@@ -550,7 +550,7 @@ func (client *client) DeleteDataRecord(ctx context.Context, recordId string, env
 				}
 				_, err = client.Api.Execute(ctx, nil, "DELETE", apiUrl.String(), nil, nil, []int{http.StatusOK, http.StatusNoContent, http.StatusNotFound}, nil)
 				if err != nil {
-					return fmt.Errorf("Error while deleting data record. %w", err)
+					return errors.New("Error while deleting data record. %w")
 				}
 			}
 		}
@@ -573,11 +573,11 @@ func (client *client) DeleteDataRecord(ctx context.Context, recordId string, env
 func getTableLogicalNameAndDataRecordIdFromMap(nestedMap map[string]any) (tableLogicalName string, dataRecordId string, err error) {
 	tableLogicalName, ok := nestedMap["table_logical_name"].(string)
 	if !ok {
-		return "", "", fmt.Errorf("table_logical_name field is missing or not a string")
+		return "", "", errors.New("table_logical_name field is missing or not a string")
 	}
 	id, ok := nestedMap["data_record_id"].(string)
 	if !ok {
-		return "", "", fmt.Errorf("data_record_id field is missing or not a string")
+		return "", "", errors.New("data_record_id field is missing or not a string")
 	}
 	return tableLogicalName, id, nil
 }
@@ -626,7 +626,7 @@ func applyRelation(ctx context.Context, environmentHost string, entityDefinition
 		for _, nestedItem := range nestedMapList {
 			nestedMap, ok := nestedItem.(map[string]any)
 			if !ok {
-				return fmt.Errorf("nestedItem is not of type map[string]any")
+				return errors.New("nestedItem is not of type map[string]any")
 			}
 
 			tableLogicalName, dataRecordId, err := getTableLogicalNameAndDataRecordIdFromMap(nestedMap)
@@ -658,7 +658,7 @@ func applyRelation(ctx context.Context, environmentHost string, entityDefinition
 	for _, nestedItem := range nestedMapList {
 		nestedMap, ok := nestedItem.(map[string]any)
 		if !ok {
-			return fmt.Errorf("nestedItem is not of type map[string]any")
+			return errors.New("nestedItem is not of type map[string]any")
 		}
 
 		tableLogicalName, dataRecordId, err := getTableLogicalNameAndDataRecordIdFromMap(nestedMap)

--- a/internal/services/data_record/resource_data_record.go
+++ b/internal/services/data_record/resource_data_record.go
@@ -6,6 +6,7 @@ package data_record
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -390,7 +391,7 @@ func caseArrayOfAny(ctx context.Context, attrValue map[string]attr.Value, attrTy
 	for _, rawItem := range relationMap {
 		item, ok := rawItem.(map[string]any)
 		if !ok {
-			return fmt.Errorf("error asserting rawItem to map[string]any")
+			return errors.New("error asserting rawItem to map[string]any")
 		}
 
 		relationTableLogicalName, err := apiClient.GetEntityRelationDefinitionInfo(ctx, environmentId, tableLogicalName, key)
@@ -404,7 +405,7 @@ func caseArrayOfAny(ctx context.Context, attrValue map[string]attr.Value, attrTy
 
 		dataRecordId, ok := item[entDefinition.PrimaryIDAttribute].(string)
 		if !ok {
-			return fmt.Errorf("error asserting dataRecordId to string")
+			return errors.New("error asserting dataRecordId to string")
 		}
 
 		v, _ := types.ObjectValue(objectType, map[string]attr.Value{

--- a/internal/services/data_record/resource_data_record_test.go
+++ b/internal/services/data_record/resource_data_record_test.go
@@ -1095,7 +1095,7 @@ func TestUnitDataRecordResource_Validate_Update_Relationships(t *testing.T) {
 			return httpmock.NewStringResponse(http.StatusOK, httpmock.File("tests/resource/Validate_Update_Relationships/get_contact_00000000-0000-0000-0000-000000000011.json").String()), nil
 		})
 
-	httpmock.RegisterResponder("GET", `https://00000000-0000-0000-0000-000000000012.crm4.dynamics.com/api/data/v9.2/contacts%2800000000-0000-0000-0000-000000000012%29`,
+	httpmock.RegisterResponder("GET", `https://00000000-0000-0000-0000-000000000001.crm4.dynamics.com/api/data/v9.2/contacts%2800000000-0000-0000-0000-000000000012%29`,
 		func(req *http.Request) (*http.Response, error) {
 			return httpmock.NewStringResponse(http.StatusOK, httpmock.File("tests/resource/Validate_Update_Relationships/get_contact_00000000-0000-0000-0000-000000000012.json").String()), nil
 		})

--- a/internal/services/data_record/resource_data_record_test.go
+++ b/internal/services/data_record/resource_data_record_test.go
@@ -5,6 +5,7 @@ package data_record_test
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -998,7 +999,7 @@ func TestAccDataRecordResource_Validate_Update_Relationships(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					mocks.TestStateValueMatch(primarycontactidStep1, primarycontactidStep2, func(a, b *mocks.StateValue) error {
 						if a.Value == b.Value {
-							return fmt.Errorf("expected primarycontactid from before and after change are equal, but a change was expected. '%s' == '%s'", a.Value, b.Value)
+							return errors.New("expected primarycontactid from before and after change are equal, but a change was expected")
 						}
 						return nil
 					}),
@@ -1094,7 +1095,7 @@ func TestUnitDataRecordResource_Validate_Update_Relationships(t *testing.T) {
 			return httpmock.NewStringResponse(http.StatusOK, httpmock.File("tests/resource/Validate_Update_Relationships/get_contact_00000000-0000-0000-0000-000000000011.json").String()), nil
 		})
 
-	httpmock.RegisterResponder("GET", `https://00000000-0000-0000-0000-000000000001.crm4.dynamics.com/api/data/v9.2/contacts%2800000000-0000-0000-0000-000000000012%29`,
+	httpmock.RegisterResponder("GET", `https://00000000-0000-0000-0000-000000000012.crm4.dynamics.com/api/data/v9.2/contacts%2800000000-0000-0000-0000-000000000012%29`,
 		func(req *http.Request) (*http.Response, error) {
 			return httpmock.NewStringResponse(http.StatusOK, httpmock.File("tests/resource/Validate_Update_Relationships/get_contact_00000000-0000-0000-0000-000000000012.json").String()), nil
 		})
@@ -1520,13 +1521,13 @@ func TestUnitDataRecordResource_Validate_Disable_On_Delete(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					func(_ *terraform.State) error {
 						if !contactDisabledExecuted {
-							return fmt.Errorf("expected mailbox to be disabled on delete")
+							return errors.New("expected mailbox to be disabled on delete")
 						}
 						return nil
 					},
 					func(_ *terraform.State) error {
 						if !businessUnitDisabledExecuted {
-							return fmt.Errorf("expected business unit to be disabled on delete")
+							return errors.New("expected business unit to be disabled on delete")
 						}
 						return nil
 					},

--- a/internal/services/environment/models.go
+++ b/internal/services/environment/models.go
@@ -6,6 +6,7 @@ package environment
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -194,7 +195,7 @@ func convertEnvironmentCreateLinkEnvironmentMetadataDtoFromDataverseSourceModel(
 
 		return linkedEnvironmentMetadata, nil
 	}
-	return nil, fmt.Errorf("dataverse object is null or unknown")
+	return nil, errors.New("dataverse object is null or unknown")
 }
 
 func convertSourceModelFromEnvironmentDto(environmentDto EnvironmentDto, currencyCode, ownerId *string, templateMetadata *createTemplateMetadataDto, templates []string, timeout timeouts.Value, providerConfig config.ProviderConfig) (*SourceModel, error) {

--- a/internal/services/environment/resource_environment.go
+++ b/internal/services/environment/resource_environment.go
@@ -5,6 +5,7 @@ package environment
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 
@@ -840,13 +841,13 @@ func (r *Resource) addBillingPolicy(ctx context.Context, plan *SourceModel) erro
 
 func (r *Resource) aiGenerativeFeaturesValidaor(plan *SourceModel) error {
 	if r.EnvironmentClient.Api.Config.CloudType != config.CloudTypePublic {
-		return fmt.Errorf("Moving data across regions is not supported in non public clouds")
+		return errors.New("Moving data across regions is not supported in non public clouds")
 	}
 	if plan.Location.ValueString() == "unitedstates" && plan.AllowMovingDataAcrossRegions.ValueBool() {
-		return fmt.Errorf("Moving data across regions is not supported in the unitedstates location")
+		return errors.New("Moving data across regions is not supported in the unitedstates location")
 	}
 	if plan.Location.ValueString() != "unitedstates" && plan.AllowBingSearch.ValueBool() && !plan.AllowMovingDataAcrossRegions.ValueBool() {
-		return fmt.Errorf("To enable AI generative features, moving data across regions must be enabled")
+		return errors.New("To enable AI generative features, moving data across regions must be enabled")
 	}
 	return nil
 }

--- a/internal/services/environment_group_rule_set/dto.go
+++ b/internal/services/environment_group_rule_set/dto.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"errors"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -475,11 +476,11 @@ func convertBackupRetentionDtoToModel(dto *environmentGroupRuleSetParameterDto) 
 	// expected format for 14 days would be 14.00:00:00
 	v := strings.Split(periodInDays.Value, ".")
 	if len(v) != 2 {
-		return types.ObjectType{AttrTypes: attrType}, types.ObjectNull(attrType), fmt.Errorf("Invalid format for period in days")
+		return types.ObjectType{AttrTypes: attrType}, types.ObjectNull(attrType), errors.New("Invalid format for period in days")
 	}
 	period, err := strconv.ParseInt(v[0], 10, 32)
 	if err != nil {
-		return types.ObjectType{AttrTypes: attrType}, types.ObjectNull(attrType), fmt.Errorf("Invalid format when parsing period in days")
+		return types.ObjectType{AttrTypes: attrType}, types.ObjectNull(attrType), errors.New("Invalid format when parsing period in days")
 	}
 	attrValue["period_in_days"] = types.Int32Value(int32(period))
 

--- a/internal/services/environment_settings/models.go
+++ b/internal/services/environment_settings/models.go
@@ -5,6 +5,7 @@ package environment_settings
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -93,7 +94,7 @@ func convertFromEnvironmentSettingsModel(ctx context.Context, environmentSetting
 	if auditSettingsObject != nil && !auditSettingsObject.IsNull() && !auditSettingsObject.IsUnknown() {
 		objectValue, ok := auditSettingsObject.(basetypes.ObjectValue)
 		if !ok {
-			return nil, fmt.Errorf("failed to convert audit settings to ObjectValue")
+			return nil, errors.New("failed to convert audit settings to ObjectValue")
 		}
 
 		var auditAndLogsSourceModel AuditSettingsSourceModel
@@ -121,7 +122,7 @@ func convertFromEnvironmentSettingsModel(ctx context.Context, environmentSetting
 		if pluginSettings != nil && !pluginSettings.IsNull() && !pluginSettings.IsUnknown() {
 			pluginSettingsValue, ok := pluginSettings.(basetypes.StringValue)
 			if !ok {
-				return nil, fmt.Errorf("pluginSettings is not of type basetypes.StringValue")
+				return nil, errors.New("pluginSettings is not of type basetypes.StringValue")
 			}
 			var v int64
 			if pluginSettingsValue.ValueString() == "Off" {
@@ -155,7 +156,7 @@ func convertFromEnvironmentEmailSettings(ctx context.Context, environmentSetting
 	if emailSettingsObject != nil && !emailSettingsObject.IsNull() && !emailSettingsObject.IsUnknown() {
 		objectValue, ok := emailSettingsObject.(basetypes.ObjectValue)
 		if !ok {
-			return fmt.Errorf("failed to convert email settings to ObjectValue")
+			return errors.New("failed to convert email settings to ObjectValue")
 		}
 
 		var emailSourceModel EmailSettingsSourceModel

--- a/internal/services/managed_environment/api_managed_environment.go
+++ b/internal/services/managed_environment/api_managed_environment.go
@@ -5,6 +5,7 @@ package managed_environment
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -101,7 +102,7 @@ type SolutionCheckerRule struct {
 
 func (client *client) FetchSolutionCheckerRules(ctx context.Context, environmentId string) ([]string, error) {
 	if client.environmentClient == (environment.Client{}) {
-		return nil, fmt.Errorf("environmentClient is not initialized")
+		return nil, errors.New("environmentClient is not initialized")
 	}
 
 	env, err := client.environmentClient.GetEnvironment(ctx, environmentId)
@@ -110,7 +111,7 @@ func (client *client) FetchSolutionCheckerRules(ctx context.Context, environment
 	}
 
 	if env.Properties.RuntimeEndpoints.PowerAppsAdvisor == "" {
-		return nil, fmt.Errorf("PowerAppsAdvisor URL is empty")
+		return nil, errors.New("PowerAppsAdvisor URL is empty")
 	}
 
 	powerAppsAdvisorUrl, err := url.Parse(env.Properties.RuntimeEndpoints.PowerAppsAdvisor)

--- a/internal/services/solution/api_solution.go
+++ b/internal/services/solution/api_solution.go
@@ -136,7 +136,7 @@ func (client *Client) CreateSolution(ctx context.Context, environmentId string, 
 	}
 
 	if content == nil {
-		err = fmt.Errorf("solution content is nil")
+		err = errors.New("solution content is nil")
 		return nil, err
 	}
 

--- a/internal/services/tenant_isolation_policy/api_tenant_isolation_policy.go
+++ b/internal/services/tenant_isolation_policy/api_tenant_isolation_policy.go
@@ -5,6 +5,7 @@ package tenant_isolation_policy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -160,7 +161,7 @@ func (client *Client) doWaitForLifecycleOperationStatus(ctx context.Context, res
 	tflog.Debug(ctx, fmt.Sprintf("Location Header: %s", locationHeader))
 
 	if locationHeader == "" {
-		return nil, fmt.Errorf("no Location or Operation-Location header found in async response")
+		return nil, errors.New("no Location or Operation-Location header found in async response")
 	}
 
 	for {

--- a/internal/services/tenant_settings/dto.go
+++ b/internal/services/tenant_settings/dto.go
@@ -5,6 +5,7 @@ package tenant_settings
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -187,7 +188,7 @@ func convertSearchModel(ctx context.Context, powerPlatformAttributes map[string]
 	if !searchObject.IsNull() && !searchObject.IsUnknown() {
 		objectValue, ok := searchObject.(basetypes.ObjectValue)
 		if !ok {
-			return fmt.Errorf("failed to convert search settings to ObjectValue")
+			return errors.New("failed to convert search settings to ObjectValue")
 		}
 
 		var searchSettings SearchSettingsModel

--- a/makefile
+++ b/makefile
@@ -23,6 +23,9 @@ clean:
 userdocs:
 	go generate
 
+userstory:
+	./scripts/user_story_prompt.sh
+
 unittest:
 	clear
 	$(MAKE) clean

--- a/scripts/user_story_prompt.sh
+++ b/scripts/user_story_prompt.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Check if gh CLI is installed
+if ! command -v gh &> /dev/null; then
+    echo "Error: GitHub CLI (gh) is not installed. Please install it first."
+    exit 1
+fi
+
+# Get the current branch name
+current_branch=$(git branch --show-current)
+echo "Current branch: $current_branch"
+
+# Try to extract issue number from branch name
+# Common patterns: issue-123, 123-description, feature/123-description
+issue_number=""
+
+# Try pattern like "issue-123"
+if [[ "$current_branch" =~ issues?[-/]([0-9]+) ]]; then
+    issue_number="${BASH_REMATCH[1]}"
+# Try pattern with numbers at start or after slash/dash
+elif [[ "$current_branch" =~ (^|/|-)([0-9]+)[-/] ]]; then
+    issue_number="${BASH_REMATCH[2]}"
+fi
+
+# If no issue found in branch name, try to get the PR that this branch is for
+if [[ -z "$issue_number" ]]; then
+    echo "Trying to find associated PR for this branch..."
+    pr_data=$(gh pr list --head "$current_branch" --json number --limit 1 2>/dev/null)
+    
+    if [[ -n "$pr_data" && "$pr_data" != "[]" ]]; then
+        pr_number=$(echo "$pr_data" | grep -o '"number":[0-9]*' | grep -o '[0-9]*')
+        if [[ -n "$pr_number" ]]; then
+            echo "Found PR #$pr_number, checking for linked issues..."
+            issue_data=$(gh pr view "$pr_number" --json closingIssues --jq '.closingIssues[0].number' 2>/dev/null)
+            if [[ -n "$issue_data" && "$issue_data" != "null" ]]; then
+                issue_number=$issue_data
+            fi
+        fi
+    fi
+fi
+
+# If still no issue found, ask user
+if [[ -z "$issue_number" ]]; then
+    echo "Could not identify an issue number from branch name: $current_branch"
+    echo "Please enter issue number:"
+    read -r issue_number
+fi
+
+# Validate that we have an issue number
+if [[ -z "$issue_number" ]]; then
+    echo "No issue number provided. Exiting."
+    exit 1
+fi
+
+echo "Using issue number: $issue_number"
+
+# Create the directory if it doesn't exist
+mkdir -p "/workspaces/terraform-provider-power-platform/.github/prompts"
+
+# Use gh CLI to get the issue content and save it to file
+output_file="/workspaces/terraform-provider-power-platform/.github/prompts/.userstory.prompt.md"
+if gh issue view "$issue_number" > "$output_file" 2>/dev/null; then
+    echo "Successfully saved issue #$issue_number to $output_file"
+    echo "Path: $output_file"
+else
+    echo "Error: Could not fetch issue #$issue_number. Make sure it exists and you have permissions."
+    exit 1
+fi


### PR DESCRIPTION
This pull request focuses on replacing the usage of `fmt.Errorf` with the `errors.New` function across multiple files for better consistency and simplicity in error handling. Additionally, there are some minor refactorings to improve code readability.

Fixes #653 

Error handling improvements:

* [`internal/api/auth.go`](diffhunk://#diff-1a28b89630d0f9aa800869f02725ff42a4f02b1fe79f01fb62477b700a07df8fL145-R154): Replaced `fmt.Errorf` with `errors.New` in several functions to streamline error messages. [[1]](diffhunk://#diff-1a28b89630d0f9aa800869f02725ff42a4f02b1fe79f01fb62477b700a07df8fL145-R154) [[2]](diffhunk://#diff-1a28b89630d0f9aa800869f02725ff42a4f02b1fe79f01fb62477b700a07df8fL249-R258) [[3]](diffhunk://#diff-1a28b89630d0f9aa800869f02725ff42a4f02b1fe79f01fb62477b700a07df8fL298-R303) [[4]](diffhunk://#diff-1a28b89630d0f9aa800869f02725ff42a4f02b1fe79f01fb62477b700a07df8fL339-R339)
* [`internal/services/copilot_studio_application_insights/api_copilot_studio_application_insights.go`](diffhunk://#diff-8b56196ade404bd6f68cf6ab84ac94797c4aea96a35e481663b048010aefc06aL36-R37): Updated error handling to use `errors.New` instead of `fmt.Errorf`. [[1]](diffhunk://#diff-8b56196ade404bd6f68cf6ab84ac94797c4aea96a35e481663b048010aefc06aL36-R37) [[2]](diffhunk://#diff-8b56196ade404bd6f68cf6ab84ac94797c4aea96a35e481663b048010aefc06aL50-R51) [[3]](diffhunk://#diff-8b56196ade404bd6f68cf6ab84ac94797c4aea96a35e481663b048010aefc06aL71-R72) [[4]](diffhunk://#diff-8b56196ade404bd6f68cf6ab84ac94797c4aea96a35e481663b048010aefc06aL104-R105)
* [`internal/services/data_record/api_data_record.go`](diffhunk://#diff-7573aa4b9cc1f5a881b223c21f5721746275a0414a905023b48bfe17e1ee99b4L123-R128): Consistently replaced `fmt.Errorf` with `errors.New` across multiple functions to standardize error handling. [[1]](diffhunk://#diff-7573aa4b9cc1f5a881b223c21f5721746275a0414a905023b48bfe17e1ee99b4L123-R128) [[2]](diffhunk://#diff-7573aa4b9cc1f5a881b223c21f5721746275a0414a905023b48bfe17e1ee99b4L217-R222) [[3]](diffhunk://#diff-7573aa4b9cc1f5a881b223c21f5721746275a0414a905023b48bfe17e1ee99b4L265-R265) [[4]](diffhunk://#diff-7573aa4b9cc1f5a881b223c21f5721746275a0414a905023b48bfe17e1ee99b4L274-R293) [[5]](diffhunk://#diff-7573aa4b9cc1f5a881b223c21f5721746275a0414a905023b48bfe17e1ee99b4L305-R324) [[6]](diffhunk://#diff-7573aa4b9cc1f5a881b223c21f5721746275a0414a905023b48bfe17e1ee99b4L336-R353) [[7]](diffhunk://#diff-7573aa4b9cc1f5a881b223c21f5721746275a0414a905023b48bfe17e1ee99b4L485-R485) [[8]](diffhunk://#diff-7573aa4b9cc1f5a881b223c21f5721746275a0414a905023b48bfe17e1ee99b4L501-R505) [[9]](diffhunk://#diff-7573aa4b9cc1f5a881b223c21f5721746275a0414a905023b48bfe17e1ee99b4L538-R543) [[10]](diffhunk://#diff-7573aa4b9cc1f5a881b223c21f5721746275a0414a905023b48bfe17e1ee99b4L553-R553) [[11]](diffhunk://#diff-7573aa4b9cc1f5a881b223c21f5721746275a0414a905023b48bfe17e1ee99b4L576-R580) [[12]](diffhunk://#diff-7573aa4b9cc1f5a881b223c21f5721746275a0414a905023b48bfe17e1ee99b4L629-R629) [[13]](diffhunk://#diff-7573aa4b9cc1f5a881b223c21f5721746275a0414a905023b48bfe17e1ee99b4L661-R661)

Minor refactoring:

* [`internal/helpers/array/array.go`](diffhunk://#diff-7fae2f57d58f2ed9dcc6c5e7ead950a94f60607a5aa60dd608c738173c38fb7eL8-L33): Modified the `Diff` function to use named return values for improved readability.
* [`internal/services/authorization/api_user.go`](diffhunk://#diff-423ce31c4d46652fbe412a0f49bd085b777ce4c38e50f50613f279692259da4fL300-R300): Replaced an empty `fmt.Errorf` initialization with a variable declaration for clarity.
* [`internal/services/data_record/resource_data_record.go`](diffhunk://#diff-367498b2e3d4a6fc20006215312a73f0e8ee0771ce511c043f994767bedcbabdR9): Added the `errors` package import to support the new error handling approach.…nsistency; add user story prompt target in Makefile.