### PR TITLE
fixing security group validation when values are unknown

### DIFF
--- a/.changes/unreleased/fixed-20250516-095207.yaml
+++ b/.changes/unreleased/fixed-20250516-095207.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Fixed issue when powerplatform_environment security_group_id validates unknown values incorrectly
+time: 2025-05-16T09:52:07.133508264Z
+custom:
+    Issue: "775"

--- a/internal/services/environment/resource_environment_test.go
+++ b/internal/services/environment/resource_environment_test.go
@@ -19,6 +19,105 @@ import (
 	"github.com/microsoft/terraform-provider-power-platform/internal/mocks"
 )
 
+func TestUnitEnvironmentsResource_Validate_Attribute_Validators(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	mocks.ActivateEnvironmentHttpMocks()
+
+	httpmock.RegisterResponder("GET", "https://europe.api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/00000000-0000-0000-0000-000000000001?api-version=2023-06-01",
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(http.StatusOK, httpmock.File("tests/resource/Validate_Attribute_Validators/get_lifecycle_delete.json").String()), nil
+		})
+
+	httpmock.RegisterResponder("GET", `=~^https://api\.bap\.microsoft\.com/providers/Microsoft\.BusinessAppPlatform/scopes/admin/environments/([\d-]+)\z`,
+		func(req *http.Request) (*http.Response, error) {
+			id := httpmock.MustGetSubmatch(req, 1)
+			return httpmock.NewStringResponse(http.StatusOK, httpmock.File(fmt.Sprintf("tests/resource/Validate_Attribute_Validators/get_environment_%s.json", id)).String()), nil
+		})
+
+	httpmock.RegisterResponder("DELETE", `=~^https://api\.bap\.microsoft\.com/providers/Microsoft\.BusinessAppPlatform/scopes/admin/environments/([\d-]+)\z`,
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(http.StatusAccepted, "")
+			resp.Header.Add("Location", "https://europe.api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/00000000-0000-0000-0000-000000000001?api-version=2023-06-01")
+			return resp, nil
+		})
+
+	httpmock.RegisterResponder("GET", "https://europe.api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/b03e1e6d-73db-4367-90e1-2e378bf7e2fc?api-version=2023-06-01",
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(http.StatusOK, httpmock.File("tests/resource/Validate_Create/get_lifecycle.json").String()), nil
+		})
+
+	httpmock.RegisterResponder("POST", "https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/environments?api-version=2023-06-01",
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(http.StatusAccepted, "")
+			resp.Header.Add("Location", "https://europe.api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/b03e1e6d-73db-4367-90e1-2e378bf7e2fc?api-version=2023-06-01")
+			return resp, nil
+		})
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+
+				variable "power_platform_environment" {
+					type = object({
+						id = string
+						display_name = string
+					    location = string
+						type = string
+						language_code = string
+						currency_code = string
+						domain = string
+						security_group_id = string
+					})
+					default = {
+						id = ""
+						display_name = "displayname"
+						location = "europe"
+						type = "Sandbox"
+						language_code = "1033"
+						currency_code = "PLN"
+						domain = "00000000-0000-0000-0000-000000000001"
+						security_group_id = "00000000-0000-0000-0000-000000000000"
+					}
+				}
+
+				resource "powerplatform_environment" "development" {
+					display_name                              = var.power_platform_environment.display_name
+					location                                  = var.power_platform_environment.location
+					environment_type                          = var.power_platform_environment.type
+					dataverse = {
+						language_code                             = var.power_platform_environment.language_code
+						currency_code                             = var.power_platform_environment.currency_code
+						domain                                    = var.power_platform_environment.domain
+						security_group_id                         = var.power_platform_environment.security_group_id
+					}
+				}`,
+
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "id", "00000000-0000-0000-0000-000000000001"),
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "display_name", "displayname"),
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "dataverse.url", "https://00000000-0000-0000-0000-000000000001.crm4.dynamics.com/"),
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "dataverse.domain", "00000000-0000-0000-0000-000000000001"),
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "location", "europe"),
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "environment_type", "Sandbox"),
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "dataverse.language_code", "1033"),
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "dataverse.currency_code", "PLN"),
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "dataverse.organization_id", "orgid"),
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "dataverse.security_group_id", "00000000-0000-0000-0000-000000000000"),
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "dataverse.version", "9.2.23092.00206"),
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "dataverse.unique_name", "00000000-0000-0000-0000-000000000001"),
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "billing_policy_id", "00000000-0000-0000-0000-000000000000"),
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "release_cycle", "Standard"),
+				),
+			},
+		},
+	})
+}
+
 func TestUnitEnvironmentsResource_Validate_Do_Not_Retry_On_NoCapacity(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()

--- a/internal/services/environment/tests/resource/Validate_Attribute_Validators/get_environment_00000000-0000-0000-0000-000000000001.json
+++ b/internal/services/environment/tests/resource/Validate_Attribute_Validators/get_environment_00000000-0000-0000-0000-000000000001.json
@@ -1,0 +1,158 @@
+{
+    "id": "/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/00000000-0000-0000-0000-000000000001",
+    "type": "Microsoft.BusinessAppPlatform/scopes/environments",
+    "location": "europe",
+    "name": "00000000-0000-0000-0000-000000000001",
+    "properties": {
+        "tenantId": "123",
+        "azureRegion": "westeurope",
+        "displayName": "displayname",
+        "createdTime": "2023-09-27T07:08:27.6057592Z",
+        "createdBy": {
+            "id": "f99f844b-ce3b-49ae-86f3-e374ecae789c",
+            "displayName": "admin",
+            "email": "admin",
+            "type": "User",
+            "tenantId": "123",
+            "userPrincipalName": "admin"
+        },
+        "billingPolicy": {
+            "id": ""
+        },
+        "lastModifiedTime": "2023-09-27T07:08:34.9205145Z",
+        "provisioningState": "Succeeded",
+        "creationType": "User",
+        "environmentSku": "Sandbox",
+        "isDefault": false,
+        "capacity": [
+            {
+                "capacityType": "Database",
+                "actualConsumption": 885.0391,
+                "ratedConsumption": 1024.0,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            },
+            {
+                "capacityType": "File",
+                "actualConsumption": 1187.142,
+                "ratedConsumption": 1187.142,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            },
+            {
+                "capacityType": "Log",
+                "actualConsumption": 0.0,
+                "ratedConsumption": 0.0,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            },
+            {
+                "capacityType": "FinOpsDatabase",
+                "actualConsumption": 0.0,
+                "ratedConsumption": 0.0,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            },
+            {
+                "capacityType": "FinOpsFile",
+                "actualConsumption": 0.0,
+                "ratedConsumption": 0.0,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            }
+        ],
+        "addons": [],
+        "clientUris": {
+            "admin": "https://admin.powerplatform.microsoft.com/environments/environment/456/hub",
+            "maker": "https://make.powerapps.com/environments/456/home"
+        },
+        "runtimeEndpoints": {
+            "microsoft.BusinessAppPlatform": "https://europe.api.bap.microsoft.com",
+            "microsoft.CommonDataModel": "https://europe.api.cds.microsoft.com",
+            "microsoft.PowerApps": "https://europe.api.powerapps.com",
+            "microsoft.PowerAppsAdvisor": "https://europe.api.advisor.powerapps.com",
+            "microsoft.PowerVirtualAgents": "https://powervamg.eu-il107.gateway.prod.island.powerapps.com",
+            "microsoft.ApiManagement": "https://management.EUROPE.azure-apihub.net",
+            "microsoft.Flow": "https://emea.api.flow.microsoft.com"
+        },
+        "databaseType": "CommonDataService",
+        "linkedEnvironmentMetadata": {
+            "resourceId": "orgid",
+            "friendlyName": "displayname",
+            "uniqueName": "00000000-0000-0000-0000-000000000001",
+            "domainName": "00000000-0000-0000-0000-000000000001",
+            "version": "9.2.23092.00206",
+            "instanceUrl": "https://00000000-0000-0000-0000-000000000001.crm4.dynamics.com/",
+            "instanceApiUrl": "https://00000000-0000-0000-0000-000000000001.api.crm4.dynamics.com",
+            "baseLanguage": 1033,
+            "instanceState": "Ready",
+            "createdTime": "2023-09-27T07:08:28.957Z",
+            "backgroundOperationsState": "Enabled",
+            "scaleGroup": "EURCRMLIVESG705",
+            "platformSku": "Standard",
+            "schemaType": "Standard"
+        },
+        "trialScenarioType": "None",
+        "notificationMetadata": {
+            "state": "NotSpecified",
+            "branding": "NotSpecific"
+        },
+        "retentionPeriod": "P7D",
+        "states": {
+            "management": {
+                "id": "Ready"
+            },
+            "runtime": {
+                "runtimeReasonCode": "NotSpecified",
+                "requestedBy": {
+                    "displayName": "SYSTEM",
+                    "type": "NotSpecified"
+                },
+                "id": "Enabled"
+            }
+        },
+        "updateCadence": {
+            "id": "Moderate"
+        },
+        "retentionDetails": {
+            "retentionPeriod": "P7D",
+            "backupsAvailableFromDateTime": "2023-10-03T09:23:06.1717665Z"
+        },
+        "protectionStatus": {
+            "keyManagedBy": "Microsoft"
+        },
+        "cluster": {
+            "category": "Prod",
+            "number": "107",
+            "uriSuffix": "eu-il107.gateway.prod.island",
+            "geoShortName": "EU",
+            "environment": "Prod"
+        },
+        "connectedGroups": [],
+        "lifecycleOperationsEnforcement": {
+            "allowedOperations": [
+                {
+                    "type": {
+                        "id": "DisableGovernanceConfiguration"
+                    },
+                    "reason": {
+                        "message": "DisableGovernanceConfiguration cannot be performed on Power Platform environment because of the governance configuration.",
+                        "type": "GovernanceConfig"
+                    }
+                },
+                {
+                    "type": {
+                        "id": "UpdateGovernanceConfiguration"
+                    },
+                    "reason": {
+                        "message": "UpdateGovernanceConfiguration cannot be performed on Power Platform environment because of the governance configuration.",
+                        "type": "GovernanceConfig"
+                    }
+                }
+            ]
+        },
+        "governanceConfiguration": {
+            "protectionLevel": "Basic"
+        }
+    }
+}

--- a/internal/services/environment/tests/resource/Validate_Attribute_Validators/get_lifecycle.json
+++ b/internal/services/environment/tests/resource/Validate_Attribute_Validators/get_lifecycle.json
@@ -1,0 +1,64 @@
+{
+    "id": "b03e1e6d-73db-4367-90e1-2e378bf7e2fc",
+    "links": {
+        "self": {
+            "path": "/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/b03e1e6d-73db-4367-90e1-2e378bf7e2fc"
+        },
+        "environment": {
+            "path": "/providers/Microsoft.BusinessAppPlatform/environments/00000000-0000-0000-0000-000000000001"
+        }
+    },
+    "type": {
+        "id": "Create"
+    },
+    "typeDisplayName": "Create",
+    "state": {
+        "id": "Succeeded"
+    },
+    "createdDateTime": "2023-10-11T07:45:25.3761337Z",
+    "lastActionDateTime": "2023-10-11T07:45:43.4915067Z",
+    "requestedBy": {
+        "id": "8784d9fb-deb0-4811-96ce-fbf21cf3a1fc",
+        "displayName": "ServicePrincipal",
+        "type": "ServicePrincipal",
+        "tenantId": "123"
+    },
+    "stages": [
+        {
+            "id": "Validate",
+            "name": "Validate",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:25.9230185Z",
+            "lastActionDateTime": "2023-10-11T07:45:25.9230185Z"
+        },
+        {
+            "id": "Prepare",
+            "name": "Prepare",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:25.9230185Z",
+            "lastActionDateTime": "2023-10-11T07:45:25.9230185Z"
+        },
+        {
+            "id": "Run",
+            "name": "Run",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:26.0011473Z",
+            "lastActionDateTime": "2023-10-11T07:45:33.2570938Z"
+        },
+        {
+            "id": "Finalize",
+            "name": "Finalize",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:33.3352196Z",
+            "lastActionDateTime": "2023-10-11T07:45:43.4915067Z"
+        }
+    ]
+}

--- a/internal/services/environment/tests/resource/Validate_Attribute_Validators/get_lifecycle_delete.json
+++ b/internal/services/environment/tests/resource/Validate_Attribute_Validators/get_lifecycle_delete.json
@@ -1,0 +1,64 @@
+{
+    "id": "b03e1e6d-73db-4367-90e1-2e378bf7e2fc",
+    "links": {
+        "self": {
+            "path": "/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/b03e1e6d-73db-4367-90e1-2e378bf7e2fc"
+        },
+        "environment": {
+            "path": "/providers/Microsoft.BusinessAppPlatform/environments/123"
+        }
+    },
+    "type": {
+        "id": "Create"
+    },
+    "typeDisplayName": "Create",
+    "state": {
+        "id": "Succeeded"
+    },
+    "createdDateTime": "2023-10-11T07:45:25.3761337Z",
+    "lastActionDateTime": "2023-10-11T07:45:43.4915067Z",
+    "requestedBy": {
+        "id": "8784d9fb-deb0-4811-96ce-fbf21cf3a1fc",
+        "displayName": "ServicePrincipal",
+        "type": "ServicePrincipal",
+        "tenantId": "123"
+    },
+    "stages": [
+        {
+            "id": "Validate",
+            "name": "Validate",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:25.9230185Z",
+            "lastActionDateTime": "2023-10-11T07:45:25.9230185Z"
+        },
+        {
+            "id": "Prepare",
+            "name": "Prepare",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:25.9230185Z",
+            "lastActionDateTime": "2023-10-11T07:45:25.9230185Z"
+        },
+        {
+            "id": "Run",
+            "name": "Run",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:26.0011473Z",
+            "lastActionDateTime": "2023-10-11T07:45:33.2570938Z"
+        },
+        {
+            "id": "Finalize",
+            "name": "Finalize",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:33.3352196Z",
+            "lastActionDateTime": "2023-10-11T07:45:43.4915067Z"
+        }
+    ]
+}


### PR DESCRIPTION
This pull request introduces a new unit test for validating attribute validators in the `powerplatform_environment` resource and enhances the `MakeFieldRequiredWhenOtherFieldDoesNotHaveValueValidator` with better error handling and logging. Additionally, it includes supporting test data for lifecycle operations and environment attributes.

### New Unit Test for Attribute Validation:
* Added a comprehensive unit test `TestUnitEnvironmentsResource_Validate_Attribute_Validators` in `internal/services/environment/resource_environment_test.go`. This test uses `httpmock` to simulate API responses and validates the `powerplatform_environment` resource attributes, ensuring correct behavior under various scenarios.

### Supporting Test Data:
* Added a mock JSON file `get_environment_00000000-0000-0000-0000-000000000001.json` to simulate environment details for the test. This includes metadata such as `displayName`, `location`, `capacity`, and `runtimeEndpoints`.
* Added `get_lifecycle.json` to simulate lifecycle operation details for environment creation, including stages like `Validate`, `Prepare`, `Run`, and `Finalize`.
* Added `get_lifecycle_delete.json` to simulate lifecycle operation details for environment deletion, structured similarly to the creation lifecycle.

### Validator Enhancements:
* Updated `MakeFieldRequiredWhenOtherFieldDoesNotHaveValueValidator` to handle unknown values gracefully. Introduced logging via `tflog` and improved error handling to skip validation when the value is unknown. [[1]](diffhunk://#diff-bcbf71cf35b80c9b275af1799d450bfa1add8cf96c44f0d216f1d4a8df13d335R9-R16) [[2]](diffhunk://#diff-bcbf71cf35b80c9b275af1799d450bfa1add8cf96c44f0d216f1d4a8df13d335L67-R78)