### PR TITLE
Update error messages to use FullTypeName for better clarity in diagn…

### DIFF
--- a/.changes/unreleased/fixed-20250331-124817.yaml
+++ b/.changes/unreleased/fixed-20250331-124817.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: standardize the logging and error messages by replacing `ProviderTypeName` with `FullTypeName`
+time: 2025-03-31T12:48:17.86943761Z
+custom:
+    Issue: "673"

--- a/internal/services/application/datasource_environment_application_packages.go
+++ b/internal/services/application/datasource_environment_application_packages.go
@@ -171,7 +171,7 @@ func (d *EnvironmentApplicationPackagesDataSource) Read(ctx context.Context, req
 	var state EnvironmentApplicationPackagesListDataSourceModel
 	resp.State.Get(ctx, &state)
 
-	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE ENVIRONMENT APPLICATION PACKAGES START: %s", d.ProviderTypeName))
+	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE ENVIRONMENT APPLICATION PACKAGES START: %s", d.FullTypeName()))
 
 	state.EnvironmentId = types.StringValue(state.EnvironmentId.ValueString())
 	state.Name = types.StringValue(state.Name.ValueString())
@@ -189,7 +189,7 @@ func (d *EnvironmentApplicationPackagesDataSource) Read(ctx context.Context, req
 
 	applications, err := d.ApplicationClient.GetApplicationsByEnvironmentId(ctx, state.EnvironmentId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.FullTypeName()), err.Error())
 		return
 	}
 
@@ -215,7 +215,7 @@ func (d *EnvironmentApplicationPackagesDataSource) Read(ctx context.Context, req
 	state.Id = types.StringValue(fmt.Sprintf("%s_%d", state.EnvironmentId.ValueString(), len(applications)))
 	diags := resp.State.Set(ctx, &state)
 
-	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE ENVIRONMENT APPLICATION PACKAGES END: %s", d.ProviderTypeName))
+	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE ENVIRONMENT APPLICATION PACKAGES END: %s", d.FullTypeName()))
 
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/services/application/datasource_tenant_application_packages.go
+++ b/internal/services/application/datasource_tenant_application_packages.go
@@ -178,7 +178,7 @@ func (d *TenantApplicationPackagesDataSource) Read(ctx context.Context, req data
 
 	applications, err := d.ApplicationClient.GetTenantApplications(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.FullTypeName()), err.Error())
 		return
 	}
 

--- a/internal/services/application/resource_environment_application_package_install.go
+++ b/internal/services/application/resource_environment_application_package_install.go
@@ -121,7 +121,7 @@ func (r *EnvironmentApplicationPackageInstallResource) Create(ctx context.Contex
 
 	applicationId, err := r.ApplicationClient.InstallApplicationInEnvironment(ctx, state.EnvironmentId.ValueString(), state.UniqueName.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -144,7 +144,7 @@ func (r *EnvironmentApplicationPackageInstallResource) Read(ctx context.Context,
 		return
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("READ: %s_application with application_name %s", r.ProviderTypeName, state.UniqueName.ValueString()))
+	tflog.Debug(ctx, fmt.Sprintf("READ: %s with application_name %s", r.FullTypeName(), state.UniqueName.ValueString()))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/internal/services/authorization/datasource_securityroles.go
+++ b/internal/services/authorization/datasource_securityroles.go
@@ -137,7 +137,7 @@ func (d *SecurityRolesDataSource) Read(ctx context.Context, req datasource.ReadR
 
 	roles, err := d.UserClient.GetDataverseSecurityRoles(ctx, state.EnvironmentId.ValueString(), state.BusinessUnitId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s_%s", d.ProviderTypeName, d.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.FullTypeName()), err.Error())
 		return
 	}
 

--- a/internal/services/authorization/resource_user.go
+++ b/internal/services/authorization/resource_user.go
@@ -165,7 +165,7 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	hasEnvDataverse, err := r.UserClient.EnvironmentHasDataverse(ctx, plan.EnvironmentId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.FullTypeName()), err.Error())
 		return
 	}
 	tflog.Debug(ctx, fmt.Sprintf("Dataverse exist in eviroment %t", hasEnvDataverse))
@@ -174,13 +174,13 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 	if hasEnvDataverse {
 		user, err := r.UserClient.CreateDataverseUser(ctx, plan.EnvironmentId.ValueString(), plan.AadId.ValueString())
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.FullTypeName()), err.Error())
 			return
 		}
 
 		user, err = r.UserClient.AddDataverseSecurityRoles(ctx, plan.EnvironmentId.ValueString(), user.Id, plan.SecurityRoles)
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.FullTypeName()), err.Error())
 			return
 		}
 		newUser = *user
@@ -188,12 +188,12 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 		// todo disalbe delete should be set to false.
 		err := validateEnvironmentSecurityRoles(plan.SecurityRoles)
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.FullTypeName()), err.Error())
 		}
 
 		user, err := r.UserClient.CreateEnvironmentUser(ctx, plan.EnvironmentId.ValueString(), plan.AadId.ValueString(), plan.SecurityRoles)
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.FullTypeName()), err.Error())
 			return
 		}
 
@@ -236,7 +236,7 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	hasEnvDataverse, err := r.UserClient.EnvironmentHasDataverse(ctx, state.EnvironmentId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.FullTypeName()), err.Error())
 		return
 	}
 	tflog.Debug(ctx, fmt.Sprintf("Dataverse exist in eviroment %t", hasEnvDataverse))
@@ -249,7 +249,7 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 				resp.State.RemoveResource(ctx)
 				return
 			}
-			resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.FullTypeName()), err.Error())
 			return
 		}
 		updateUser = *user
@@ -266,7 +266,7 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 				resp.State.RemoveResource(ctx)
 				return
 			}
-			resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.FullTypeName()), err.Error())
 			return
 		}
 
@@ -292,7 +292,7 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	state.DisableDelete = model.DisableDelete
 	state.BusinessUnitId = model.BusinessUnitId
 
-	tflog.Debug(ctx, fmt.Sprintf("READ: %s_environment with id %s", r.ProviderTypeName, state.Id.ValueString()))
+	tflog.Debug(ctx, fmt.Sprintf("READ: %s with id %s", r.FullTypeName(), state.Id.ValueString()))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -314,7 +314,7 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	hasEnvDataverse, err := r.UserClient.EnvironmentHasDataverse(ctx, state.EnvironmentId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.FullTypeName()), err.Error())
 		return
 	}
 	tflog.Debug(ctx, fmt.Sprintf("Dataverse exist in eviroment %t", hasEnvDataverse))
