### PR TITLE
Fix CalculateSHA256 function to validate file type

### DIFF
--- a/.changes/unreleased/fixed-20250411-043430.yaml
+++ b/.changes/unreleased/fixed-20250411-043430.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Improved file hashing to check if file is a real file and not a symbolic link
+time: 2025-04-11T04:34:30.505953343Z
+custom:
+    Issue: "698"

--- a/.github/copilot-commit-message-instructions.md
+++ b/.github/copilot-commit-message-instructions.md
@@ -1,0 +1,3 @@
+Write commit messages that conform to the Convention Commits 1.0.0 specification
+
+#fetch https://www.conventionalcommits.org/en/v1.0.0/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -61,5 +61,10 @@
         "--fast"
     ],
     "makefile.configureOnOpen": false,
-    "chat.mcp.discovery.enabled": true
+    "chat.mcp.discovery.enabled": true,
+    "github.copilot.chat.commitMessageGeneration.instructions": [
+        {
+            "file": ".github/copilot-commit-message-instructions.md"
+        }
+    ]
 }

--- a/internal/helpers/hash.go
+++ b/internal/helpers/hash.go
@@ -15,6 +15,21 @@ import (
 // If the file does not exist, it returns an empty string without an error.
 // For other errors (e.g., permission issues), it returns the error.
 func CalculateSHA256(filePath string) (string, error) {
+	fileInfo, err := os.Lstat(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// File does not exist; return empty checksum
+			return "", nil
+		}
+		// An unexpected error occurred; return it
+		return "", fmt.Errorf("failed to stat file '%s': %w", filePath, err)
+	}
+
+	// Check if the file is a symbolic link
+	if !fileInfo.Mode().IsRegular() {
+		return "", fmt.Errorf("file '%s' is not a regular file", filePath)
+	}
+	
 	// Attempt to open the file directly
 	file, err := os.Open(filePath)
 	if err != nil {

--- a/internal/helpers/hash.go
+++ b/internal/helpers/hash.go
@@ -29,7 +29,7 @@ func CalculateSHA256(filePath string) (string, error) {
 	if !fileInfo.Mode().IsRegular() {
 		return "", fmt.Errorf("file '%s' is not a regular file", filePath)
 	}
-	
+
 	// Attempt to open the file directly
 	file, err := os.Open(filePath)
 	if err != nil {

--- a/internal/helpers/hash.go
+++ b/internal/helpers/hash.go
@@ -27,7 +27,7 @@ func CalculateSHA256(filePath string) (string, error) {
 
 	// Check if the file is a symbolic link
 	if !fileInfo.Mode().IsRegular() {
-		return "", fmt.Errorf("file '%s' is not a regular file", filePath)
+		return "", fmt.Errorf("symbolic links are not allowed '%s'", filePath)
 	}
 
 	// Attempt to open the file directly

--- a/internal/helpers/hash_fuzz_test.go
+++ b/internal/helpers/hash_fuzz_test.go
@@ -12,7 +12,6 @@ import (
 
 // FuzzCalculateSHA256 is a fuzz test for the CalculateSHA256 function.
 func FuzzCalculateSHA256(f *testing.F) {
-
 	tmp := f.TempDir()
 	expected := tmp + "/test.txt"
 	err := os.WriteFile(expected, []byte("same"), 0644)
@@ -29,9 +28,9 @@ func FuzzCalculateSHA256(f *testing.F) {
 	f.Add("/path/with/illegal|char")
 	f.Add("/path/with/<>*?")
 	f.Add("/path/with/\\backslashes")
-	f.Add("/dev/null")                    // Reserved name on Linux
-	f.Add("CON")                          // Reserved name on Windows
-	f.Add(string(make([]byte, 300, 300))) // Extremely long path
+	f.Add("/dev/null")               // Reserved name on Linux
+	f.Add("CON")                     // Reserved name on Windows
+	f.Add(string(make([]byte, 300))) // Extremely long path
 	f.Add("../relative/path")
 	f.Add("./current/dir")
 	f.Add(" ")                    // Single space

--- a/internal/helpers/hash_fuzz_test.go
+++ b/internal/helpers/hash_fuzz_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package helpers_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/microsoft/terraform-provider-power-platform/internal/helpers"
+)
+
+// FuzzCalculateSHA256 is a fuzz test for the CalculateSHA256 function.
+func FuzzCalculateSHA256(f *testing.F) {
+
+	tmp := f.TempDir()
+	expected := tmp + "/test.txt"
+	err := os.WriteFile(expected, []byte("same"), 0644)
+	if err != nil {
+		f.Fatal(err)
+	}
+
+	// Add initial seed corpus
+	f.Add(expected)
+	f.Add("") // Empty string
+	f.Add("/invalid/path/to/file")
+
+	// Add additional edge cases to the seed corpus
+	f.Add("/path/with/illegal|char")
+	f.Add("/path/with/<>*?")
+	f.Add("/path/with/\\backslashes")
+	f.Add("/dev/null")                    // Reserved name on Linux
+	f.Add("CON")                          // Reserved name on Windows
+	f.Add(string(make([]byte, 300, 300))) // Extremely long path
+	f.Add("../relative/path")
+	f.Add("./current/dir")
+	f.Add(" ")                    // Single space
+	f.Add("\n")                   // Newline character
+	f.Add("Z:/nonexistent/drive") // Nonexistent drive on Windows
+	f.Add("//network/share")
+	f.Add("\\\\network\\share")
+	f.Add("/dev/random")  // Special device file on Linux
+	f.Add("/dev/urandom") // Special device file on Linux
+
+	f.Fuzz(func(t *testing.T, filePath string) {
+		// Call the function with the fuzzed input
+		_, err := helpers.CalculateSHA256(filePath)
+
+		// Ensure the function does not panic and handles errors gracefully
+		if err != nil {
+			t.Logf("Expected error for input '%s': %v", filePath, err)
+		}
+	})
+}


### PR DESCRIPTION
This pull request includes several changes aimed at improving file hashing, adding commit message instructions, and enhancing testing. The most important changes are grouped into improvements to file hashing, commit message instructions, and testing.

Improvements to file hashing:

* [`internal/helpers/hash.go`](diffhunk://#diff-1dd00b7482f63999ae2beb8156bafbd81efc43df3c2cd5b5d4296d9dece5f0e3R18-R32): Added checks to ensure the file is a regular file and not a symbolic link before attempting to calculate its SHA256 hash.

Commit message instructions:

* [`.github/copilot-commit-message-instructions.md`](diffhunk://#diff-70f95a9efd88a2ec38593a8ba9a294e25c2a0cd823204d2005fbc224887323b0R1-R3): Added instructions to write commit messages conforming to the Convention Commits 1.0.0 specification.
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L64-R69): Updated settings to include the path to the commit message instructions file.

Testing enhancements:

* [`internal/helpers/hash_fuzz_test.go`](diffhunk://#diff-637c97d4eb652b50aabab659b60e1442762fb195058b6507d595747e1e8b5c2fR1-R54): Added a fuzz test for the `CalculateSHA256` function to ensure it handles various edge cases and errors gracefully.

Additionally, a change log entry was added to document the improvement in file hashing:

* [`.changes/unreleased/fixed-20250411-043430.yaml`](diffhunk://#diff-647f5dfc85f245f7299e1017bba04e005c7a63453d4f623c0f2fe458f03f357cR1-R5): Documented the improvement in file hashing to check if a file is a real file and not a symbolic link.