### PR TITLE
Fix #704: Replace panic with proper error handling in ExecuteApiRequest function

### DIFF
--- a/.changes/unreleased/fixed-20250430-064642.yaml
+++ b/.changes/unreleased/fixed-20250430-064642.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Replaced panic with proper error handling in ExecuteApiRequest function
+time: 2025-04-30T06:46:42.197147475Z
+custom:
+    Issue: "704"

--- a/internal/services/rest/api_rest.go
+++ b/internal/services/rest/api_rest.go
@@ -83,8 +83,9 @@ func (client *client) ExecuteApiRequest(ctx context.Context, scope *string, url,
 		h.Add(k, v)
 	}
 
-	if scope != nil {
-		return client.Api.Execute(ctx, []string{*scope}, method, url, h, body, expectedStatusCodes, nil)
+	if scope == nil {
+		return nil, errors.New("invalid input: scope or environment_id must be provided")
 	}
-	panic("scope or evironment_id must be provided")
+
+	return client.Api.Execute(ctx, []string{*scope}, method, url, h, body, expectedStatusCodes, nil)
 }

--- a/internal/services/rest/api_rest.go
+++ b/internal/services/rest/api_rest.go
@@ -84,7 +84,7 @@ func (client *client) ExecuteApiRequest(ctx context.Context, scope *string, url,
 	}
 
 	if scope == nil {
-		return nil, errors.New("invalid input: scope or environment_id must be provided")
+		return nil, errors.New("invalid input: scope must be provided")
 	}
 
 	return client.Api.Execute(ctx, []string{*scope}, method, url, h, body, expectedStatusCodes, nil)


### PR DESCRIPTION
This pull request addresses an issue in the `ExecuteApiRequest` function by replacing a `panic` statement with proper error handling. This change improves the robustness of the code and ensures better error reporting.

### Error Handling Improvements:

* [`.changes/unreleased/fixed-20250430-064642.yaml`](diffhunk://#diff-24b5fab5dd7b9f754e98f7aa97f2f7ec2f3d58e156314957c37af35476cbc4c2R1-R5): Added a changelog entry documenting the fix, specifying that the `panic` was replaced with proper error handling in the `ExecuteApiRequest` function.
* [`internal/services/rest/api_rest.go`](diffhunk://#diff-508b88487f5a19cc0a2d7da2a9819699090fcf5a64fa5f9f93c26e7a555e35c8L86-R90): Updated the `ExecuteApiRequest` function to remove the `panic` statement and replace it with an error return when the `scope` is `nil`. This ensures that invalid input is handled gracefully with a descriptive error message.