@@ -325,7 +325,7 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		if len(addedSecurityRoles) > 0 {
 			userDto, err := r.UserClient.AddDataverseSecurityRoles(ctx, plan.EnvironmentId.ValueString(), state.Id.ValueString(), addedSecurityRoles)
 			if err != nil {
-				resp.Diagnostics.AddError(fmt.Sprintf("Client error when adding security roles %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+				resp.Diagnostics.AddError(fmt.Sprintf("Client error when adding security roles %s", r.FullTypeName()), err.Error())
 				return
 			}
 			user = *userDto
@@ -333,7 +333,7 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		if len(removedSecurityRoles) > 0 {
 			userDto, err := r.UserClient.RemoveDataverseSecurityRoles(ctx, plan.EnvironmentId.ValueString(), state.Id.ValueString(), removedSecurityRoles)
 			if err != nil {
-				resp.Diagnostics.AddError(fmt.Sprintf("Client error when removing security roles %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+				resp.Diagnostics.AddError(fmt.Sprintf("Client error when removing security roles %s", r.FullTypeName()), err.Error())
 				return
 			}
 			user = *userDto
@@ -341,12 +341,12 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	} else {
 		err := validateEnvironmentSecurityRoles(plan.SecurityRoles)
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.FullTypeName()), err.Error())
 		}
 		if len(addedSecurityRoles) > 0 {
 			userDto, err := r.UserClient.AddEnvironmentUserSecurityRoles(ctx, plan.EnvironmentId.ValueString(), plan.AadId.ValueString(), addedSecurityRoles)
 			if err != nil {
-				resp.Diagnostics.AddError(fmt.Sprintf("Client error when adding security roles %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+				resp.Diagnostics.AddError(fmt.Sprintf("Client error when adding security roles %s", r.FullTypeName()), err.Error())
 				return
 			}
 			user = *userDto
@@ -355,19 +355,19 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 			savedRoles := []securityRoleDto{}
 			rolesObj, diag := resp.Private.GetKey(ctx, "role")
 			if diag.HasError() {
-				resp.Diagnostics.AddError(fmt.Sprintf("Error when updating %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+				resp.Diagnostics.AddError(fmt.Sprintf("Error when updating %s", r.FullTypeName()), err.Error())
 				return
 			}
 
 			err := json.Unmarshal(rolesObj, &savedRoles)
 			if err != nil {
-				resp.Diagnostics.AddError(fmt.Sprintf("Error when updating %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+				resp.Diagnostics.AddError(fmt.Sprintf("Error when updating %s", r.FullTypeName()), err.Error())
 				return
 			}
 
 			userDto, err := r.UserClient.RemoveEnvironmentUserSecurityRoles(ctx, plan.EnvironmentId.ValueString(), plan.AadId.ValueString(), removedSecurityRoles, savedRoles)
 			if err != nil {
-				resp.Diagnostics.AddError(fmt.Sprintf("Client error when removing security roles %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+				resp.Diagnostics.AddError(fmt.Sprintf("Client error when removing security roles %s", r.FullTypeName()), err.Error())
 				return
 			}
 			user = *userDto
@@ -409,7 +409,7 @@ func (r *UserResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 	hasEnvDataverse, err := r.UserClient.EnvironmentHasDataverse(ctx, state.EnvironmentId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.FullTypeName()), err.Error())
 		return
 	}
 	tflog.Debug(ctx, fmt.Sprintf("Dataverse exist in eviroment %t", hasEnvDataverse))
@@ -418,7 +418,7 @@ func (r *UserResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		if state.DisableDelete.ValueBool() {
 			err := r.UserClient.DeleteDataverseUser(ctx, state.EnvironmentId.ValueString(), state.Id.ValueString())
 			if err != nil {
-				resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+				resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s", r.FullTypeName()), err.Error())
 				return
 			}
 		} else {
@@ -433,17 +433,17 @@ func (r *UserResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 		err := json.Unmarshal(rolesObj, &savedRoles)
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("Error when deleting %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("Error when deleting %s", r.FullTypeName()), err.Error())
 			return
 		}
 
 		_, err = r.UserClient.RemoveEnvironmentUserSecurityRoles(ctx, state.EnvironmentId.ValueString(), state.AadId.ValueString(), state.SecurityRoles, savedRoles)
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s", r.FullTypeName()), err.Error())
 			return
 		}
 	}
-	tflog.Debug(ctx, fmt.Sprintf("DELETE RESOURCE END: %s", r.ProviderTypeName))
+	tflog.Debug(ctx, fmt.Sprintf("DELETE RESOURCE END: %s", r.FullTypeName()))
 }
 
 func (r *UserResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/services/connection/datasource_connections.go
+++ b/internal/services/connection/datasource_connections.go
@@ -121,11 +121,11 @@ func (d *ConnectionsDataSource) Read(ctx context.Context, req datasource.ReadReq
 	var state ConnectionsListDataSourceModel
 	resp.State.Get(ctx, &state)
 
-	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE START: %s", d.ProviderTypeName))
+	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE START: %s", d.FullTypeName()))
 
 	connections, err := d.ConnectionsClient.GetConnections(ctx, state.EnvironmentId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.FullTypeName()), err.Error())
 		return
 	}
 
@@ -135,7 +135,7 @@ func (d *ConnectionsDataSource) Read(ctx context.Context, req datasource.ReadReq
 	}
 	diags := resp.State.Set(ctx, &state)
 
-	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE END: %s", d.ProviderTypeName))
+	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE END: %s", d.FullTypeName()))
 
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/services/connection/resource_connection.go
+++ b/internal/services/connection/resource_connection.go
@@ -222,7 +222,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -275,7 +275,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 
 	connection, err := r.ConnectionsClient.UpdateConnection(ctx, plan.EnvironmentId.ValueString(), plan.Name.ValueString(), plan.Id.ValueString(), plan.DisplayName.ValueString(), connParams, connParamsSet)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -311,7 +311,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 
 	err := r.ConnectionsClient.DeleteConnection(ctx, state.EnvironmentId.ValueString(), state.Name.ValueString(), state.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s", r.FullTypeName()), err.Error())
 		return
 	}
 }

--- a/internal/services/connectors/datasource_connectors.go
+++ b/internal/services/connectors/datasource_connectors.go
@@ -122,7 +122,7 @@ func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp 
 
 	connectors, err := d.ConnectorsClient.GetConnectors(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.FullTypeName()), err.Error())
 		return
 	}
 

--- a/internal/services/copilot_studio_application_insights/resource_copilot_studio_application_insights.go
+++ b/internal/services/copilot_studio_application_insights/resource_copilot_studio_application_insights.go
@@ -148,7 +148,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	// You can't really create a config, so treat a create as an update
 	appInsightsConfigDto, err := r.CopilotStudioApplicationInsightsClient.updateCopilotStudioAppInsightsConfiguration(ctx, *appInsightsConfigToCreate, plan.BotId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating/updating %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating/updating %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -180,7 +180,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -213,7 +213,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	// You can't really create a config, so treat a create as an update
 	appInsightsConfigDto, err := r.CopilotStudioApplicationInsightsClient.updateCopilotStudioAppInsightsConfiguration(ctx, *appInsightsConfigToCreate, plan.BotId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating/updating %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating/updating %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -251,7 +251,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 
 	_, err = r.CopilotStudioApplicationInsightsClient.updateCopilotStudioAppInsightsConfiguration(ctx, *appInsightsConfigToCreate, state.BotId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s", r.FullTypeName()), err.Error())
 		return
 	}
 	resp.State.RemoveResource(ctx)

--- a/internal/services/currencies/datasource_currencies.go
+++ b/internal/services/currencies/datasource_currencies.go
@@ -123,7 +123,7 @@ func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp 
 
 	currencies, err := d.CurrenciesClient.GetCurrenciesByLocation(ctx, state.Location.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.FullTypeName()), err.Error())
 		return
 	}
 	state.Location = types.StringValue(state.Location.ValueString())

--- a/internal/services/data_record/datasource_data_record.go
+++ b/internal/services/data_record/datasource_data_record.go
@@ -210,7 +210,7 @@ func (d *DataRecordDataSource) Read(ctx context.Context, req datasource.ReadRequ
 	var state DataRecordListDataSourceModel
 	var config DataRecordListDataSourceModel
 
-	tflog.Debug(ctx, fmt.Sprintf("READ RESOURCE START: %s", d.ProviderTypeName))
+	tflog.Debug(ctx, fmt.Sprintf("READ RESOURCE START: %s", d.FullTypeName()))
 
 	resp.Diagnostics.Append(resp.State.Get(ctx, &state)...)
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
@@ -259,7 +259,7 @@ func (d *DataRecordDataSource) Read(ctx context.Context, req datasource.ReadRequ
 	rows, _ := types.TupleValue(elementTypes, elements)
 	state.Rows = types.DynamicValue(rows)
 
-	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE END: %s", d.ProviderTypeName))
+	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE END: %s", d.FullTypeName()))
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 
 	if resp.Diagnostics.HasError() {

--- a/internal/services/data_record/resource_data_record.go
+++ b/internal/services/data_record/resource_data_record.go
@@ -149,7 +149,7 @@ func (r *DataRecordResource) Create(ctx context.Context, req resource.CreateRequ
 
 	dr, err := r.DataRecordClient.ApplyDataRecord(ctx, plan.Id.ValueString(), plan.EnvironmentId.ValueString(), plan.TableLogicalName.ValueString(), mapColumns)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -177,7 +177,7 @@ func (r *DataRecordResource) Read(ctx context.Context, req resource.ReadRequest,
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -190,7 +190,7 @@ func (r *DataRecordResource) Read(ctx context.Context, req resource.ReadRequest,
 	}
 	state.Columns = *columns
 
-	tflog.Debug(ctx, fmt.Sprintf("READ: %s_data_record with table_name %s", r.ProviderTypeName, state.TableLogicalName.ValueString()))
+	tflog.Debug(ctx, fmt.Sprintf("READ: %s with table_name %s", r.FullTypeName(), state.TableLogicalName.ValueString()))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -224,7 +224,7 @@ func (r *DataRecordResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	dr, err := r.DataRecordClient.ApplyDataRecord(ctx, state.Id.ValueString(), plan.EnvironmentId.ValueString(), plan.TableLogicalName.ValueString(), mapColumns)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -253,7 +253,7 @@ func (r *DataRecordResource) Delete(ctx context.Context, req resource.DeleteRequ
 	if state.DisableOnDestroy.ValueBool() {
 		entityAttr, err := r.DataRecordClient.GetEntityAttributesDefinition(ctx, state.EnvironmentId.ValueString(), state.TableLogicalName.ValueString())
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("Client error when getting entity attributes definition %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("Client error when getting entity attributes definition %s", r.FullTypeName()), err.Error())
 			return
 		}
 		var containsIsDisableAttr, containsStateCode bool
@@ -273,23 +273,23 @@ func (r *DataRecordResource) Delete(ctx context.Context, req resource.DeleteRequ
 		} else if containsIsDisableAttr {
 			attributes["isdisabled"] = true
 		} else {
-			tflog.Debug(ctx, fmt.Sprintf("No statecode or isdisabled attribute found for %s_%s", r.ProviderTypeName, r.TypeName))
+			tflog.Debug(ctx, fmt.Sprintf("No statecode or isdisabled attribute found for %s", r.FullTypeName()))
 		}
 
 		if len(attributes) > 0 {
 			_, err = r.DataRecordClient.ApplyDataRecord(ctx, state.Id.ValueString(), state.EnvironmentId.ValueString(), state.TableLogicalName.ValueString(), attributes)
 			if err != nil {
-				resp.Diagnostics.AddError(fmt.Sprintf("Client error when disabling %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+				resp.Diagnostics.AddError(fmt.Sprintf("Client error when disabling %s", r.FullTypeName()), err.Error())
 				return
 			}
 		} else {
-			tflog.Debug(ctx, fmt.Sprintf("No statecode or isdisabled attribute found for %s_%s", r.ProviderTypeName, r.TypeName))
+			tflog.Debug(ctx, fmt.Sprintf("No statecode or isdisabled attribute found for %s", r.FullTypeName()))
 		}
 	}
 
 	err = r.DataRecordClient.DeleteDataRecord(ctx, state.Id.ValueString(), state.EnvironmentId.ValueString(), state.TableLogicalName.ValueString(), mapColumns)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s", r.FullTypeName()), err.Error())
 		return
 	}
 }

--- a/internal/services/dlp_policy/datasource_dlp_policy.go
+++ b/internal/services/dlp_policy/datasource_dlp_policy.go
@@ -234,7 +234,7 @@ func (d *DataLossPreventionPolicyDataSource) Read(ctx context.Context, req datas
 
 	var state policiesListDataSourceModel
 
-	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE POLICIES START: %s_%s", d.ProviderTypeName, d.TypeName))
+	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE POLICIES START: %s", d.FullTypeName()))
 
 	resp.Diagnostics.Append(resp.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -243,7 +243,7 @@ func (d *DataLossPreventionPolicyDataSource) Read(ctx context.Context, req datas
 
 	policies, err := d.DlpPolicyClient.GetPolicies(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s_%s", d.ProviderTypeName, d.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.FullTypeName()), err.Error())
 		return
 	}
 

--- a/internal/services/dlp_policy/resource_dlp_policy.go
+++ b/internal/services/dlp_policy/resource_dlp_policy.go
@@ -291,7 +291,7 @@ func (r *DataLossPreventionPolicyResource) Read(ctx context.Context, req resourc
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -340,7 +340,7 @@ func (r *DataLossPreventionPolicyResource) Create(ctx context.Context, req resou
 
 	policy, err_client := r.DlpPolicyClient.CreatePolicy(ctx, policyToCreate)
 	if err_client != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s_%s", r.ProviderTypeName, r.TypeName), err_client.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.FullTypeName()), err_client.Error())
 		return
 	}
 
@@ -393,7 +393,7 @@ func (r *DataLossPreventionPolicyResource) Update(ctx context.Context, req resou
 
 	policy, err_client := r.DlpPolicyClient.UpdatePolicy(ctx, policyToUpdate)
 	if err_client != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.TypeName), err_client.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.FullTypeName()), err_client.Error())
 		return
 	}
 
@@ -426,7 +426,7 @@ func (r *DataLossPreventionPolicyResource) Delete(ctx context.Context, req resou
 
 	err := r.DlpPolicyClient.DeletePolicy(ctx, state.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s", r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s", r.FullTypeName()), err.Error())
 		return
 	}
 }

--- a/internal/services/enterprise_policy/resource_enterprise_policy.go
+++ b/internal/services/enterprise_policy/resource_enterprise_policy.go
@@ -124,7 +124,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 
 	err := r.EnterprisePolicyClient.LinkEnterprisePolicy(ctx, plan.EnvironmentId.ValueString(), plan.PolicyType.ValueString(), plan.SystemId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -154,7 +154,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 
 	env, err := r.EnterprisePolicyClient.EnvironmentClient.GetEnvironment(ctx, state.EnvironmentId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading environment in %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading environment in %s", r.FullTypeName()), err.Error())
 		return
 	}
 	if env.Properties.EnterprisePolicies != nil {
@@ -199,7 +199,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 
 	err := r.EnterprisePolicyClient.UnLinkEnterprisePolicy(ctx, state.EnvironmentId.ValueString(), state.PolicyType.ValueString(), state.SystemId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s", r.FullTypeName()), err.Error())
 		return
 	}
 }

--- a/internal/services/environment/datasource_environments.go
+++ b/internal/services/environment/datasource_environments.go
@@ -258,7 +258,7 @@ func (d *EnvironmentsDataSource) Read(ctx context.Context, req datasource.ReadRe
 	envs, err := d.EnvironmentClient.GetEnvironments(ctx)
 
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.FullTypeName()), err.Error())
 		return
 	}
 

--- a/internal/services/environment/resource_environment.go
+++ b/internal/services/environment/resource_environment.go
@@ -407,13 +407,13 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 
 	err = r.EnvironmentClient.LocationValidator(ctx, envToCreate.Location, envToCreate.Properties.AzureRegion)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Location validation failed for %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Location validation failed for %s", r.FullTypeName()), err.Error())
 		return
 	}
 
 	err = r.aiGenerativeFeaturesValidaor(plan)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Location validation failed for %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Location validation failed for %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -421,27 +421,27 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	if envToCreate.Properties.LinkedEnvironmentMetadata != nil {
 		err = languageCodeValidator(ctx, r.EnvironmentClient.Api, envToCreate.Location, fmt.Sprintf("%d", envToCreate.Properties.LinkedEnvironmentMetadata.BaseLanguage))
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("Language code validation failed for %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("Language code validation failed for %s", r.FullTypeName()), err.Error())
 			return
 		}
 
 		err = currencyCodeValidator(ctx, r.EnvironmentClient.Api, envToCreate.Location, envToCreate.Properties.LinkedEnvironmentMetadata.Currency.Code)
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("Currency code validation failed for %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("Currency code validation failed for %s", r.FullTypeName()), err.Error())
 			return
 		}
 	}
 
 	envDto, err := r.EnvironmentClient.CreateEnvironment(ctx, *envToCreate)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.FullTypeName()), err.Error())
 		return
 	}
 
 	if !plan.AllowBingSearch.IsNull() && !plan.AllowBingSearch.IsUnknown() {
 		err := r.updateEnvironmentAiFeatures(ctx, envDto.Name, plan.AllowBingSearch.ValueBool(), plan.AllowMovingDataAcrossRegions.ValueBoolPointer())
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.FullTypeName()), err.Error())
 			return
 		}
 
@@ -451,7 +451,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 				resp.State.RemoveResource(ctx)
 				return
 			}
-			resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.FullTypeName()), err.Error())
 			return
 		}
 	}
@@ -501,7 +501,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -542,7 +542,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		return
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("READ: %s_environment with id %s", r.ProviderTypeName, state.Id.ValueString()))
+	tflog.Debug(ctx, fmt.Sprintf("READ: %s with id %s", r.FullTypeName(), state.Id.ValueString()))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
 }
