### PR TITLE
Eduardodfmex/688 nil pointer dereference in regex validation

### DIFF
--- a/internal/validators/other_field_required_when_value_of_validator.go
+++ b/internal/validators/other_field_required_when_value_of_validator.go
@@ -82,8 +82,8 @@ func (av OtherFieldRequiredWhenValueOfValidator) Validate(ctx context.Context, r
 			isUnknown = strings.Contains(d.Errors()[0].Detail(), "Received unknown value") || strings.Contains(d.Errors()[0].Summary(), "Received unknown value")
 		}
 
-		if (av.OtherFieldValueRegex != nil && otherFieldValue != nil && !av.OtherFieldValueRegex.MatchString(*otherFieldValue)) || 
-		   (av.OtherFieldValueRegex == nil && (otherFieldValue == nil || *otherFieldValue == "") && !isUnknown) {
+		if (av.OtherFieldValueRegex != nil && otherFieldValue != nil && !av.OtherFieldValueRegex.MatchString(*otherFieldValue)) ||
+			(av.OtherFieldValueRegex == nil && (otherFieldValue == nil || *otherFieldValue == "") && !isUnknown) {
 			res.Diagnostics.AddError(av.ErrorMessage, av.ErrorMessage)
 		}
 	}

--- a/internal/validators/other_field_required_when_value_of_validator.go
+++ b/internal/validators/other_field_required_when_value_of_validator.go
@@ -82,7 +82,8 @@ func (av OtherFieldRequiredWhenValueOfValidator) Validate(ctx context.Context, r
 			isUnknown = strings.Contains(d.Errors()[0].Detail(), "Received unknown value") || strings.Contains(d.Errors()[0].Summary(), "Received unknown value")
 		}
 
-		if av.OtherFieldValueRegex != nil && !av.OtherFieldValueRegex.MatchString(*otherFieldValue) || av.OtherFieldValueRegex == nil && (otherFieldValue == nil || *otherFieldValue == "") && !isUnknown {
+		if (av.OtherFieldValueRegex != nil && otherFieldValue != nil && !av.OtherFieldValueRegex.MatchString(*otherFieldValue)) || 
+		   (av.OtherFieldValueRegex == nil && (otherFieldValue == nil || *otherFieldValue == "") && !isUnknown) {
 			res.Diagnostics.AddError(av.ErrorMessage, av.ErrorMessage)
 		}
 	}


### PR DESCRIPTION
This pull request includes a minor update to the `Validate` method in the `other_field_required_when_value_of_validator.go` file. The change improves the readability and logical grouping of conditions in the `if` statement.

* [`internal/validators/other_field_required_when_value_of_validator.go`](diffhunk://#diff-af5fc6d6ba835ddfdb89798b544504c7a2caf85f7e734e5850a6af4c2efc453fL85-R86): Refactored the `if` statement to group conditions more clearly by adding parentheses and restructuring the logic for better readability.