### PR TITLE
fix: refine current value check in MakeFieldRequiredWhenOtherFieldDoesNotHaveValueValidator

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,6 +60,10 @@
     "go.lintFlags": [
         "--fast"
     ],
+    //https://github.com/golang/vscode-go/blob/master/docs/debugging.md#switch-to-legacy-debug-adapter
+    "go.delveConfig": {
+        "debugAdapter": "legacy",
+    },
     "makefile.configureOnOpen": false,
     "chat.mcp.discovery.enabled": true,
     "github.copilot.chat.commitMessageGeneration.instructions": [

--- a/internal/validators/make_field_required_when_other_field_does_not_have_value_validator.go
+++ b/internal/validators/make_field_required_when_other_field_does_not_have_value_validator.go
@@ -67,7 +67,7 @@ func (av MakeFieldRequiredWhenOtherFieldDoesNotHaveValueValidator) Validate(ctx 
 	_ = req.Config.GetAttribute(ctx, paths[0], &otherFieldValue)
 
 	doesNotMatchCorrectly := !av.OtherFieldValueRegex.MatchString(otherFieldValue)
-	currentValueNotDefined := req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull()
+	currentValueNotDefined := req.ConfigValue.IsNull()
 
 	if (doesNotMatchCorrectly && !currentValueNotDefined) || (!doesNotMatchCorrectly && currentValueNotDefined) {
 		res.Diagnostics.AddError(av.ErrorMessage, av.ErrorMessage)


### PR DESCRIPTION
This pull request includes changes to improve debugging configurations and refactor a validation function. The key updates involve adding a legacy debug adapter configuration for Go and simplifying a condition in the `MakeFieldRequiredWhenOtherFieldDoesNotHaveValueValidator` logic.

### Debugging Configuration Updates:
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R63-R66): Added a configuration to use the legacy debug adapter for Go debugging, as per the official documentation. This change is intended to address potential compatibility or debugging issues.

### Validation Logic Refactor:
* [`internal/validators/make_field_required_when_other_field_does_not_have_value_validator.go`](diffhunk://#diff-bcbf71cf35b80c9b275af1799d450bfa1add8cf96c44f0d216f1d4a8df13d335L70-R70): Simplified the `currentValueNotDefined` condition by removing the check for `IsUnknown()`, as it was deemed unnecessary. This makes the validation logic more concise and easier to maintain.