### PR TITLE
fix: add http.StatusConflict to API response handling lifecycle operations

### DIFF
--- a/.changes/unreleased/fixed-20250428-093846.yaml
+++ b/.changes/unreleased/fixed-20250428-093846.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: 'fix: add http.StatusConflict to API response handling in enterprise and managed environment services'
+time: 2025-04-28T09:38:46.730077628Z
+custom:
+    Issue: "745"

--- a/internal/services/enterprise_policy/api_enterprise_policy.go
+++ b/internal/services/enterprise_policy/api_enterprise_policy.go
@@ -42,7 +42,7 @@ func (client *Client) LinkEnterprisePolicy(ctx context.Context, environmentId, e
 		SystemId: systemId,
 	}
 
-	apiResponse, err := client.Api.Execute(ctx, nil, "POST", apiUrl.String(), nil, linkEnterprosePolicyDto, []int{http.StatusAccepted}, nil)
+	apiResponse, err := client.Api.Execute(ctx, nil, "POST", apiUrl.String(), nil, linkEnterprosePolicyDto, []int{http.StatusAccepted, http.StatusConflict}, nil)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func (client *Client) UnLinkEnterprisePolicy(ctx context.Context, environmentId,
 	linkEnterprosePolicyDto := linkEnterprosePolicyDto{
 		SystemId: systemId,
 	}
-	apiResponse, err := client.Api.Execute(ctx, nil, "POST", apiUrl.String(), nil, linkEnterprosePolicyDto, []int{http.StatusAccepted}, nil)
+	apiResponse, err := client.Api.Execute(ctx, nil, "POST", apiUrl.String(), nil, linkEnterprosePolicyDto, []int{http.StatusAccepted, http.StatusConflict}, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/services/environment/api_environment.go
+++ b/internal/services/environment/api_environment.go
@@ -404,7 +404,7 @@ func (client *Client) ModifyEnvironmentType(ctx context.Context, environmentId, 
 		EnvironmentSku: environmentType,
 	}
 
-	apiResponse, err := client.Api.Execute(ctx, nil, "POST", apiUrl.String(), nil, modifySkuDto, []int{http.StatusAccepted, http.StatusOK}, nil)
+	apiResponse, err := client.Api.Execute(ctx, nil, "POST", apiUrl.String(), nil, modifySkuDto, []int{http.StatusAccepted, http.StatusOK, http.StatusConflict}, nil)
 	if err != nil {
 		return err
 	}
@@ -440,7 +440,7 @@ func (client *Client) CreateEnvironment(ctx context.Context, environmentToCreate
 	values := url.Values{}
 	values.Add("api-version", "2023-06-01")
 	apiUrl.RawQuery = values.Encode()
-	apiResponse, err := client.Api.Execute(ctx, nil, "POST", apiUrl.String(), nil, environmentToCreate, []int{http.StatusAccepted, http.StatusCreated, http.StatusInternalServerError}, nil)
+	apiResponse, err := client.Api.Execute(ctx, nil, "POST", apiUrl.String(), nil, environmentToCreate, []int{http.StatusAccepted, http.StatusCreated, http.StatusInternalServerError, http.StatusConflict}, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -501,7 +501,7 @@ func (client *Client) UpdateEnvironmentAiFeatures(ctx context.Context, environme
 	values := url.Values{}
 	values.Add("api-version", "2021-04-01")
 	apiUrl.RawQuery = values.Encode()
-	apiResponse, err := client.Api.Execute(ctx, nil, "PATCH", apiUrl.String(), nil, generativeAIConfig, []int{http.StatusAccepted}, nil)
+	apiResponse, err := client.Api.Execute(ctx, nil, "PATCH", apiUrl.String(), nil, generativeAIConfig, []int{http.StatusAccepted, http.StatusConflict}, nil)
 	if err != nil {
 		return err
 	}
@@ -540,7 +540,7 @@ func (client *Client) UpdateEnvironment(ctx context.Context, environmentId strin
 	// values.Add("api-version", "2022-05-01")
 	values.Add("api-version", "2021-04-01")
 	apiUrl.RawQuery = values.Encode()
-	apiResponse, err := client.Api.Execute(ctx, nil, "PATCH", apiUrl.String(), nil, environment, []int{http.StatusAccepted}, nil)
+	apiResponse, err := client.Api.Execute(ctx, nil, "PATCH", apiUrl.String(), nil, environment, []int{http.StatusAccepted, http.StatusConflict}, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/managed_environment/api_managed_environment.go
+++ b/internal/services/managed_environment/api_managed_environment.go
@@ -38,7 +38,7 @@ func (client *client) EnableManagedEnvironment(ctx context.Context, managedEnvSe
 	values.Add("api-version", "2021-04-01")
 	apiUrl.RawQuery = values.Encode()
 
-	apiResponse, err := client.Api.Execute(ctx, nil, "POST", apiUrl.String(), nil, managedEnvSettings, []int{http.StatusNoContent, http.StatusAccepted}, nil)
+	apiResponse, err := client.Api.Execute(ctx, nil, "POST", apiUrl.String(), nil, managedEnvSettings, []int{http.StatusNoContent, http.StatusAccepted, http.StatusConflict}, nil)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (client *client) DisableManagedEnvironment(ctx context.Context, environment
 		ProtectionLevel: "Basic",
 	}
 
-	apiResponse, err := client.Api.Execute(ctx, nil, "POST", apiUrl.String(), nil, managedEnv, []int{http.StatusAccepted}, nil)
+	apiResponse, err := client.Api.Execute(ctx, nil, "POST", apiUrl.String(), nil, managedEnv, []int{http.StatusAccepted, http.StatusConflict}, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This pull request addresses a bug by adding support for handling `http.StatusConflict` (409) in API response handling across enterprise, environment, and managed environment services. This ensures more robust error handling for conflict scenarios.

### API Response Handling Updates:

* **Enterprise Policy Service**:
  - Updated `LinkEnterprisePolicy` and `UnLinkEnterprisePolicy` methods to include `http.StatusConflict` in the list of acceptable response codes. (`internal/services/enterprise_policy/api_enterprise_policy.go`, [[1]](diffhunk://#diff-dcad5c91afb551cad105bcb507216f34d6829e25b22285c44473544c707af977L45-R45) [[2]](diffhunk://#diff-dcad5c91afb551cad105bcb507216f34d6829e25b22285c44473544c707af977L81-R81)

* **Environment Service**:
  - Updated methods such as `ModifyEnvironmentType`, `CreateEnvironment`, `UpdateEnvironmentAiFeatures`, and `UpdateEnvironment` to handle `http.StatusConflict` in API responses. (`internal/services/environment/api_environment.go`, [[1]](diffhunk://#diff-6939b69029f482f476bfc737204e004670b40a16e4a3a6c3af61eb9efb8244afL407-R407) [[2]](diffhunk://#diff-6939b69029f482f476bfc737204e004670b40a16e4a3a6c3af61eb9efb8244afL443-R443) [[3]](diffhunk://#diff-6939b69029f482f476bfc737204e004670b40a16e4a3a6c3af61eb9efb8244afL504-R504) [[4]](diffhunk://#diff-6939b69029f482f476bfc737204e004670b40a16e4a3a6c3af61eb9efb8244afL543-R543)

* **Managed Environment Service**:
  - Added `http.StatusConflict` handling to `EnableManagedEnvironment` and `DisableManagedEnvironment` methods. (`internal/services/managed_environment/api_managed_environment.go`, [[1]](diffhunk://#diff-54cb8722c62907a94fa72c170bfb2cea874ec34ffd35d5e498fa478106d2a464L41-R41) [[2]](diffhunk://#diff-54cb8722c62907a94fa72c170bfb2cea874ec34ffd35d5e498fa478106d2a464L77-R77)

### Documentation:

* Added a changelog entry to document the fix for adding `http.StatusConflict` handling. (`.changes/unreleased/fixed-20250428-093846.yaml`, [.changes/unreleased/fixed-20250428-093846.yamlR1-R5](diffhunk://#diff-398ea68f53c0a65483c18ca8e14ae5d7af769bf67339b167b1cb04182f4ac45bR1-R5))