### PR TITLE
Remove unnecessary flags from goreleaser ldflags configuration

### DIFF
--- a/.changes/unreleased/changed-20250428-210552.yaml
+++ b/.changes/unreleased/changed-20250428-210552.yaml
@@ -1,0 +1,5 @@
+kind: changed
+body: Include debug symbols in goreleaser builds by removing -s -w flags from ldflags
+time: 2025-04-28T21:05:52.764469281Z
+custom:
+    Issue: "736"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - '-s -w -X github.com/microsoft/terraform-provider-power-platform/common.ProviderVersion={{ .Version }} -X github.com/microsoft/terraform-provider-power-platform/common.Commit={{.Commit}} -X github.com/microsoft/terraform-provider-power-platform/common.Branch={{ .Branch }}'
+      - '-X github.com/microsoft/terraform-provider-power-platform/common.ProviderVersion={{ .Version }} -X github.com/microsoft/terraform-provider-power-platform/common.Commit={{.Commit}} -X github.com/microsoft/terraform-provider-power-platform/common.Branch={{ .Branch }}'
       
     goos:
       - freebsd


### PR DESCRIPTION
This pull request includes a minor update to the `.goreleaser.yml` file. The change removes the `-s -w` linker flags from the `ldflags` configuration, likely to include debugging information or reduce binary stripping during the build process.