### PR TITLE
Chore: Update permissions in changelog workflow

### DIFF
--- a/.github/workflows/check_changie_comment_on_pr.yml
+++ b/.github/workflows/check_changie_comment_on_pr.yml
@@ -11,16 +11,16 @@
       group: ${{ format('{0}-{1}-{2}-{3}-{4}', github.workflow, github.event_name, github.ref, github.base_ref || null, github.head_ref || null) }}
       cancel-in-progress: true
     
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
+
     
     jobs:
       changelog-existence:
         name: Check Changelog
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') && github.actor != 'dependabot[bot]' }}
         runs-on: ubuntu-latest
+        permissions:
+          contents: read
+          pull-requests: write
         steps:
           - name: Checkout
             uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -65,6 +65,10 @@
         name: Check Changelog
         if: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changelog') || github.actor == 'dependabot[bot]' }}
         runs-on: ubuntu-latest
+        permissions:
+          contents: read
+          #issues: write
+          pull-requests: write
         steps:
           - name: Find comment
             if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/check_changie_comment_on_pr.yml
+++ b/.github/workflows/check_changie_comment_on_pr.yml
@@ -1,93 +1,90 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 ---
-    name: Changelog
-    
-    on:
-      pull_request:
-        types: [opened, reopened, labeled, unlabeled, synchronize]
-      workflow_dispatch:
-    
-    concurrency:
-      group: ${{ format('{0}-{1}-{2}-{3}-{4}', github.workflow, github.event_name, github.ref, github.base_ref || null, github.head_ref || null) }}
-      cancel-in-progress: true
-    
+name: Changelog
 
-    
-    jobs:
-      changelog-existence:
-        name: Check Changelog
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') && github.actor != 'dependabot[bot]' }}
-        runs-on: ubuntu-latest
-        permissions:
-          contents: read
-          pull-requests: write
-        steps:
-          - name: Checkout
-            uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    
-          - name: Output GitHub Variables
-            run: env | grep GITHUB
+on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+  workflow_dispatch:
 
-          - name: Check if changelog file was added
-            uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-            id: changelog_check
-            with:
-              filters: |
-                exists:
-                  - added|modified: '.changes/unreleased/**.yaml'
-    
-          - name: Setup Go
-            if: steps.changelog_check.outputs.exists == 'true'
-            uses: actions/setup-go@v5
-            with:
-              go-version-file: go.mod
-              cache: true
-                
-          - name: Install Changie
-            if: steps.changelog_check.outputs.exists == 'true'
-            run: |
-                go install github.com/miniscruff/changie@latest
-                go mod download
-    
-          - name: Pass if changelog entry exists
-            if: steps.changelog_check.outputs.exists == 'true'
-            run: |
-              echo "Changelog entry exists."
-              exit 0
-    
-          - name: Fail if changelog entry is missing and required
-            if: steps.changelog_check.outputs.exists == 'false'
-            run: |
-              echo "🛑 Changelog entry required to merge."
-              exit 1
-    
-      changelog-skip:
-        name: Check Changelog
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changelog') || github.actor == 'dependabot[bot]' }}
-        runs-on: ubuntu-latest
-        permissions:
-          contents: read
-          #issues: write
-          pull-requests: write
-        steps:
-          - name: Find comment
-            if: github.actor != 'dependabot[bot]'
-            uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
-            id: fc
-            with:
-              issue-number: ${{ github.event.pull_request.number }}
-              comment-author: github-actions[bot]
-              body-includes: "<!-- changelog -->"
-    
-          - name: Delete comment
-            uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-            if: github.actor != 'dependabot[bot]' && steps.fc.outputs.comment-id != ''
-            with:
-              script: |
-                github.rest.issues.deleteComment({
-                  ...context.repo,
-                  comment_id: ${{ steps.fc.outputs.comment-id }},
-                });
-    
-          - name: Pass (skip)
-            run: exit 0
+concurrency:
+  group: ${{ format('{0}-{1}-{2}-{3}-{4}', github.workflow, github.event_name, github.ref, github.base_ref || null, github.head_ref || null) }}
+  cancel-in-progress: true
+
+jobs:
+  changelog-existence:
+    name: Check Changelog
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') && github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read       # Required for checkout
+      pull-requests: read  # Only need to read PR info, not write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Output GitHub Variables
+        run: env | grep GITHUB
+
+      - name: Check if changelog file was added
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changelog_check
+        with:
+          filters: |
+            exists:
+              - added|modified: '.changes/unreleased/**.yaml'
+
+      - name: Setup Go
+        if: steps.changelog_check.outputs.exists == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+            
+      - name: Install Changie
+        if: steps.changelog_check.outputs.exists == 'true'
+        run: |
+            go install github.com/miniscruff/changie@latest
+            go mod download
+
+      - name: Pass if changelog entry exists
+        if: steps.changelog_check.outputs.exists == 'true'
+        run: |
+          echo "Changelog entry exists."
+          exit 0
+
+      - name: Fail if changelog entry is missing and required
+        if: steps.changelog_check.outputs.exists == 'false'
+        run: |
+          echo "🛑 Changelog entry required to merge."
+          exit 1
+
+  changelog-skip:
+    name: Check Changelog
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changelog') || github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read      # Required for checkout
+      pull-requests: write # Required for comment deletion
+    steps:
+      - name: Find comment
+        if: github.actor != 'dependabot[bot]'
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: "<!-- changelog -->"
+
+      - name: Delete comment
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        if: github.actor != 'dependabot[bot]' && steps.fc.outputs.comment-id != ''
+        with:
+          script: |
+            github.rest.issues.deleteComment({
+              ...context.repo,
+              comment_id: ${{ steps.fc.outputs.comment-id }},
+            });
+
+      - name: Pass (skip)
+        run: exit 0

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,15 +6,13 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  # Optional: allow read access to pull request. Use with `only-new-issues` option.
-  pull-requests: read
-
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read       # Required for checkout
+      pull-requests: read  # Required for reviewing PRs
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -6,14 +6,13 @@ on:
     - cron: '0 8 * * 1'
   workflow_dispatch: # Allow manual triggering
 
