### PR TITLE
Operation lifecycle operation continue on HTTP 409 responses

### DIFF
--- a/.changes/unreleased/added-20250424-132557.yaml
+++ b/.changes/unreleased/added-20250424-132557.yaml
@@ -1,0 +1,5 @@
+kind: added
+body: Operation lifecycle operation continue on HTTP 409 responses
+time: 2025-04-24T13:25:57.572972549Z
+custom:
+    Issue: "719"

--- a/internal/api/lifecycle.go
+++ b/internal/api/lifecycle.go
@@ -66,7 +66,7 @@ func (client *Client) DoWaitForLifecycleOperationStatus(ctx context.Context, res
 
 	for {
 		lifecycleResponse := LifecycleDto{}
-		response, err = client.Execute(ctx, nil, "GET", locationHeader, nil, nil, []int{http.StatusOK}, &lifecycleResponse)
+		response, err = client.Execute(ctx, nil, "GET", locationHeader, nil, nil, []int{http.StatusOK, http.StatusConflict}, &lifecycleResponse)
 		if err != nil {
 			return nil, err
 		}
@@ -76,8 +76,11 @@ func (client *Client) DoWaitForLifecycleOperationStatus(ctx context.Context, res
 			return nil, err
 		}
 
-		tflog.Debug(ctx, "Lifecycle Operation State: '"+lifecycleResponse.State.Id+"'")
 		tflog.Debug(ctx, "Lifecycle Operation HTTP Status: '"+response.HttpResponse.Status+"'")
+		if response.HttpResponse.StatusCode == http.StatusConflict {
+			continue
+		}
+		tflog.Debug(ctx, "Lifecycle Operation State: '"+lifecycleResponse.State.Id+"'")
 
 		if lifecycleResponse.State.Id == "Succeeded" || lifecycleResponse.State.Id == "Failed" {
 			return &lifecycleResponse, nil

--- a/internal/services/application/api_application.go
+++ b/internal/services/application/api_application.go
@@ -123,9 +123,14 @@ func (client *client) InstallApplicationInEnvironment(ctx context.Context, envir
 
 		for {
 			lifecycleResponse := environmentApplicationLifecycleDto{}
-			_, err = client.Api.Execute(ctx, nil, "GET", operationLocationHeader, nil, nil, []int{http.StatusOK}, &lifecycleResponse)
+			response, err := client.Api.Execute(ctx, nil, "GET", operationLocationHeader, nil, nil, []int{http.StatusOK, http.StatusConflict}, &lifecycleResponse)
 			if err != nil {
 				return "", err
+			}
+
+			if response.HttpResponse.StatusCode == http.StatusConflict {
+				tflog.Debug(ctx, "Lifecycle Operation HTTP Status: '"+response.HttpResponse.Status+"'")
+				continue
 			}
 
 			if lifecycleResponse.Status == "Succeeded" {

--- a/internal/services/tenant_isolation_policy/api_tenant_isolation_policy.go
+++ b/internal/services/tenant_isolation_policy/api_tenant_isolation_policy.go
@@ -165,12 +165,15 @@ func (client *Client) doWaitForLifecycleOperationStatus(ctx context.Context, res
 	}
 
 	for {
-		apiResp, err := client.Api.Execute(ctx, nil, "GET", locationHeader, nil, nil, []int{http.StatusOK, http.StatusAccepted}, nil)
+		apiResp, err := client.Api.Execute(ctx, nil, "GET", locationHeader, nil, nil, []int{http.StatusOK, http.StatusAccepted, http.StatusConflict}, nil)
 		if err != nil {
 			return nil, fmt.Errorf("error polling operation status: %v", err)
 		}
 
 		tflog.Debug(ctx, fmt.Sprintf("Operation poll status: %s", apiResp.HttpResponse.Status))
+		if apiResp.HttpResponse.StatusCode == http.StatusConflict {
+			continue
+		}
 
 		// If we get a 200 OK, the operation is complete
 		if apiResp.HttpResponse.StatusCode == http.StatusOK {


### PR DESCRIPTION
This pull request introduces changes to handle HTTP `409 Conflict` responses more gracefully across multiple lifecycle-related operations. The updates ensure that the system retries the operation instead of failing immediately when encountering a `409 Conflict`. Additionally, some redundant logging has been removed for clarity.

### Enhancements to HTTP `409 Conflict` Handling:
* **Lifecycle Operations in `internal/api/lifecycle.go`:** Modified the `DoWaitForLifecycleOperationStatus` method to include `http.StatusConflict` in the list of acceptable status codes and added logic to retry the operation when a `409 Conflict` is encountered. [[1]](diffhunk://#diff-66f38c9ec36726a5119bb84ea62c468284d58a5e6b6b25ce1a8631f01d0fba56L69-R69) [[2]](diffhunk://#diff-66f38c9ec36726a5119bb84ea62c468284d58a5e6b6b25ce1a8631f01d0fba56L79-R83)
* **Application Installation in `internal/services/application/api_application.go`:** Updated the `InstallApplicationInEnvironment` method to handle `409 Conflict` responses by retrying and logging the status.
* **Dataverse Creation in `internal/services/environment/api_environment.go`:** Enhanced the `AddDataverseToEnvironment` method to include `409 Conflict` handling and added debugging logs for better traceability.

### Code Simplification:
* **Removed Redundant Logging in `api_environment.go`:** Eliminated duplicate logging of the HTTP status during Dataverse creation to streamline the debug output.

### Consistent Conflict Handling in Tenant Isolation Policy:
* **Tenant Isolation Policy in `api_tenant_isolation_policy.go`:** Updated the `doWaitForLifecycleOperationStatus` method to handle `409 Conflict` responses by retrying the operation.