### PR TITLE
Fix retryAfter function to properly handle all formats of Retry-After HTTP header as defined in RFC 7231

### DIFF
--- a/.changes/unreleased/fixed-20250424-150958.yaml
+++ b/.changes/unreleased/fixed-20250424-150958.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Fix retryAfter function to properly handle all formats of Retry-After HTTP header as defined in RFC 7231
+time: 2025-04-24T15:09:58.885875991Z
+custom:
+    Issue: "702"

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,13 @@
+{
+    "servers": {
+        "mcp/fetch": {
+            "command": "docker",
+            "args": [
+                "run",
+                "-i",
+                "--rm",
+                "mcp/fetch"
+            ]
+        }
+    }
+}

--- a/internal/api/request.go
+++ b/internal/api/request.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"runtime"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -98,15 +99,33 @@ func (apiResponse *Response) GetHeader(name string) string {
 
 func retryAfter(ctx context.Context, resp *http.Response) time.Duration {
 	retryHeader := resp.Header.Get(constants.HEADER_RETRY_AFTER)
-	tflog.Debug(ctx, "Retry Header: "+retryHeader)
-
-	retryAfter, err := time.ParseDuration(retryHeader)
-	if err != nil {
-		// default retry after 5-10 seconds
+	if retryHeader == "" {
 		return DefaultRetryAfter()
 	}
+	tflog.Debug(ctx, "Retry Header: "+retryHeader)
 
-	return retryAfter
+	// Check if the header is a delta-seconds value (integer)
+	if deltaSeconds, err := strconv.Atoi(retryHeader); err == nil {
+		return time.Duration(deltaSeconds) * time.Second
+	}
+
+	// Check if the header is an HTTP-date
+	if retryTime, err := http.ParseTime(retryHeader); err == nil {
+		// Calculate duration until the retry time
+		duration := time.Until(retryTime)
+		if duration > 0 {
+			return duration
+		}
+	}
+
+	// Try to parse as a duration string (non-standard but sometimes used)
+	if retryAfter, err := time.ParseDuration(retryHeader); err == nil {
+		return retryAfter
+	}
+
+	// Fallback to a default retry duration
+	tflog.Warn(ctx, "Invalid Retry-After header, falling back to default")
+	return DefaultRetryAfter()
 }
 
 func (client *Client) buildCorrelationHeaders(ctx context.Context) (sessionId string, requestId string) {


### PR DESCRIPTION
This pull request addresses a bug in the `retryAfter` function, adds a configuration file for a development tool, and includes minor dependency updates. The most significant change is the enhancement of the `retryAfter` function to handle all formats of the `Retry-After` HTTP header as defined in RFC 7231.

### Bug Fixes:
* Enhanced the `retryAfter` function in `internal/api/request.go` to properly handle all formats of the `Retry-After` HTTP header, including delta-seconds, HTTP-date, and non-standard duration strings, with a fallback to a default duration.
* Added a changelog entry in `.changes/unreleased/fixed-20250424-150958.yaml` documenting the fix for the `retryAfter` function.

### Development Tooling:
* Added a new `.vscode/mcp.json` configuration file to define a Docker-based server command for `mcp/fetch`.

### Dependency Updates:
* Imported the `strconv` package in `internal/api/request.go` to support parsing delta-seconds values in the `Retry-After` header.