@@ -563,7 +563,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 
 	err := r.aiGenerativeFeaturesValidaor(plan)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Location validation failed for %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Location validation failed for %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -611,7 +611,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 
 	envDto, err := r.EnvironmentClient.UpdateEnvironment(ctx, plan.Id.ValueString(), environmentDto)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -619,7 +619,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	if plan.DisplayName.ValueString() != state.DisplayName.ValueString() {
 		envDto, err = r.EnvironmentClient.UpdateEnvironment(ctx, plan.Id.ValueString(), environmentDto)
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.ProviderTypeName), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.FullTypeName()), err.Error())
 			return
 		}
 	}
@@ -751,7 +751,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 
 	err := r.EnvironmentClient.DeleteEnvironment(ctx, state.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s", r.FullTypeName()), err.Error())
 	}
 	resp.State.RemoveResource(ctx)
 }

--- a/internal/services/environment/resource_environment_test.go
+++ b/internal/services/environment/resource_environment_test.go
@@ -233,7 +233,7 @@ func TestAccEnvironmentsResource_Validate_CreateGenerativeAiFeatures_US_Region_E
 		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				ExpectError: regexp.MustCompile(".*Moving data across regions is not supported in the unitedstates location.*"),
+				ExpectError: regexp.MustCompile(".*moving data across regions is not supported in the unitedstates location.*"),
 				Config: `
 					resource "powerplatform_environment" "development" {
 						display_name                              = "` + fmt.Sprintf("%s_%d", t.Name(), rand.Intn(100000)) + `"
@@ -255,7 +255,7 @@ func TestAccEnvironmentsResource_Validate_CreateGenerativeAiFeatures_Non_US_Regi
 		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				ExpectError: regexp.MustCompile(".*To enable AI generative features, moving data across regions must be enabled.*"),
+				ExpectError: regexp.MustCompile(".*to enable ai generative features, moving data across regions must be enabled.*"),
 				Config: `
 					resource "powerplatform_environment" "development" {
 						display_name                              = "` + fmt.Sprintf("%s_%d", t.Name(), rand.Intn(100000)) + `"

--- a/internal/services/environment_group_rule_set/resource_environment_group_rule_set.go
+++ b/internal/services/environment_group_rule_set/resource_environment_group_rule_set.go
@@ -381,7 +381,7 @@ func (r *environmentGroupRuleSetResource) Delete(ctx context.Context, req resour
 
 	err := r.EnvironmentGroupRuleSetClient.DeleteEnvironmentGroupRuleSet(ctx, state.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s", r.FullTypeName()), err.Error())
 		return
 	}
 }

--- a/internal/services/environment_groups/resource_environment_group.go
+++ b/internal/services/environment_groups/resource_environment_group.go
@@ -102,7 +102,7 @@ func (r *EnvironmentGroupResource) Read(ctx context.Context, req resource.ReadRe
 
 	environmentGroup, err := r.EnvironmentGroupClient.GetEnvironmentGroup(ctx, state.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -135,7 +135,7 @@ func (r *EnvironmentGroupResource) Create(ctx context.Context, req resource.Crea
 
 	eg, err := r.EnvironmentGroupClient.CreateEnvironmentGroup(ctx, environmentGroupToCreate)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -172,7 +172,7 @@ func (r *EnvironmentGroupResource) Update(ctx context.Context, req resource.Upda
 
 	eg, err := r.EnvironmentGroupClient.UpdateEnvironmentGroup(ctx, state.Id.ValueString(), environmentGroupToUpdate)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -196,19 +196,19 @@ func (r *EnvironmentGroupResource) Delete(ctx context.Context, req resource.Dele
 
 	err := r.EnvironmentGroupClient.DeleteEnvironmentGroup(ctx, state.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s", r.FullTypeName()), err.Error())
 		return
 	}
 
 	if customerrors.Code(err) == customerrors.ERROR_ENVIRONMENT_URL_NOT_FOUND || customerrors.Code(err) == customerrors.ERROR_POLICY_ASSIGNED_TO_ENV_GROUP {
 		envs, err := r.EnvironmentGroupClient.GetEnvironmentsInEnvironmentGroup(ctx, state.Id.ValueString())
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s", r.FullTypeName()), err.Error())
 			return
 		}
 
 		if len(envs) > 0 {
-			tflog.Debug(ctx, fmt.Sprintf("Environment group %s_%s has %d environments. Removing them.", r.ProviderTypeName, r.TypeName, len(envs)))
+			tflog.Debug(ctx, fmt.Sprintf("Environment group %s has %d environments. Removing them.", r.FullTypeName(), len(envs)))
 			for _, env := range envs {
 				err := r.EnvironmentGroupClient.RemoveEnvironmentFromEnvironmentGroup(ctx, state.Id.ValueString(), env.Name)
 				if err != nil {
@@ -225,7 +225,7 @@ func (r *EnvironmentGroupResource) Delete(ctx context.Context, req resource.Dele
 		}
 
 		if customerrors.Code(err) != customerrors.ERROR_OBJECT_NOT_FOUND && ruleSet != nil && len(ruleSet.Parameters) > 0 {
-			tflog.Debug(ctx, fmt.Sprintf("Environment group %s_%s has %d rule sets. Deleting them.", r.ProviderTypeName, r.TypeName, len(ruleSet.Parameters)))
+			tflog.Debug(ctx, fmt.Sprintf("Environment group %s has %d rule sets. Deleting them.", r.FullTypeName(), len(ruleSet.Parameters)))
 			err := r.EnvironmentGroupClient.RuleSetApi.DeleteEnvironmentGroupRuleSet(ctx, *ruleSet.Id)
 			if err != nil {
 				resp.Diagnostics.AddError("error when deleting rule set", err.Error())
@@ -235,7 +235,7 @@ func (r *EnvironmentGroupResource) Delete(ctx context.Context, req resource.Dele
 
 		err = r.EnvironmentGroupClient.DeleteEnvironmentGroup(ctx, state.Id.ValueString())
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s", r.FullTypeName()), err.Error())
 			return
 		}
 	}

--- a/internal/services/environment_settings/datasource_environment_settings.go
+++ b/internal/services/environment_settings/datasource_environment_settings.go
@@ -56,7 +56,7 @@ func (d *EnvironmentSettingsDataSource) Read(ctx context.Context, req datasource
 	defer exitContext()
 	var state EnvironmentSettingsDataSourceModel
 
-	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE ENVIRONMENT SETTINGS START: %s", d.ProviderTypeName))
+	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE ENVIRONMENT SETTINGS START: %s", d.FullTypeName()))
 
 	resp.Diagnostics.Append(resp.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -80,7 +80,7 @@ func (d *EnvironmentSettingsDataSource) Read(ctx context.Context, req datasource
 
 	envSettings, err := d.EnvironmentSettingsClient.GetEnvironmentSettings(ctx, state.EnvironmentId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.FullTypeName()), err.Error())
 		return
 	}
 
@@ -88,7 +88,7 @@ func (d *EnvironmentSettingsDataSource) Read(ctx context.Context, req datasource
 
 	diags := resp.State.Set(ctx, &state)
 
-	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE ENVIRONMENT SETTINGS END: %s", d.ProviderTypeName))
+	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE ENVIRONMENT SETTINGS END: %s", d.FullTypeName()))
 
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/services/environment_settings/resources_environment_settings.go
+++ b/internal/services/environment_settings/resources_environment_settings.go
@@ -372,7 +372,7 @@ func (r *EnvironmentSettingsResource) Read(ctx context.Context, req resource.Rea
 
 	envSettings, err := r.EnvironmentSettingClient.GetEnvironmentSettings(ctx, state.EnvironmentId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.FullTypeName()), err.Error())
 		return
 	}
 

--- a/internal/services/environment_templates/datasource_environment_templates.go
+++ b/internal/services/environment_templates/datasource_environment_templates.go
@@ -154,7 +154,7 @@ func (d *EnvironmentTemplatesDataSource) Read(ctx context.Context, req datasourc
 
 	environment_templates, err := d.EnvironmentTemplatesClient.GetEnvironmentTemplatesByLocation(ctx, state.Location.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.FullTypeName()), err.Error())
 		return
 	}
 

--- a/internal/services/environment_wave/resource_environment_wave.go
+++ b/internal/services/environment_wave/resource_environment_wave.go
@@ -124,7 +124,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 
 	feature, err := r.EnvironmentWaveClient.UpdateFeature(ctx, plan.EnvironmentId.ValueString(), plan.FeatureName.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -154,7 +154,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.FullTypeName()), err.Error())
 		return
 	}
 

--- a/internal/services/languages/datasource_languages.go
+++ b/internal/services/languages/datasource_languages.go
@@ -119,11 +119,11 @@ func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp 
 		return
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE LANGUAGES START: %s", d.ProviderTypeName))
+	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE LANGUAGES START: %s", d.FullTypeName()))
 
 	languages, err := d.LanguagesClient.GetLanguagesByLocation(ctx, state.Location.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.FullTypeName()), err.Error())
 		return
 	}
 
@@ -142,7 +142,7 @@ func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp 
 
 	diags := resp.State.Set(ctx, &state)
 
-	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE LANGUAGES END: %s", d.ProviderTypeName))
+	tflog.Debug(ctx, fmt.Sprintf("READ DATASOURCE LANGUAGES END: %s", d.FullTypeName()))
 
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/services/licensing/datasource_billing_policies.go
+++ b/internal/services/licensing/datasource_billing_policies.go
@@ -130,7 +130,7 @@ func (d *BillingPoliciesDataSource) Read(ctx context.Context, req datasource.Rea
 	policies, err := d.LicensingClient.GetBillingPolicies(ctx)
 
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.FullTypeName()), err.Error())
 		return
 	}
 

--- a/internal/services/licensing/datasource_billing_policies_environments.go
+++ b/internal/services/licensing/datasource_billing_policies_environments.go
@@ -103,7 +103,7 @@ func (d *BillingPoliciesEnvironmetsDataSource) Read(ctx context.Context, req dat
 	environments, err := d.LicensingClient.GetEnvironmentsForBillingPolicy(ctx, state.BillingPolicyId)
 
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.FullTypeName()), err.Error())
 		return
 	}
 

--- a/internal/services/licensing/resource_billing_policy.go
+++ b/internal/services/licensing/resource_billing_policy.go
@@ -160,7 +160,7 @@ func (r *BillingPolicyResource) Create(ctx context.Context, req resource.CreateR
 
 	policy, err := r.LicensingClient.CreateBillingPolicy(ctx, billingPolicyToCreate)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -193,7 +193,7 @@ func (r *BillingPolicyResource) Read(ctx context.Context, req resource.ReadReque
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -205,7 +205,7 @@ func (r *BillingPolicyResource) Read(ctx context.Context, req resource.ReadReque
 	state.BillingInstrument.ResourceGroup = types.StringValue(billing.BillingInstrument.ResourceGroup)
 	state.BillingInstrument.SubscriptionId = types.StringValue(billing.BillingInstrument.SubscriptionId)
 
-	tflog.Debug(ctx, fmt.Sprintf("READ %s_%s with Id: %s", r.ProviderTypeName, r.TypeName, billing.Id))
+	tflog.Debug(ctx, fmt.Sprintf("READ %s with Id: %s", r.FullTypeName(), billing.Id))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -235,7 +235,7 @@ func (r *BillingPolicyResource) Update(ctx context.Context, req resource.UpdateR
 
 		policy, err := r.LicensingClient.UpdateBillingPolicy(ctx, plan.Id.ValueString(), policyToUpdate)
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.ProviderTypeName), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.FullTypeName()), err.Error())
 			return
 		}
 
@@ -262,7 +262,7 @@ func (r *BillingPolicyResource) Delete(ctx context.Context, req resource.DeleteR
 
 	err := r.LicensingClient.DeleteBillingPolicy(ctx, state.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s", r.FullTypeName()), err.Error())
 		return
 	}
 }

--- a/internal/services/licensing/resource_billing_policy_environment.go
+++ b/internal/services/licensing/resource_billing_policy_environment.go
@@ -102,27 +102,27 @@ func (r *BillingPolicyEnvironmentResource) Create(ctx context.Context, req resou
 
 	environments, err := r.LicensingClient.GetEnvironmentsForBillingPolicy(ctx, plan.BillingPolicyId)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.FullTypeName()), err.Error())
 		return
 	}
 
 	if len(environments) > 0 {
 		err = r.LicensingClient.RemoveEnvironmentsToBillingPolicy(ctx, plan.BillingPolicyId, environments)
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.ProviderTypeName), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.FullTypeName()), err.Error())
 			return
 		}
 	}
 
 	err = r.LicensingClient.AddEnvironmentsToBillingPolicy(ctx, plan.BillingPolicyId, plan.Environments)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.FullTypeName()), err.Error())
 		return
 	}
 
 	environments, err = r.LicensingClient.GetEnvironmentsForBillingPolicy(ctx, plan.BillingPolicyId)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -150,7 +150,7 @@ func (r *BillingPolicyEnvironmentResource) Read(ctx context.Context, req resourc
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -159,7 +159,7 @@ func (r *BillingPolicyEnvironmentResource) Read(ctx context.Context, req resourc
 		return
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("READ %s_%s with Id: %s", r.ProviderTypeName, r.TypeName, state.BillingPolicyId))
+	tflog.Debug(ctx, fmt.Sprintf("READ %s with Id: %s", r.FullTypeName(), state.BillingPolicyId))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -181,25 +181,25 @@ func (r *BillingPolicyEnvironmentResource) Update(ctx context.Context, req resou
 
 	environments, err := r.LicensingClient.GetEnvironmentsForBillingPolicy(ctx, plan.BillingPolicyId)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.FullTypeName()), err.Error())
 		return
 	}
 
 	err = r.LicensingClient.RemoveEnvironmentsToBillingPolicy(ctx, plan.BillingPolicyId, environments)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.FullTypeName()), err.Error())
 		return
 	}
 
 	err = r.LicensingClient.AddEnvironmentsToBillingPolicy(ctx, plan.BillingPolicyId, plan.Environments)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.FullTypeName()), err.Error())
 		return
 	}
 
 	environments, err = r.LicensingClient.GetEnvironmentsForBillingPolicy(ctx, plan.BillingPolicyId)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -220,7 +220,7 @@ func (r *BillingPolicyEnvironmentResource) Delete(ctx context.Context, req resou
 
 	err := r.LicensingClient.RemoveEnvironmentsToBillingPolicy(ctx, state.BillingPolicyId, state.Environments)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s", r.FullTypeName()), err.Error())
 		return
 	}
 }

