### PR TITLE
fix(auth): handle nil Count in getAssertion response from OIDC provider

### DIFF
--- a/.changes/unreleased/fixed-20250425-201842.yaml
+++ b/.changes/unreleased/fixed-20250425-201842.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Potential Nil Dereference in getAssertion Method.
+time: 2025-04-25T20:18:42.603194108Z
+custom:
+    Issue: "730"

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -349,7 +349,7 @@ func (w *OidcCredential) getAssertion(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("getAssertion: cannot unmarshal response: %v", err)
 	}
 
-	if tokenRes == nil || tokenRes.Value == nil {
+	if tokenRes.Count == nil || tokenRes.Value == nil {
 		return "", errors.New("getAssertion: nil JWT assertion received from OIDC provider")
 	}
 

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -349,7 +349,7 @@ func (w *OidcCredential) getAssertion(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("getAssertion: cannot unmarshal response: %v", err)
 	}
 
-	if tokenRes.Value == nil {
+	if tokenRes.Value == nil || tokenRes.Count == nil {
 		return "", errors.New("getAssertion: nil JWT assertion received from OIDC provider")
 	}
 

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -349,7 +349,7 @@ func (w *OidcCredential) getAssertion(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("getAssertion: cannot unmarshal response: %v", err)
 	}
 
-	if tokenRes.Value == nil || tokenRes.Count == nil {
+	if tokenRes == nil || tokenRes.Value == nil {
 		return "", errors.New("getAssertion: nil JWT assertion received from OIDC provider")
 	}
 


### PR DESCRIPTION
This pull request includes a small but important change to the `internal/api/auth.go` file. The change adds an additional condition to check if `tokenRes.Count` is `nil` before proceeding, ensuring that both `Value` and `Count` are not `nil` when receiving a JWT assertion from the OIDC provider.