### PR TITLE
fix: update API permissions for Power Platform Provider documentation

### DIFF
--- a/.changes/unreleased/fixed-20250714-085622.yaml
+++ b/.changes/unreleased/fixed-20250714-085622.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: update API permissions for Power Platform Provider documentation
+time: 2025-07-14T08:56:22.104178201Z
+custom:
+    Issue: "877"

--- a/.devcontainer/features/local_provider_dev/install.sh
+++ b/.devcontainer/features/local_provider_dev/install.sh
@@ -45,7 +45,7 @@ tfenv install latest
 
 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0.1
 # Removing the golangci-lint binary from GOROOT/bin to avoid conflicts duplicated binaries
-rm $(go env GOROOT)/bin/golangci-lint
+rm -f "$(go env GOROOT)/bin/golangci-lint" || true
 
 # Turn off telemetry for az cli
 # https://github.com/Azure/azure-cli?tab=readme-ov-file#telemetry-configuration

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -299,4 +299,4 @@ Use the Terraform plugin logger (`tflog`) for logging within resource implementa
   - `<description>` is a concise summary of what was changed or fixed. Follow the commit message style described in `copilot-commit-message-instructions.md`.
   - `<issue_number>` is the related issue or PR number. If unknown, use `0`.
 
-- Ensure your changelog entry is clear, descriptive, and follows the project's conventions.
+- Ensure your changelog entry is clear, short, descriptive, and follows the project's conventions.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -280,3 +280,23 @@ Use the Terraform plugin logger (`tflog`) for logging within resource implementa
 - **Test Coverage:** Aim for **at least 80%** code coverage for unit tests on new code. `make unittest` will return a coverage score by service and overall. Focus on the service that is currently being worked on when adding tests to improve coverage.
 
 - **Examples and Documentation:** Whenever a new resource or data source is added, provide an example configuration under the `/examples` directory to demonstrate usage. This helps both in documentation and in manually verifying the resource behavior. After implementing and testing, run `make userdocs` to update the documentation in `/docs` from your schema comments.
+
+## Tools
+
+### Changelog Management with Changie
+
+- Use [Changie](https://changie.dev/) to create a single changelog entry for each pull request or change.
+- Do **not** run the changie tool multiple times per change.
+- Look at the git commit history to determine the kind of change being made and what description to use to describe the change.
+- To create a changelog entry, run the following command from the repository root:
+
+  ```bash
+  changie new --kind <kind_key> --body "<description>" --custom Issue=<issue_number>
+  ```
+
+  Where:
+  - `<kind_key>` is one of: `breaking`, `changed`, `deprecated`, `removed`, `fixed`, `security`, `documentation`
+  - `<description>` is a concise summary of what was changed or fixed. Follow the commit message style described in `copilot-commit-message-instructions.md`.
+  - `<issue_number>` is the related issue or PR number. If unknown, use `0`.
+
+- Ensure your changelog entry is clear, descriptive, and follows the project's conventions.

--- a/docs/guides/app_registration.md
+++ b/docs/guides/app_registration.md
@@ -23,16 +23,12 @@ Following API permissions are required to use the Terraform Power Platform provi
 - Power Platform API
   - AppManagement.ApplicationPackages.Install
   - AppManagement.ApplicationPackages.Read
-  - Licensing.Allocations.Read
   - Licensing.Allocations.ReadWrite
-  - Licensing.BillingPolicies.Read
   - Licensing.BillingPolicies.ReadWrite
   - PowerApps.Apps.Play
   - PowerApps.Apps.Read
   - EnvironmentManagement.Environments.Read
-  - EnvironmentManagement.Groups.Read
   - EnvironmentManagement.Groups.ReadWrite
-  - EnvironmentManagement.Settings.Read
   - EnvironmentManagement.Settings.ReadWrite
 
 - PowerApps Service

--- a/templates/guides/app_registration.md.tmpl
+++ b/templates/guides/app_registration.md.tmpl
@@ -23,16 +23,12 @@ Following API permissions are required to use the Terraform Power Platform provi
 - Power Platform API
   - AppManagement.ApplicationPackages.Install
   - AppManagement.ApplicationPackages.Read
-  - Licensing.Allocations.Read
   - Licensing.Allocations.ReadWrite
-  - Licensing.BillingPolicies.Read
   - Licensing.BillingPolicies.ReadWrite
   - PowerApps.Apps.Play
   - PowerApps.Apps.Read
   - EnvironmentManagement.Environments.Read
-  - EnvironmentManagement.Groups.Read
   - EnvironmentManagement.Groups.ReadWrite
-  - EnvironmentManagement.Settings.Read
   - EnvironmentManagement.Settings.ReadWrite
 
 - PowerApps Service


### PR DESCRIPTION
This pull request updates the required API permissions for using the Terraform Power Platform provider in the `app_registration.md.tmpl` guide. It removes several read-only permissions, likely to streamline the permissions list and focus on those with broader access.

### Changes to API permissions:

* Removed `Licensing.Allocations.Read`, `Licensing.BillingPolicies.Read`, `EnvironmentManagement.Groups.Read`, and `EnvironmentManagement.Settings.Read` from the required permissions list. These were all read-only permissions.