### PR TITLE
Add custom error message for lack of management application permissions

### DIFF
--- a/.changes/unreleased/fixed-20250328-112001.yaml
+++ b/.changes/unreleased/fixed-20250328-112001.yaml
@@ -1,5 +1,5 @@
 kind: fixed
-body: Added custom error massage for lack of management application permissions
+body: Added custom error message for lack of management application permissions
 time: 2025-03-28T11:20:01.849495183Z
 custom:
     Issue: "670"

--- a/.changes/unreleased/fixed-20250328-112001.yaml
+++ b/.changes/unreleased/fixed-20250328-112001.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Added custom error massage for lack of management application permissions
+time: 2025-03-28T11:20:01.849495183Z
+custom:
+    Issue: "670"

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -176,5 +176,5 @@ const (
 )
 
 const (
-	NO_MANAGEMENT_APPLICATION_ERROR_MSG = "Authorization has been denied for this request. Make sure that your service principal is registered as an admin management appplication: https://learn.microsoft.com/en-us/power-platform/admin/powerplatform-api-create-service-principal#registering-an-admin-management-application"
+	NO_MANAGEMENT_APPLICATION_ERROR_MSG = "Authorization has been denied for this request. Make sure that your service principal is registered as an admin management application: https://learn.microsoft.com/en-us/power-platform/admin/powerplatform-api-create-service-principal#registering-an-admin-management-application"
 )

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -174,3 +174,7 @@ const (
 const (
 	SOLUTION_CHECKER_RULESET_ID = "0ad12346-e108-40b8-a956-9a8f95ea18c9"
 )
+
+const (
+	NO_MANAGEMENT_APPLICATION_ERROR_MSG = "Authorization has been denied for this request. Make sure that your service principal is registered as an admin management appplication: https://learn.microsoft.com/en-us/power-platform/admin/powerplatform-api-create-service-principal#registering-an-admin-management-application"
+)

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -176,5 +176,5 @@ const (
 )
 
 const (
-	NO_MANAGEMENT_APPLICATION_ERROR_MSG = "Authorization has been denied for this request. Make sure that your service principal is registered as an admin management application: https://learn.microsoft.com/en-us/power-platform/admin/powerplatform-api-create-service-principal#registering-an-admin-management-application"
+	NO_MANAGEMENT_APPLICATION_ERROR_MSG = "authorization has been denied for this request. Make sure that your service principal is registered as an admin management application: https://learn.microsoft.com/en-us/power-platform/admin/powerplatform-api-create-service-principal#registering-an-admin-management-application"
 )

--- a/internal/services/environment_groups/resource_environment_group_test.go
+++ b/internal/services/environment_groups/resource_environment_group_test.go
@@ -9,9 +9,28 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/jarcoal/httpmock"
+	"github.com/microsoft/terraform-provider-power-platform/internal/constants"
 	"github.com/microsoft/terraform-provider-power-platform/internal/helpers"
 	"github.com/microsoft/terraform-provider-power-platform/internal/mocks"
 )
+
+func TestNoManagementAppPermissionsMessage(t *testing.T) {
+	t.Skip("Skipping test. This should run with an sp that does not have management app permissions.")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				resource "powerplatform_environment_group" "test_env_group" {
+					display_name = "test_env_group"
+					description = "test env group"
+				}`,
+				ExpectError: regexp.MustCompile(constants.NO_MANAGEMENT_APPLICATION_ERROR_MSG[:50]),
+			},
+		},
+	})
+}
 
 func TestAccEnvironmentGroupResource_Validate_Create(t *testing.T) {
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
This pull request introduces a custom error message for cases where there is a lack of management application permissions. The changes span multiple files, including the addition of a new validation function and a test case to ensure the error message is handled correctly.

Key changes include:

### Error Handling Improvements:
* Added a custom error message for lack of management application permissions in the `.changes/unreleased/fixed-20250328-112001.yaml` file.
* Imported the `errors` package in `internal/api/client.go` to support custom error handling.
* Implemented a new function `validateNoManagementApplicationPermissionsForBapiRequest` in `internal/api/client.go` to validate and return the custom error when appropriate.

### Code Cleanup:
* Removed commented-out code related to token saving in the `Execute` method of `internal/api/client.go`.

### Constants and Testing:
* Defined a new constant `NO_MANAGEMENT_APPLICATION_ERROR_MSG` in `internal/constants/constants.go` for the custom error message.
* Added a test case `TestNoManagementAppPermissionsMessage` in `internal/services/environment_groups/resource_environment_group_test.go` to verify the error message for scenarios lacking management application permissions.