--- a/internal/services/locations/datasource_locations.go
+++ b/internal/services/locations/datasource_locations.go
@@ -138,7 +138,7 @@ func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp 
 
 	locations, err := d.LocationsClient.GetLocations(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.FullTypeName()), err.Error())
 		return
 	}
 

--- a/internal/services/managed_environment/resource_managed_environment.go
+++ b/internal/services/managed_environment/resource_managed_environment.go
@@ -224,13 +224,13 @@ func (r *ManagedEnvironmentResource) Create(ctx context.Context, req resource.Cr
 
 	err = r.ManagedEnvironmentClient.EnableManagedEnvironment(ctx, managedEnvironmentDto, plan.EnvironmentId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when enabling managed environment %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when enabling managed environment %s", r.FullTypeName()), err.Error())
 		return
 	}
 
 	env, err := r.ManagedEnvironmentClient.environmentClient.GetEnvironment(ctx, plan.EnvironmentId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading environment %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading environment %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -273,7 +273,7 @@ func (r *ManagedEnvironmentResource) Read(ctx context.Context, req resource.Read
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -371,13 +371,13 @@ func (r *ManagedEnvironmentResource) Update(ctx context.Context, req resource.Up
 
 	err = r.ManagedEnvironmentClient.EnableManagedEnvironment(ctx, managedEnvironmentDto, plan.EnvironmentId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when enabling managed environment %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when enabling managed environment %s", r.FullTypeName()), err.Error())
 		return
 	}
 
 	env, err := r.ManagedEnvironmentClient.environmentClient.GetEnvironment(ctx, plan.EnvironmentId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading environment %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading environment %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -415,7 +415,7 @@ func (r *ManagedEnvironmentResource) Delete(ctx context.Context, req resource.De
 
 	err := r.ManagedEnvironmentClient.DisableManagedEnvironment(ctx, state.EnvironmentId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when disabling managed environment %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when disabling managed environment %s", r.FullTypeName()), err.Error())
 		return
 	}
 }

--- a/internal/services/powerapps/datasource_environment_powerapps.go
+++ b/internal/services/powerapps/datasource_environment_powerapps.go
@@ -111,7 +111,7 @@ func (d *EnvironmentPowerAppsDataSource) Read(ctx context.Context, req datasourc
 
 	apps, err := d.PowerAppssClient.GetPowerApps(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.FullTypeName()), err.Error())
 		return
 	}
 

--- a/internal/services/solution/datasource_solutions.go
+++ b/internal/services/solution/datasource_solutions.go
@@ -143,7 +143,7 @@ func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp 
 
 	solutions, err := d.SolutionClient.GetSolutions(ctx, state.EnvironmentId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.FullTypeName()), err.Error())
 		return
 	}
 

--- a/internal/services/solution/resource_solution.go
+++ b/internal/services/solution/resource_solution.go
@@ -208,7 +208,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.FullTypeName()), err.Error())
 		return
 	}
 
