### PR TITLE
Fix: Update authorization header check in doRequest function

### DIFF
--- a/internal/api/request.go
+++ b/internal/api/request.go
@@ -36,7 +36,7 @@ func (client *Client) doRequest(ctx context.Context, token *string, request *htt
 
 	httpClient := http.DefaultClient
 
-	if request.Header["Authorization"] == nil {
+	if request.Header.Get("Authorization") == "" {
 		request.Header.Set("Authorization", "Bearer "+*token)
 	}
 


### PR DESCRIPTION
This pull request includes a small but important change to the `internal/api/request.go` file. The change modifies the way the `Authorization` header is checked and set in the `doRequest` function.

* [`internal/api/request.go`](diffhunk://#diff-4dac40c2e7a5517541a205a586a514e23debf09e34a3566c264fd7500dc883a5L39-R39): Changed the condition from checking if the `Authorization` header is nil to checking if it is an empty string.