### PR TITLE
Eduardodfmex/718 example resource powerplatform enterprise policy doesn't work

### DIFF
--- a/examples/resources/powerplatform_enterprise_policy/encryption/main.tf
+++ b/examples/resources/powerplatform_enterprise_policy/encryption/main.tf
@@ -20,66 +20,6 @@ terraform {
   }
 }
 
-variable "environment_id" {
-  description = "The ID of the environment"
-  type        = string
-  validation {
-    condition     = length(var.environment_id) > 0
-    error_message = "The environment ID must not be empty"
-  }
-}
-
-variable "should_register_provider" {
-  description = "A flag to determine if the PowerPlatfomr provider should be registered in the subscription"
-  type        = bool
-  default     = true
-}
-
-variable "resource_group_name" {
-  description = "The name of the resource group"
-  type        = string
-  validation {
-    condition     = length(var.resource_group_name) > 0
-    error_message = "The resource group name must not be empty"
-  }
-}
-
-variable "resource_group_location" {
-  description = "The location of the resource group"
-  type        = string
-  validation {
-    condition     = length(var.resource_group_location) > 0
-    error_message = "The resource group location must not be empty"
-  }
-
-}
-
-variable "enterprise_policy_name" {
-  description = "The name of the enterprise policy"
-  type        = string
-  validation {
-    condition     = length(var.enterprise_policy_name) > 0
-    error_message = "The enterprise policy name must not be empty"
-  }
-}
-
-variable "enterprise_policy_location" {
-  description = "The location of the enterprise policy"
-  type        = string
-  validation {
-    condition     = length(var.enterprise_policy_location) > 0
-    error_message = "The enterprise policy location must not be empty"
-  }
-}
-
-variable "keyvault_name" {
-  description = "The name of the key vault"
-  type        = string
-  validation {
-    condition     = length(var.keyvault_name) > 0
-    error_message = "The key vault name must not be empty"
-  }
-}
 
 resource "azurerm_resource_group" "resource_group" {
   name     = var.resource_group_name

--- a/examples/resources/powerplatform_enterprise_policy/encryption/main.tf
+++ b/examples/resources/powerplatform_enterprise_policy/encryption/main.tf
@@ -13,6 +13,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~>4.16.0"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.7.0"
+    }
   }
 }
 

--- a/examples/resources/powerplatform_enterprise_policy/encryption/main.tf
+++ b/examples/resources/powerplatform_enterprise_policy/encryption/main.tf
@@ -1,11 +1,17 @@
 terraform {
   required_version = "> 1.7.0"
   required_providers {
+    powerplatform = {
+      source  = "microsoft/power-platform"
+      version = "~>3.5.0"
+    }
     azapi = {
-      source = "azure/azapi"
+      source  = "azure/azapi"
+      version = "~>2.2.0"
     }
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
+      version = "~>4.16.0"
     }
   }
 }

--- a/examples/resources/powerplatform_enterprise_policy/encryption/variables.tf
+++ b/examples/resources/powerplatform_enterprise_policy/encryption/variables.tf
@@ -1,0 +1,60 @@
+variable "environment_id" {
+  description = "The ID of the environment"
+  type        = string
+  validation {
+    condition     = length(var.environment_id) > 0
+    error_message = "The environment ID must not be empty"
+  }
+}
+
+variable "should_register_provider" {
+  description = "A flag to determine if the PowerPlatfomr provider should be registered in the subscription"
+  type        = bool
+  default     = true
+}
+
+variable "resource_group_name" {
+  description = "The name of the resource group"
+  type        = string
+  validation {
+    condition     = length(var.resource_group_name) > 0
+    error_message = "The resource group name must not be empty"
+  }
+}
+
+variable "resource_group_location" {
+  description = "The location of the resource group"
+  type        = string
+  validation {
+    condition     = length(var.resource_group_location) > 0
+    error_message = "The resource group location must not be empty"
+  }
+
+}
+
+variable "enterprise_policy_name" {
+  description = "The name of the enterprise policy"
+  type        = string
+  validation {
+    condition     = length(var.enterprise_policy_name) > 0
+    error_message = "The enterprise policy name must not be empty"
+  }
+}
+
+variable "enterprise_policy_location" {
+  description = "The location of the enterprise policy"
+  type        = string
+  validation {
+    condition     = length(var.enterprise_policy_location) > 0
+    error_message = "The enterprise policy location must not be empty"
+  }
+}
+
+variable "keyvault_name" {
+  description = "The name of the key vault"
+  type        = string
+  validation {
+    condition     = length(var.keyvault_name) > 0
+    error_message = "The key vault name must not be empty"
+  }
+}