-permissions:
-  issues: write
-  pull-requests: read
-
 jobs:
   metrics:
     name: Repository Metrics Collection
     runs-on: ubuntu-latest
+    permissions:
+      issues: read      
+      pull-requests: read
     steps:
       - name: Get date for query
         id: date

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,14 +8,11 @@ on:
     tags:
       - 'v*'
 
-# Releases need permissions to read and write the repository contents.
-# GitHub considers creating releases and uploading assets as writing contents.
-permissions:
-  contents: write
-
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required for creating releases
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1

--- a/.github/workflows/release_prep.yml
+++ b/.github/workflows/release_prep.yml
@@ -2,12 +2,11 @@ name: Release Preparation
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 jobs:
   prepare-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required for committing changes and creating tags
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -14,13 +14,11 @@ concurrency:
   group: acceptancetests
   cancel-in-progress: false
 
-permissions:
-  id-token: write # This is required for requesting the JWT
-  contents: read  # This is required for actions/checkout
-
 jobs:
   should_run:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Required for checkout
     if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-acceptance-tests'))
     outputs:
       acceptance_tests: ${{ steps.set_acceptance_tests.outputs.acceptance_tests }}
@@ -28,10 +26,12 @@ jobs:
       - id: set_acceptance_tests
         name: Only run acceptance tests if necessary
         run: echo "acceptance_tests=true" >> $GITHUB_OUTPUT
-  # ensure go.mod and go.sum are updated
+
   depscheck:
     name: Check Dependencies
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Required for checkout
     needs: should_run
     if: ${{ needs.should_run.outputs.acceptance_tests == 'true' }}
     steps:
@@ -58,10 +58,11 @@ jobs:
         git diff --exit-code -- go.mod go.sum || \
         (echo; echo "Unexpected difference in go.mod/go.sum files. Run 'go mod tidy' command or revert any go.mod/go.sum changes and commit."; exit 1)
 
-  # ensure the code builds
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Required for checkout
     needs: should_run
     if: ${{ needs.should_run.outputs.acceptance_tests == 'true' }}
     timeout-minutes: 5
