### PR TITLE
feat: implement conflict handling and retry logic for environment operations

### DIFF
--- a/internal/services/environment/resource_environment_test.go
+++ b/internal/services/environment/resource_environment_test.go
@@ -19,6 +19,114 @@ import (
 	"github.com/microsoft/terraform-provider-power-platform/internal/mocks"
 )
 
+func TestUnitEnvironmentsResource_Validate_Do_Not_Retry_On_NoCapacity(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	mocks.ActivateEnvironmentHttpMocks()
+
+	httpmock.RegisterResponder("POST", "https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/environments?api-version=2023-06-01",
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(http.StatusConflict, httpmock.File("tests/resource/Validate_Do_Not_Retry_On_NoCapacity/post_environment.json").String())
+			return resp, nil
+		})
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ExpectError: regexp.MustCompile(".*InsufficientCapacity_StorageDriven.*"),
+				Config: `
+				resource "powerplatform_environment" "development" {
+					display_name                              = "displayname"
+					location                                  = "europe"
+					environment_type                          = "Sandbox"
+					dataverse = {
+						language_code                             = "1033"
+						currency_code                             = "PLN"
+						domain                                    = "00000000-0000-0000-0000-000000000001"
+						security_group_id                         = "00000000-0000-0000-0000-000000000000"
+					}
+				}`,
+
+				Check: resource.ComposeTestCheckFunc(),
+			},
+		},
+	})
+}
+
+func TestUnitEnvironmentsResource_Validate_Retry_On_Running_LifecycleOperation(t *testing.T) {
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	mocks.ActivateEnvironmentHttpMocks()
+
+	deleteRetryCount := 0
+	lifecycleOperationInProgressCount := 5
+
+	httpmock.RegisterResponder("DELETE", `=~^https://api\.bap\.microsoft\.com/providers/Microsoft\.BusinessAppPlatform/scopes/admin/environments/([\d-]+)\z`,
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(http.StatusAccepted, "")
+			resp.Header.Add("Location", "https://europe.api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/00000000-0000-0000-0000-000000000001?api-version=2023-06-01")
+			return resp, nil
+		})
+
+	httpmock.RegisterResponder("GET", "https://europe.api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/00000000-0000-0000-0000-000000000001?api-version=2023-06-01",
+		func(req *http.Request) (*http.Response, error) {
+			deleteRetryCount++
+			return httpmock.NewStringResponse(http.StatusOK, httpmock.File(fmt.Sprintf("tests/resource/Validate_Retry_On_Running_LifecycleOperation/get_lifecycle_delete_%d.json", deleteRetryCount)).String()), nil
+		})
+
+	httpmock.RegisterResponder("GET", "https://europe.api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/b03e1e6d-73db-4367-90e1-2e378bf7e2fc?api-version=2023-06-01",
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(http.StatusOK, httpmock.File("tests/resource/Validate_Retry_On_Running_LifecycleOperation/get_lifecycle.json").String()), nil
+		})
+
+	httpmock.RegisterResponder("POST", "https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/environments?api-version=2023-06-01",
+		func(req *http.Request) (*http.Response, error) {
+			if lifecycleOperationInProgressCount > 0 {
+				lifecycleOperationInProgressCount--
+				resp := httpmock.NewStringResponse(http.StatusConflict, httpmock.File("tests/resource/Validate_Retry_On_Running_LifecycleOperation/post_environment_operation_in_progress.json").String())
+				return resp, nil
+			} else {
+				resp := httpmock.NewStringResponse(http.StatusAccepted, "")
+				resp.Header.Add("Location", "https://europe.api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/b03e1e6d-73db-4367-90e1-2e378bf7e2fc?api-version=2023-06-01")
+				return resp, nil
+			}
+		})
+
+	httpmock.RegisterResponder("GET", `=~^https://api\.bap\.microsoft\.com/providers/Microsoft\.BusinessAppPlatform/scopes/admin/environments/([\d-]+)\z`,
+		func(req *http.Request) (*http.Response, error) {
+			id := httpmock.MustGetSubmatch(req, 1)
+			return httpmock.NewStringResponse(http.StatusOK, httpmock.File(fmt.Sprintf("tests/resource/Validate_Retry_On_Running_LifecycleOperation/get_environment_%s.json", id)).String()), nil
+		})
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				resource "powerplatform_environment" "development" {
+					display_name                              = "displayname"
+					location                                  = "europe"
+					environment_type                          = "Sandbox"
+					dataverse = {
+						language_code                             = "1033"
+						currency_code                             = "PLN"
+						domain                                    = "00000000-0000-0000-0000-000000000001"
+						security_group_id                         = "00000000-0000-0000-0000-000000000000"
+					}
+				}`,
+
+				Check: resource.ComposeTestCheckFunc(),
+			},
+		},
+	})
+}
+
 func TestUnitEnvironmentsResource_Validate_Retry_LifecycleOperation(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()

--- a/internal/services/environment/tests/resource/Validate_Do_Not_Retry_On_NoCapacity/post_environment.json
+++ b/internal/services/environment/tests/resource/Validate_Do_Not_Retry_On_NoCapacity/post_environment.json
@@ -1,0 +1,7 @@
+{
+    "error": {
+        "code": "InsufficientCapacity_StorageDriven",
+        "message": "This environment can't be created because your org (tenant) needs at least 1 GB of database capacity.",
+        "detailUrlType": "NotSpecified"
+    }
+}

--- a/internal/services/environment/tests/resource/Validate_Retry_On_Running_LifecycleOperation/get_environment_00000000-0000-0000-0000-000000000001.json
+++ b/internal/services/environment/tests/resource/Validate_Retry_On_Running_LifecycleOperation/get_environment_00000000-0000-0000-0000-000000000001.json
@@ -1,0 +1,158 @@
+{
+    "id": "/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/00000000-0000-0000-0000-000000000001",
+    "type": "Microsoft.BusinessAppPlatform/scopes/environments",
+    "location": "europe",
+    "name": "00000000-0000-0000-0000-000000000001",
+    "properties": {
+        "tenantId": "123",
+        "azureRegion": "westeurope",
+        "displayName": "displayname",
+        "createdTime": "2023-09-27T07:08:27.6057592Z",
+        "createdBy": {
+            "id": "f99f844b-ce3b-49ae-86f3-e374ecae789c",
+            "displayName": "admin",
+            "email": "admin",
+            "type": "User",
+            "tenantId": "123",
+            "userPrincipalName": "admin"
+        },
+        "billingPolicy": {
+            "id": ""
+        },
+        "lastModifiedTime": "2023-09-27T07:08:34.9205145Z",
+        "provisioningState": "Succeeded",
+        "creationType": "User",
+        "environmentSku": "Sandbox",
+        "isDefault": false,
+        "capacity": [
+            {
+                "capacityType": "Database",
+                "actualConsumption": 885.0391,
+                "ratedConsumption": 1024.0,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            },
+            {
+                "capacityType": "File",
+                "actualConsumption": 1187.142,
+                "ratedConsumption": 1187.142,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            },
+            {
+                "capacityType": "Log",
+                "actualConsumption": 0.0,
+                "ratedConsumption": 0.0,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            },
+            {
+                "capacityType": "FinOpsDatabase",
+                "actualConsumption": 0.0,
+                "ratedConsumption": 0.0,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            },
+            {
+                "capacityType": "FinOpsFile",
+                "actualConsumption": 0.0,
+                "ratedConsumption": 0.0,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            }
+        ],
+        "addons": [],
+        "clientUris": {
+            "admin": "https://admin.powerplatform.microsoft.com/environments/environment/456/hub",
+            "maker": "https://make.powerapps.com/environments/456/home"
+        },
+        "runtimeEndpoints": {
+            "microsoft.BusinessAppPlatform": "https://europe.api.bap.microsoft.com",
+            "microsoft.CommonDataModel": "https://europe.api.cds.microsoft.com",
+            "microsoft.PowerApps": "https://europe.api.powerapps.com",
+            "microsoft.PowerAppsAdvisor": "https://europe.api.advisor.powerapps.com",
+            "microsoft.PowerVirtualAgents": "https://powervamg.eu-il107.gateway.prod.island.powerapps.com",
+            "microsoft.ApiManagement": "https://management.EUROPE.azure-apihub.net",
+            "microsoft.Flow": "https://emea.api.flow.microsoft.com"
+        },
+        "databaseType": "CommonDataService",
+        "linkedEnvironmentMetadata": {
+            "resourceId": "orgid",
+            "friendlyName": "displayname",
+            "uniqueName": "00000000-0000-0000-0000-000000000001",
+            "domainName": "00000000-0000-0000-0000-000000000001",
+            "version": "9.2.23092.00206",
+            "instanceUrl": "https://00000000-0000-0000-0000-000000000001.crm4.dynamics.com/",
+            "instanceApiUrl": "https://00000000-0000-0000-0000-000000000001.api.crm4.dynamics.com",
+            "baseLanguage": 1033,
+            "instanceState": "Ready",
+            "createdTime": "2023-09-27T07:08:28.957Z",
+            "backgroundOperationsState": "Enabled",
+            "scaleGroup": "EURCRMLIVESG705",
+            "platformSku": "Standard",
+            "schemaType": "Standard"
+        },
+        "trialScenarioType": "None",
+        "notificationMetadata": {
+            "state": "NotSpecified",
+            "branding": "NotSpecific"
+        },
+        "retentionPeriod": "P7D",
+        "states": {
+            "management": {
+                "id": "Ready"
+            },
+            "runtime": {
+                "runtimeReasonCode": "NotSpecified",
+                "requestedBy": {
+                    "displayName": "SYSTEM",
+                    "type": "NotSpecified"
+                },
+                "id": "Enabled"
+            }
+        },
+        "updateCadence": {
+            "id": "Moderate"
+        },
+        "retentionDetails": {
+            "retentionPeriod": "P7D",
+            "backupsAvailableFromDateTime": "2023-10-03T09:23:06.1717665Z"
+        },
+        "protectionStatus": {
+            "keyManagedBy": "Microsoft"
+        },
+        "cluster": {
+            "category": "Prod",
+            "number": "107",
+            "uriSuffix": "eu-il107.gateway.prod.island",
+            "geoShortName": "EU",
+            "environment": "Prod"
+        },
+        "connectedGroups": [],
+        "lifecycleOperationsEnforcement": {
+            "allowedOperations": [
+                {
+                    "type": {
+                        "id": "DisableGovernanceConfiguration"
+                    },
+                    "reason": {
+                        "message": "DisableGovernanceConfiguration cannot be performed on Power Platform environment because of the governance configuration.",
+                        "type": "GovernanceConfig"
+                    }
+                },
+                {
+                    "type": {
+                        "id": "UpdateGovernanceConfiguration"
+                    },
+                    "reason": {
+                        "message": "UpdateGovernanceConfiguration cannot be performed on Power Platform environment because of the governance configuration.",
+                        "type": "GovernanceConfig"
+                    }
+                }
+            ]
+        },
+        "governanceConfiguration": {
+            "protectionLevel": "Basic"
+        }
+    }
+}

--- a/internal/services/environment/tests/resource/Validate_Retry_On_Running_LifecycleOperation/get_lifecycle.json
+++ b/internal/services/environment/tests/resource/Validate_Retry_On_Running_LifecycleOperation/get_lifecycle.json
@@ -1,0 +1,64 @@
+{
+    "id": "b03e1e6d-73db-4367-90e1-2e378bf7e2fc",
+    "links": {
+        "self": {
+            "path": "/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/b03e1e6d-73db-4367-90e1-2e378bf7e2fc"
+        },
+        "environment": {
+            "path": "/providers/Microsoft.BusinessAppPlatform/environments/00000000-0000-0000-0000-000000000001"
+        }
+    },
+    "type": {
+        "id": "Create"
+    },
+    "typeDisplayName": "Create",
+    "state": {
+        "id": "Succeeded"
+    },
+    "createdDateTime": "2023-10-11T07:45:25.3761337Z",
+    "lastActionDateTime": "2023-10-11T07:45:43.4915067Z",
+    "requestedBy": {
+        "id": "8784d9fb-deb0-4811-96ce-fbf21cf3a1fc",
+        "displayName": "ServicePrincipal",
+        "type": "ServicePrincipal",
+        "tenantId": "123"
+    },
+    "stages": [
+        {
+            "id": "Validate",
+            "name": "Validate",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:25.9230185Z",
+            "lastActionDateTime": "2023-10-11T07:45:25.9230185Z"
+        },
+        {
+            "id": "Prepare",
+            "name": "Prepare",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:25.9230185Z",
+            "lastActionDateTime": "2023-10-11T07:45:25.9230185Z"
+        },
+        {
+            "id": "Run",
+            "name": "Run",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:26.0011473Z",
+            "lastActionDateTime": "2023-10-11T07:45:33.2570938Z"
+        },
+        {
+            "id": "Finalize",
+            "name": "Finalize",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:33.3352196Z",
+            "lastActionDateTime": "2023-10-11T07:45:43.4915067Z"
+        }
+    ]
+}

--- a/internal/services/environment/tests/resource/Validate_Retry_On_Running_LifecycleOperation/get_lifecycle_delete_1.json
+++ b/internal/services/environment/tests/resource/Validate_Retry_On_Running_LifecycleOperation/get_lifecycle_delete_1.json
@@ -1,0 +1,64 @@
+{
+    "id": "b03e1e6d-73db-4367-90e1-2e378bf7e2fc",
+    "links": {
+        "self": {
+            "path": "/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/b03e1e6d-73db-4367-90e1-2e378bf7e2fc"
+        },
+        "environment": {
+            "path": "/providers/Microsoft.BusinessAppPlatform/environments/123"
+        }
+    },
+    "type": {
+        "id": "Create"
+    },
+    "typeDisplayName": "Create",
+    "state": {
+        "id": "Failed"
+    },
+    "createdDateTime": "2023-10-11T07:45:25.3761337Z",
+    "lastActionDateTime": "2023-10-11T07:45:43.4915067Z",
+    "requestedBy": {
+        "id": "8784d9fb-deb0-4811-96ce-fbf21cf3a1fc",
+        "displayName": "ServicePrincipal",
+        "type": "ServicePrincipal",
+        "tenantId": "123"
+    },
+    "stages": [
+        {
+            "id": "Validate",
+            "name": "Validate",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:25.9230185Z",
+            "lastActionDateTime": "2023-10-11T07:45:25.9230185Z"
+        },
+        {
+            "id": "Prepare",
+            "name": "Prepare",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:25.9230185Z",
+            "lastActionDateTime": "2023-10-11T07:45:25.9230185Z"
+        },
+        {
+            "id": "Run",
+            "name": "Run",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:26.0011473Z",
+            "lastActionDateTime": "2023-10-11T07:45:33.2570938Z"
+        },
+        {
+            "id": "Finalize",
+            "name": "Finalize",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:33.3352196Z",
+            "lastActionDateTime": "2023-10-11T07:45:43.4915067Z"
+        }
+    ]
+}

--- a/internal/services/environment/tests/resource/Validate_Retry_On_Running_LifecycleOperation/get_lifecycle_delete_2.json
+++ b/internal/services/environment/tests/resource/Validate_Retry_On_Running_LifecycleOperation/get_lifecycle_delete_2.json
@@ -1,0 +1,64 @@
+{
+    "id": "b03e1e6d-73db-4367-90e1-2e378bf7e2fc",
+    "links": {
+        "self": {
+            "path": "/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/b03e1e6d-73db-4367-90e1-2e378bf7e2fc"
+        },
+        "environment": {
+            "path": "/providers/Microsoft.BusinessAppPlatform/environments/123"
+        }
+    },
+    "type": {
+        "id": "Create"
+    },
+    "typeDisplayName": "Create",
+    "state": {
+        "id": "Failed"
+    },
+    "createdDateTime": "2023-10-11T07:45:25.3761337Z",
+    "lastActionDateTime": "2023-10-11T07:45:43.4915067Z",
+    "requestedBy": {
+        "id": "8784d9fb-deb0-4811-96ce-fbf21cf3a1fc",
+        "displayName": "ServicePrincipal",
+        "type": "ServicePrincipal",
+        "tenantId": "123"
+    },
+    "stages": [
+        {
+            "id": "Validate",
+            "name": "Validate",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:25.9230185Z",
+            "lastActionDateTime": "2023-10-11T07:45:25.9230185Z"
+        },
+        {
+            "id": "Prepare",
+            "name": "Prepare",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:25.9230185Z",
+            "lastActionDateTime": "2023-10-11T07:45:25.9230185Z"
+        },
+        {
+            "id": "Run",
+            "name": "Run",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:26.0011473Z",
+            "lastActionDateTime": "2023-10-11T07:45:33.2570938Z"
+        },
+        {
+            "id": "Finalize",
+            "name": "Finalize",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:33.3352196Z",
+            "lastActionDateTime": "2023-10-11T07:45:43.4915067Z"
+        }
+    ]
+}

--- a/internal/services/environment/tests/resource/Validate_Retry_On_Running_LifecycleOperation/get_lifecycle_delete_3.json
+++ b/internal/services/environment/tests/resource/Validate_Retry_On_Running_LifecycleOperation/get_lifecycle_delete_3.json
@@ -1,0 +1,64 @@
+{
+    "id": "b03e1e6d-73db-4367-90e1-2e378bf7e2fc",
+    "links": {
+        "self": {
+            "path": "/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/b03e1e6d-73db-4367-90e1-2e378bf7e2fc"
+        },
+        "environment": {
+            "path": "/providers/Microsoft.BusinessAppPlatform/environments/123"
+        }
+    },
+    "type": {
+        "id": "Create"
+    },
+    "typeDisplayName": "Create",
+    "state": {
+        "id": "Succeeded"
+    },
+    "createdDateTime": "2023-10-11T07:45:25.3761337Z",
+    "lastActionDateTime": "2023-10-11T07:45:43.4915067Z",
+    "requestedBy": {
+        "id": "8784d9fb-deb0-4811-96ce-fbf21cf3a1fc",
+        "displayName": "ServicePrincipal",
+        "type": "ServicePrincipal",
+        "tenantId": "123"
+    },
+    "stages": [
+        {
+            "id": "Validate",
+            "name": "Validate",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:25.9230185Z",
+            "lastActionDateTime": "2023-10-11T07:45:25.9230185Z"
+        },
+        {
+            "id": "Prepare",
+            "name": "Prepare",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:25.9230185Z",
+            "lastActionDateTime": "2023-10-11T07:45:25.9230185Z"
+        },
+        {
+            "id": "Run",
+            "name": "Run",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:26.0011473Z",
+            "lastActionDateTime": "2023-10-11T07:45:33.2570938Z"
+        },
+        {
+            "id": "Finalize",
+            "name": "Finalize",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:33.3352196Z",
+            "lastActionDateTime": "2023-10-11T07:45:43.4915067Z"
+        }
+    ]
+}

--- a/internal/services/environment/tests/resource/Validate_Retry_On_Running_LifecycleOperation/post_environment_operation_in_progress.json
+++ b/internal/services/environment/tests/resource/Validate_Retry_On_Running_LifecycleOperation/post_environment_operation_in_progress.json
@@ -1,0 +1,7 @@
+{
+    "error": {
+        "code": "OperationNotStartable",
+        "message": "TThis operation cannot be performed because there is an active lifecycle operation on the environment 00000000-0000-0000-0000-000000000000.",
+        "detailUrlType": "NotSpecified"
+    }
+}


### PR DESCRIPTION
This pull request enhances the handling of HTTP 409 (Conflict) responses in environment lifecycle operations by introducing a reusable conflict resolution method and adding unit tests to validate the behavior. The changes improve code maintainability and ensure robust handling of lifecycle operation conflicts.

### Conflict Resolution Enhancements:
* Added a new method `handleHttpConflict` in `api_environment.go` to centralize the handling of HTTP 409 responses, including logging, waiting for ongoing operations to complete, and retrying the request.
* Updated the `DeleteEnvironment`, `CreateEnvironment`, `UpdateEnvironmentAiFeatures`, and `UpdateEnvironment` methods to use the new `handleHttpConflict` method for consistent conflict handling. [[1]](diffhunk://#diff-6939b69029f482f476bfc737204e004670b40a16e4a3a6c3af61eb9efb8244afL302-L307) [[2]](diffhunk://#diff-6939b69029f482f476bfc737204e004670b40a16e4a3a6c3af61eb9efb8244afR452-R459) [[3]](diffhunk://#diff-6939b69029f482f476bfc737204e004670b40a16e4a3a6c3af61eb9efb8244afR521-R528) [[4]](diffhunk://#diff-6939b69029f482f476bfc737204e004670b40a16e4a3a6c3af61eb9efb8244afR584-R591)

### Unit Tests:
* Added unit tests in `resource_environment_test.go` to validate conflict handling:
  - `TestUnitEnvironmentsResource_Validate_Do_Not_Retry_On_NoCapacity` ensures no retry occurs when the conflict is due to insufficient capacity.
  - `TestUnitEnvironmentsResource_Validate_Retry_On_Running_LifecycleOperation` verifies retry behavior for ongoing lifecycle operations.

### Test Data:
* Added JSON files to simulate API responses for different conflict scenarios:
  - `post_environment.json` for insufficient capacity conflicts.
  - `get_environment_00000000-0000-0000-0000-000000000001.json` for environment details.
  - `get_lifecycle.json` and `get_lifecycle_delete_1.json` for lifecycle operation states. [[1]](diffhunk://#diff-101f6a116beac328d82bbf7ebf52ca64bf970de4b2a9727339a01cba2c4f3ecfR1-R64) [[2]](diffhunk://#diff-8b699495d3ab58147dfce7fec88aaa4240c9f10968399f3c054f21544add855fR1-R64)