@@ -327,7 +327,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 		err := r.SolutionClient.DeleteSolution(ctx, state.EnvironmentId.ValueString(), solutionId)
 
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s_%s", r.ProviderTypeName, r.TypeName), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s", r.FullTypeName()), err.Error())
 			return
 		}
 	}

--- a/internal/services/solution_checker_rules/datasource_solution_checker_rules.go
+++ b/internal/services/solution_checker_rules/datasource_solution_checker_rules.go
@@ -134,7 +134,7 @@ func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp 
 	environmentId := state.EnvironmentId.ValueString()
 	rules, err := d.SolutionCheckerRulesClient.GetSolutionCheckerRules(ctx, environmentId)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.FullTypeName()), err.Error())
 		return
 	}
 

--- a/internal/services/tenant_settings/datasource_tenant_settings.go
+++ b/internal/services/tenant_settings/datasource_tenant_settings.go
@@ -61,7 +61,7 @@ func (d *TenantSettingsDataSource) Read(ctx context.Context, req datasource.Read
 
 	tenantSettings, err := d.TenantSettingsClient.GetTenantSettings(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.ProviderTypeName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", d.FullTypeName()), err.Error())
 		return
 	}
 

--- a/internal/services/tenant_settings/resource_tenant_settings.go
+++ b/internal/services/tenant_settings/resource_tenant_settings.go
@@ -453,7 +453,7 @@ func (r *TenantSettingsResource) Read(ctx context.Context, req resource.ReadRequ
 	newState, _ := convertFromTenantSettingsDto[TenantSettingsResourceModel](*newStateDto, state.Timeouts)
 	newState.Id = types.StringValue(tenant.TenantId)
 
-	tflog.Debug(ctx, fmt.Sprintf("READ: %s_tenant_settings with id %s", r.ProviderTypeName, newState.Id.ValueString()))
+	tflog.Debug(ctx, fmt.Sprintf("READ: %s with id %s", r.FullTypeName(), newState.Id.ValueString()))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
 }


### PR DESCRIPTION
This pull request includes changes across multiple files to standardize the logging and error messages by replacing `ProviderTypeName` with `FullTypeName`. This change ensures consistency and clarity in the debug logs and error diagnostics.

### Standardization of Logging and Error Messages:

* [`internal/services/application/datasource_environment_application_packages.go`](diffhunk://#diff-ffb32d64bf68eeb153b2df1fbd5998cbb5b570452cac71ffdea93806fd66a047L174-R174): Updated debug logs and error messages in the `Read` method to use `FullTypeName` instead of `ProviderTypeName`. [[1]](diffhunk://#diff-ffb32d64bf68eeb153b2df1fbd5998cbb5b570452cac71ffdea93806fd66a047L174-R174) [[2]](diffhunk://#diff-ffb32d64bf68eeb153b2df1fbd5998cbb5b570452cac71ffdea93806fd66a047L192-R192) [[3]](diffhunk://#diff-ffb32d64bf68eeb153b2df1fbd5998cbb5b570452cac71ffdea93806fd66a047L218-R218)
* [`internal/services/application/datasource_tenant_application_packages.go`](diffhunk://#diff-8765e156a9ebac43d71d1210346acbc3235ccb795724cb1d73e03bd476234784L181-R181): Changed error messages in the `Read` method to use `FullTypeName`.
* [`internal/services/application/resource_environment_application_package_install.go`](diffhunk://#diff-25d5acd5e61b963ec86a41b8c62a614f3cf8b8413cfb86eb5d62747efa9f83bcL124-R124): Modified debug logs and error messages in the `Create` and `Read` methods to use `FullTypeName`. [[1]](diffhunk://#diff-25d5acd5e61b963ec86a41b8c62a614f3cf8b8413cfb86eb5d62747efa9f83bcL124-R124) [[2]](diffhunk://#diff-25d5acd5e61b963ec86a41b8c62a614f3cf8b8413cfb86eb5d62747efa9f83bcL147-R147)
* [`internal/services/authorization/resource_user.go`](diffhunk://#diff-1f9c90c2f35775511acace8d916e9e0e5cf18d4c0f5323ee6b568b01d8df19a7L168-R168): Updated multiple methods (`Create`, `Read`, `Update`, `Delete`) to use `FullTypeName` in error messages and debug logs. [[1]](diffhunk://#diff-1f9c90c2f35775511acace8d916e9e0e5cf18d4c0f5323ee6b568b01d8df19a7L168-R168) [[2]](diffhunk://#diff-1f9c90c2f35775511acace8d916e9e0e5cf18d4c0f5323ee6b568b01d8df19a7L177-R196) [[3]](diffhunk://#diff-1f9c90c2f35775511acace8d916e9e0e5cf18d4c0f5323ee6b568b01d8df19a7L239-R239) [[4]](diffhunk://#diff-1f9c90c2f35775511acace8d916e9e0e5cf18d4c0f5323ee6b568b01d8df19a7L252-R252) [[5]](diffhunk://#diff-1f9c90c2f35775511acace8d916e9e0e5cf18d4c0f5323ee6b568b01d8df19a7L269-R269) [[6]](diffhunk://#diff-1f9c90c2f35775511acace8d916e9e0e5cf18d4c0f5323ee6b568b01d8df19a7L295-R295) [[7]](diffhunk://#diff-1f9c90c2f35775511acace8d916e9e0e5cf18d4c0f5323ee6b568b01d8df19a7L317-R317) [[8]](diffhunk://#diff-1f9c90c2f35775511acace8d916e9e0e5cf18d4c0f5323ee6b568b01d8df19a7L328-R349) [[9]](diffhunk://#diff-1f9c90c2f35775511acace8d916e9e0e5cf18d4c0f5323ee6b568b01d8df19a7L358-R370) [[10]](diffhunk://#diff-1f9c90c2f35775511acace8d916e9e0e5cf18d4c0f5323ee6b568b01d8df19a7L412-R412) [[11]](diffhunk://#diff-1f9c90c2f35775511acace8d916e9e0e5cf18d4c0f5323ee6b568b01d8df19a7L421-R421) [[12]](diffhunk://#diff-1f9c90c2f35775511acace8d916e9e0e5cf18d4c0f5323ee6b568b01d8df19a7L436-R446)
* [`internal/services/connection/datasource_connections.go`](diffhunk://#diff-95f8b97a8891fdde58994c69e410404f3e69acc08a3a6d1b6a80e2be821bfe4dL124-R128): Adjusted debug logs and error messages in the `Read` method to use `FullTypeName`. [[1]](diffhunk://#diff-95f8b97a8891fdde58994c69e410404f3e69acc08a3a6d1b6a80e2be821bfe4dL124-R128) [[2]](diffhunk://#diff-95f8b97a8891fdde58994c69e410404f3e69acc08a3a6d1b6a80e2be821bfe4dL138-R138)
* [`internal/services/connection/resource_connection.go`](diffhunk://#diff-ec7631d52f143f5d2de3fe52cf05f7d6526740b4621b941aeb4efef583dfd47cL225-R225): Standardized error messages in the `Read`, `Update`, and `Delete` methods to use `FullTypeName`. [[1]](diffhunk://#diff-ec7631d52f143f5d2de3fe52cf05f7d6526740b4621b941aeb4efef583dfd47cL225-R225) [[2]](diffhunk://#diff-ec7631d52f143f5d2de3fe52cf05f7d6526740b4621b941aeb4efef583dfd47cL278-R278) [[3]](diffhunk://#diff-ec7631d52f143f5d2de3fe52cf05f7d6526740b4621b941aeb4efef583dfd47cL314-R314)
* [`internal/services/connectors/datasource_connectors.go`](diffhunk://#diff-c08a55acb6d0973bb243384967731fcbcbbb6e5f30c857e1bc2bdeac259248afL125-R125): Updated error messages in the `Read` method to use `FullTypeName`.