--- a/examples/resources/powerplatform_enterprise_policy/network_injection/main.tf
+++ b/examples/resources/powerplatform_enterprise_policy/network_injection/main.tf
@@ -1,6 +1,10 @@
 terraform {
   required_version = "> 1.7.0"
   required_providers {
+    powerplatform = {
+      source  = "microsoft/power-platform"
+      version = "~>3.5.0"
+    }
     azapi = {
       source  = "azure/azapi"
       version = "~>2.2.0"

--- a/examples/resources/powerplatform_enterprise_policy/network_injection/main.tf
+++ b/examples/resources/powerplatform_enterprise_policy/network_injection/main.tf
@@ -16,67 +16,6 @@ terraform {
   }
 }
 
-variable "environment_id" {
-  description = "The ID of the environment"
-  type        = string
-  validation {
-    condition     = length(var.environment_id) > 0
-    error_message = "The environment ID must not be empty"
-  }
-}
-
-variable "should_register_provider" {
-  description = "A flag to determine if the PowerPlatfomr provider should be registered in the subscription"
-  type        = bool
-  default     = true
-}
-
-variable "resource_group_name" {
-  description = "The name of the resource group"
-  type        = string
-  validation {
-    condition     = length(var.resource_group_name) > 0
-    error_message = "The resource group name must not be empty"
-  }
-}
-
-
-variable "resource_group_location" {
-  description = "The location of the resource group"
-  type        = string
-  validation {
-    condition     = length(var.resource_group_location) > 0
-    error_message = "The resource group location must not be empty"
-  }
-
-}
-
-variable "vnet_locations" {
-  description = "The location of the virtual networks"
-  type        = list(string)
-  validation {
-    condition     = length(var.vnet_locations) != 1
-    error_message = "Two virtual network locations in the same region must be provided"
-  }
-}
-
-variable "enterprise_policy_name" {
-  description = "The name of the enterprise policy"
-  type        = string
-  validation {
-    condition     = length(var.enterprise_policy_name) > 0
-    error_message = "The enterprise policy name must not be empty"
-  }
-}
-
-variable "enterprise_policy_location" {
-  description = "The location of the enterprise policy"
-  type        = string
-  validation {
-    condition     = length(var.enterprise_policy_location) > 0
-    error_message = "The enterprise policy location must not be empty"
-  }
-}
 
 resource "azurerm_resource_group" "resource_group" {
   name     = var.resource_group_name
@@ -148,13 +87,6 @@ resource "azapi_resource" "powerplatform_policy" {
   }
 }
 
-resource "powerplatform_enterprise_policy" "network_injection" {
-  environment_id = var.environment_id
-  system_id      = azapi_resource.powerplatform_policy.output.properties.systemId
-  policy_type    = "NetworkInjection"
-
-  depends_on = [powerplatform_managed_environment.managed_development]
-}
 
 output "enterprise_policy_system_id" {
   value = azapi_resource.powerplatform_policy.output.properties.systemId

--- a/examples/resources/powerplatform_enterprise_policy/network_injection/outputs.tf
+++ b/examples/resources/powerplatform_enterprise_policy/network_injection/outputs.tf
@@ -1,0 +1,9 @@
+output "policy_system_id" {
+  description = "The system ID of the enterprise policy created in Azure"
+  value       = azapi_resource.powerplatform_policy.output.properties.systemId
+}
+
+output "policy_id" {
+  description = "The ID of the enterprise policy resource in Azure"
+  value       = azapi_resource.powerplatform_policy.output.id
+}

--- a/examples/resources/powerplatform_enterprise_policy/network_injection/variables.tf
+++ b/examples/resources/powerplatform_enterprise_policy/network_injection/variables.tf
@@ -1,0 +1,52 @@
+variable "should_register_provider" {
+  description = "A flag to determine if the PowerPlatfomr provider should be registered in the subscription"
+  type        = bool
+  default     = true
+}
+
+variable "resource_group_name" {
+  description = "The name of the resource group"
+  type        = string
+  validation {
+    condition     = length(var.resource_group_name) > 0
+    error_message = "The resource group name must not be empty"
+  }
+}
+
+
+variable "resource_group_location" {
+  description = "The location of the resource group"
+  type        = string
+  validation {
+    condition     = length(var.resource_group_location) > 0
+    error_message = "The resource group location must not be empty"
+  }
+
+}
+
+variable "vnet_locations" {
+  description = "The location of the virtual networks"
+  type        = list(string)
+  validation {
+    condition     = length(var.vnet_locations) != 1
+    error_message = "Two virtual network locations in the same region must be provided"
+  }
+}
+
+variable "enterprise_policy_name" {
+  description = "The name of the enterprise policy"
+  type        = string
+  validation {
+    condition     = length(var.enterprise_policy_name) > 0
+    error_message = "The enterprise policy name must not be empty"
+  }
+}
+
+variable "enterprise_policy_location" {
+  description = "The location of the enterprise policy"
+  type        = string
+  validation {
+    condition     = length(var.enterprise_policy_location) > 0
+    error_message = "The enterprise policy location must not be empty"
+  }
+}

--- a/examples/resources/powerplatform_enterprise_policy/resource.tf
+++ b/examples/resources/powerplatform_enterprise_policy/resource.tf
@@ -64,13 +64,11 @@ resource "powerplatform_managed_environment" "managed_development" {
 }
 
 
-// module that creates all azure resources required for the network injection policy and the policy itself
+// module that creates all azure resources required for the network injection (resource group, vnet's and subnet's) policy and the policy itself
 module "network_injection" {
   source = "./network_injection"
 
   should_register_provider = false
-
-  environment_id = powerplatform_environment.example_environment.id
 
   resource_group_name        = "rg_example_network_injection_policy"
   resource_group_location    = local.europe_location[0].azure_regions[0]
@@ -95,4 +93,12 @@ module "encryption" {
 
   // let's wait for first policy to be executed
   depends_on = [powerplatform_enterprise_policy.network_injection]
+}
+
+resource "powerplatform_enterprise_policy" "network_injection" {
+  environment_id = powerplatform_environment.example_environment.id
+  system_id      = module.network_injection.policy_system_id
+  policy_type    = "NetworkInjection"
+
+  depends_on = [powerplatform_managed_environment.managed_development]
 }

--- a/examples/resources/powerplatform_enterprise_policy/resource.tf
+++ b/examples/resources/powerplatform_enterprise_policy/resource.tf
@@ -3,15 +3,15 @@ terraform {
   required_providers {
     powerplatform = {
       source  = "microsoft/power-platform"
-      version = "~>3.0"
+      version = "~>3.5.0"
     }
     azapi = {
       source  = "azure/azapi"
-      version = "~>2.0"
+      version = "~>2.2.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>4.8"
+      version = "~>4.16.0"
     }
   }
 }


### PR DESCRIPTION
This pull request refactors and updates Terraform configurations for Power Platform enterprise policies by modularizing variable definitions, upgrading provider versions, and restructuring resources. The most significant changes include moving variable definitions to separate files, upgrading required provider versions, and restructuring the `network_injection` policy to improve modularity and maintainability.

### Provider Updates
* Updated provider versions in `main.tf` files across multiple modules to ensure compatibility and leverage new features:
  - `powerplatform` upgraded to `~>3.5.0`. [[1]](diffhunk://#diff-ec806ea5b4d9d320d048ff4fe6fba1bb9246ef31d5b57c1007e3fa4bfae6365eR4-L72) [[2]](diffhunk://#diff-5a479e3d8144b6f4602e78fcd73d679db387778ba36d9dbed4abca6484eea9eeR4-R7) [[3]](diffhunk://#diff-7cec343c8fd2ef23e8857a0bd0df50fb74ffc88f4f1405f3d3cda1fb333b4c3fL6-R14)
  - `azapi` upgraded to `~>2.2.0`. [[1]](diffhunk://#diff-ec806ea5b4d9d320d048ff4fe6fba1bb9246ef31d5b57c1007e3fa4bfae6365eR4-L72) [[2]](diffhunk://#diff-7cec343c8fd2ef23e8857a0bd0df50fb74ffc88f4f1405f3d3cda1fb333b4c3fL6-R14)
  - `azurerm` upgraded to `~>4.16.0`. [[1]](diffhunk://#diff-ec806ea5b4d9d320d048ff4fe6fba1bb9246ef31d5b57c1007e3fa4bfae6365eR4-L72) [[2]](diffhunk://#diff-7cec343c8fd2ef23e8857a0bd0df50fb74ffc88f4f1405f3d3cda1fb333b4c3fL6-R14)
  - Added `time` provider with version `>= 0.7.0` in `encryption/main.tf`.

### Variable Refactoring
* Moved variable definitions from `main.tf` to dedicated `variables.tf` files for better modularity and reusability:
  - `encryption` module variables moved to `variables.tf`.
  - `network_injection` module variables moved to `variables.tf`.

### Resource and Module Restructuring
* Restructured the `network_injection` policy:
  - Removed the `powerplatform_enterprise_policy` resource from `network_injection/main.tf`.
  - Added a new `powerplatform_enterprise_policy` resource in `resource.tf` to centralize policy creation.
  - Updated the `network_injection` module to exclude `environment_id`.

### Outputs
* Added new outputs to the `network_injection` module for better visibility of created resources:
  - `policy_system_id` and `policy_id` outputs defined in `outputs.tf`.