@@ -95,6 +96,9 @@ jobs:
     needs: [build, should_run]
     if: ${{ needs.should_run.outputs.acceptance_tests == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC authentication
+      contents: read  # Required for checkout
     steps:
     
     - name: Harden Runner

--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -11,6 +11,8 @@ jobs:
   depscheck:
     name: Check Dependencies
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Required for checkout
     steps:
 
     - name: Harden Runner
@@ -40,6 +42,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read  # Required for checkout
     steps:
 
     - name: Harden Runner
@@ -70,6 +74,8 @@ jobs:
     name: Unit Test
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Required for checkout
     steps:
 
     - name: Harden Runner
@@ -109,6 +115,8 @@ jobs:
     name: Check Generated Docs
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Required for checkout
     steps:
 
       - name: Harden Runner


### PR DESCRIPTION
This pull request includes several changes to the permissions settings in various GitHub Actions workflow files. The main goal is to ensure that each job has the minimum required permissions for its tasks, improving security and maintaining the principle of least privilege.

### Permissions Adjustments in GitHub Actions Workflows:

* [`.github/workflows/check_changie_comment_on_pr.yml`](diffhunk://#diff-dc06ad408e877ac2ac90b105bac6d47d4b9b3431bacd0b15fb7a9d2b439240f9L14-R21): Adjusted permissions for the `changelog-existence` and `check-changelog` jobs to read-only access for contents and pull-requests. [[1]](diffhunk://#diff-dc06ad408e877ac2ac90b105bac6d47d4b9b3431bacd0b15fb7a9d2b439240f9L14-R21) [[2]](diffhunk://#diff-dc06ad408e877ac2ac90b105bac6d47d4b9b3431bacd0b15fb7a9d2b439240f9R66-R68)

* [`.github/workflows/golangci-lint.yml`](diffhunk://#diff-d9a956120ac84289d2650137f64bd8f0893331de05e44cc41899dd984c9e0d48L9-R15): Updated permissions for the `golangci` job to read-only access for contents and pull-requests.

* [`.github/workflows/metrics.yml`](diffhunk://#diff-42d31188c1d75b9460b01dc33518bf940a893261f8ea207e3cd6a1d5d485e020L9-R15): Modified permissions for the `metrics` job to read-only access for issues and pull-requests.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L11-R15): Set permissions for the `goreleaser` job to write access for contents, necessary for creating releases.

* [`.github/workflows/release_prep.yml`](diffhunk://#diff-dffd297667becf7a7442547cf1a4670fd12f3844871a4492bad67d49d574db18L5-R9): Adjusted permissions for the `prepare-release` job to write access for contents, required for committing changes and creating tags.

* [`.github/workflows/run_tests.yml`](diffhunk://#diff-c2e9f7c1bfaf65da79bbd29ed3ce389b2acc8b4099a257914a7292a66e6b9bc9L17-R34): Updated permissions for multiple jobs (`should_run`, `depscheck`, `build`, `test`) to read-only access for contents and added write access for id-token where required. [[1]](diffhunk://#diff-c2e9f7c1bfaf65da79bbd29ed3ce389b2acc8b4099a257914a7292a66e6b9bc9L17-R34) [[2]](diffhunk://#diff-c2e9f7c1bfaf65da79bbd29ed3ce389b2acc8b4099a257914a7292a66e6b9bc9L61-R65) [[3]](diffhunk://#diff-c2e9f7c1bfaf65da79bbd29ed3ce389b2acc8b4099a257914a7292a66e6b9bc9R99-R101)

* [`.github/workflows/terraform_provider.yml`](diffhunk://#diff-9fa590c928d7324e2af24ae397276bc6a73b89ef6082dfb0eb440b17f527dc0fR14-R15): Adjusted permissions for multiple jobs (`depscheck`, `build`, `unit test`, `check generated docs`) to read-only access for contents. [[1]](diffhunk://#diff-9fa590c928d7324e2af24ae397276bc6a73b89ef6082dfb0eb440b17f527dc0fR14-R15) [[2]](diffhunk://#diff-9fa590c928d7324e2af24ae397276bc6a73b89ef6082dfb0eb440b17f527dc0fR45-R46) [[3]](diffhunk://#diff-9fa590c928d7324e2af24ae397276bc6a73b89ef6082dfb0eb440b17f527dc0fR77-R78) [[4]](diffhunk://#diff-9fa590c928d7324e2af24ae397276bc6a73b89ef6082dfb0eb440b17f527dc0fR118-R119)