### PR TITLE
Fix TestAccEnvironmentsResource_Validate_CreateGenerativeAiFeatures_US_Region_Update test

### DIFF
--- a/internal/services/environment/api_environment.go
+++ b/internal/services/environment/api_environment.go
@@ -541,9 +541,14 @@ func (client *Client) updateEnvironmentAiFeaturesWithRetry(ctx context.Context, 
 	values := url.Values{}
 	values.Add(constants.API_VERSION_PARAM, constants.BAP_2021_API_VERSION)
 	apiUrl.RawQuery = values.Encode()
-	apiResponse, err := client.Api.Execute(ctx, nil, "PATCH", apiUrl.String(), nil, generativeAIConfig, []int{http.StatusAccepted, http.StatusConflict}, nil)
+	apiResponse, err := client.Api.Execute(ctx, nil, "PATCH", apiUrl.String(), nil, generativeAIConfig, []int{http.StatusAccepted, http.StatusConflict, http.StatusNoContent}, nil)
 	if err != nil {
 		return err
+	}
+
+	if apiResponse.HttpResponse.StatusCode == http.StatusNoContent {
+		tflog.Info(ctx, "No update operation occurred for Environment AI features")
+		return nil
 	}
 
 	if apiResponse.HttpResponse.StatusCode == http.StatusConflict {


### PR DESCRIPTION
This pull request introduces a small but important change to the `updateEnvironmentAiFeaturesWithRetry` method in `internal/services/environment/api_environment.go`. The change improves the handling of HTTP status codes by adding support for `http.StatusNoContent` and logging a message when no update operation occurs.

* Enhanced HTTP status code handling in `updateEnvironmentAiFeaturesWithRetry`:
  - Added `http.StatusNoContent` to the list of acceptable response codes for the API call.
  - Introduced a conditional check to log a message and return early when the response status is `http.StatusNoContent`, indicating no update occurred.