### PR TITLE
fix: correct typos in error messages and debug logs in User resource

### DIFF
--- a/.changes/unreleased/fixed-20250428-083052.yaml
+++ b/.changes/unreleased/fixed-20250428-083052.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Fixed misleading error message and debug log typos in the User resource
+time: 2025-04-28T08:30:52.479403707Z
+custom:
+    Issue: "709"

--- a/internal/services/authorization/resource_user.go
+++ b/internal/services/authorization/resource_user.go
@@ -168,7 +168,7 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.FullTypeName()), err.Error())
 		return
 	}
-	tflog.Debug(ctx, fmt.Sprintf("Dataverse exist in eviroment %t", hasEnvDataverse))
+	tflog.Debug(ctx, fmt.Sprintf("Dataverse exists in environment: %t", hasEnvDataverse))
 
 	newUser := userDto{}
 	if hasEnvDataverse {
@@ -236,10 +236,10 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	hasEnvDataverse, err := r.UserClient.EnvironmentHasDataverse(ctx, state.EnvironmentId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.FullTypeName()), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.FullTypeName()), err.Error())
 		return
 	}
-	tflog.Debug(ctx, fmt.Sprintf("Dataverse exist in eviroment %t", hasEnvDataverse))
+	tflog.Debug(ctx, fmt.Sprintf("Dataverse exists in environment: %t", hasEnvDataverse))
 
 	updateUser := userDto{}
 	if hasEnvDataverse {
@@ -314,10 +314,10 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	hasEnvDataverse, err := r.UserClient.EnvironmentHasDataverse(ctx, state.EnvironmentId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Client error when creating %s", r.FullTypeName()), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.FullTypeName()), err.Error())
 		return
 	}
-	tflog.Debug(ctx, fmt.Sprintf("Dataverse exist in eviroment %t", hasEnvDataverse))
+	tflog.Debug(ctx, fmt.Sprintf("Dataverse exists in environment: %t", hasEnvDataverse))
 
 	addedSecurityRoles, removedSecurityRoles := array.Diff(plan.SecurityRoles, state.SecurityRoles)
 	user := userDto{}


### PR DESCRIPTION
This pull request addresses a bug fix in the `UserResource` implementation by correcting error messages and debug log typos, ensuring more accurate and professional logging. It also updates the release notes to document the fix.

### Bug Fixes and Improvements:

* **Error Message Updates**:
  - Corrected error messages in `Create`, `Read`, and `Update` methods of `UserResource` to reflect the correct operation being performed (e.g., "creating" updated to "reading" or "updating"). (`internal/services/authorization/resource_user.go`, [[1]](diffhunk://#diff-1f9c90c2f35775511acace8d916e9e0e5cf18d4c0f5323ee6b568b01d8df19a7L239-R242) [[2]](diffhunk://#diff-1f9c90c2f35775511acace8d916e9e0e5cf18d4c0f5323ee6b568b01d8df19a7L317-R320)

* **Debug Log Typos**:
  - Fixed typos in debug log messages across `Create`, `Read`, and `Update` methods. For example, "Dataverse exist in eviroment" was corrected to "Dataverse exists in environment." (`internal/services/authorization/resource_user.go`, [[1]](diffhunk://#diff-1f9c90c2f35775511acace8d916e9e0e5cf18d4c0f5323ee6b568b01d8df19a7L171-R171) [[2]](diffhunk://#diff-1f9c90c2f35775511acace8d916e9e0e5cf18d4c0f5323ee6b568b01d8df19a7L239-R242) [[3]](diffhunk://#diff-1f9c90c2f35775511acace8d916e9e0e5cf18d4c0f5323ee6b568b01d8df19a7L317-R320)

### Documentation:

* **Release Notes**:
  - Added an entry in `.changes/unreleased/fixed-20250428-083052.yaml` to document the fix for misleading error messages and debug log typos in the `UserResource`. (`.changes/unreleased/fixed-20250428-083052.yaml`, [.changes/unreleased/fixed-20250428-083052.yamlR1-R5](diffhunk://#diff-30667f99018c9c3dc832d1d002bfd92bea03451a933a356e6b7ca1cc147d947eR1-R5))