### PR TITLE
chore: update release guidelines for improved changelog generation an…

### DIFF
--- a/devdocs/release_guidelines.md
+++ b/devdocs/release_guidelines.md
@@ -9,7 +9,6 @@ Releasing a new version involves a sequence of steps that tie together Changie, 
 1. **Work on new branch**
 
     ```bash
-    git checkout -b releases/vNext
     git switch -c release/vNext 
     ```
 

--- a/devdocs/release_guidelines.md
+++ b/devdocs/release_guidelines.md
@@ -9,6 +9,9 @@ Releasing a new version involves a sequence of steps that tie together Changie, 
 1. **Work on new branch**
 
     ```bash
+    git fetch origin
+    git checkout -b main origin/main
+    git pull origin main
     git switch -c release/vNext 
     ```
 


### PR DESCRIPTION
This pull request updates the release process documentation for the Power Platform Terraform Provider to provide a more structured and detailed workflow. Key changes include the addition of a new branching strategy, updates to the changelog generation process, and clarification of steps for tagging and publishing releases.

### Updates to the release process:

* **Branching strategy introduced**: Added instructions for creating and working on a dedicated release branch (`release/vNext`) to isolate release-related changes from the `main` branch.

* **Enhanced changelog generation and review process**: Consolidated steps for accumulating changes, generating the changelog using Changie, and reviewing it. This includes committing the updated changelog and creating a pull request targeting `main`.

* **Clarified tagging and publishing steps**: Updated instructions for tagging the release after merging the PR into `main` and publishing the draft release on GitHub. Emphasized the importance of verifying the draft release before publishing it.

### General improvements:

* **Refinement of documentation structure**: Improved clarity and organization of the release guide by updating step numbering and adding more detailed explanations for each phase.

* **Security and quality safeguards section**: Retained the existing safeguards section without changes, ensuring the workflow adheres to security and quality standards.…d PR process