### PR TITLE
Chore(deps): Update Microsoft.PowerApps.CLI.Tool to version 1.47.1

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -10,7 +10,7 @@ on:
      branches:
        - main
 
-       
+
 concurrency:
   group: acceptancetests
   cancel-in-progress: false
@@ -142,7 +142,7 @@ jobs:
       if: success() || failure()
       shell: pwsh
       run: |
-        dotnet tool install --global Microsoft.PowerApps.CLI.Tool --version 1.47.1
+        dotnet tool install --global Microsoft.PowerApps.CLI.Tool --version 1.42.1
         pac auth create --githubFederated --tenant ${{ secrets.ACCEPTANCE_TESTS_ENV_TENANT_ID }} --applicationId ${{ secrets.ACCEPTANCE_TESTS_ENV_CLIENT_ID }}
         $environmentsList = (pac admin list --name "Test" --json | ConvertFrom-Json)
         $environmentsList | ForEach-Object -Parallel {

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -142,7 +142,7 @@ jobs:
       if: success() || failure()
       shell: pwsh
       run: |
-        dotnet tool install --global Microsoft.PowerApps.CLI.Tool --version 1.42.1
+        dotnet tool install --global Microsoft.PowerApps.CLI.Tool --version 1.44.2
         pac auth create --githubFederated --tenant ${{ secrets.ACCEPTANCE_TESTS_ENV_TENANT_ID }} --applicationId ${{ secrets.ACCEPTANCE_TESTS_ENV_CLIENT_ID }}
         $environmentsList = (pac admin list --name "Test" --json | ConvertFrom-Json)
         $environmentsList | ForEach-Object -Parallel {

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -141,7 +141,7 @@ jobs:
       if: success() || failure()
       shell: pwsh
       run: |
-        dotnet tool install --global Microsoft.PowerApps.CLI.Tool
+        dotnet tool install --global Microsoft.PowerApps.CLI.Tool --version 1.47.1
         pac auth create --githubFederated --tenant ${{ secrets.ACCEPTANCE_TESTS_ENV_TENANT_ID }} --applicationId ${{ secrets.ACCEPTANCE_TESTS_ENV_CLIENT_ID }}
         $environmentsList = (pac admin list --name "Test" --json | ConvertFrom-Json)
         $environmentsList | ForEach-Object -Parallel {

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -10,6 +10,7 @@ on:
      branches:
        - main
 
+       
 concurrency:
   group: acceptancetests
   cancel-in-progress: false

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.11.0
 	github.com/hashicorp/terraform-plugin-docs v0.22.0
-	github.com/hashicorp/terraform-plugin-framework v1.15.1
+	github.com/hashicorp/terraform-plugin-framework v1.15.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.5.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.18.0
 	github.com/hashicorp/terraform-plugin-go v0.28.0

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/hashicorp/terraform-json v0.25.0 h1:rmNqc/CIfcWawGiwXmRuiXJKEiJu1ntGo
 github.com/hashicorp/terraform-json v0.25.0/go.mod h1:sMKS8fiRDX4rVlR6EJUMudg1WcanxCMoWwTLkgZP/vc=
 github.com/hashicorp/terraform-plugin-docs v0.22.0 h1:fwIDStbFel1PPNkM+mDPnpB4efHZBdGoMz/zt5FbTDw=
 github.com/hashicorp/terraform-plugin-docs v0.22.0/go.mod h1:55DJVyZ7BNK4t/lANcQ1YpemRuS6KsvIO1BbGA+xzGE=
-github.com/hashicorp/terraform-plugin-framework v1.15.1 h1:2mKDkwb8rlx/tvJTlIcpw0ykcmvdWv+4gY3SIgk8Pq8=
-github.com/hashicorp/terraform-plugin-framework v1.15.1/go.mod h1:hxrNI/GY32KPISpWqlCoTLM9JZsGH3CyYlir09bD/fI=
+github.com/hashicorp/terraform-plugin-framework v1.15.0 h1:LQ2rsOfmDLxcn5EeIwdXFtr03FVsNktbbBci8cOKdb4=
+github.com/hashicorp/terraform-plugin-framework v1.15.0/go.mod h1:hxrNI/GY32KPISpWqlCoTLM9JZsGH3CyYlir09bD/fI=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.5.0 h1:I/N0g/eLZ1ZkLZXUQ0oRSXa8YG/EF0CEuQP1wXdrzKw=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.5.0/go.mod h1:t339KhmxnaF4SzdpxmqW8HnQBHVGYazwtfxU0qCs4eE=
 github.com/hashicorp/terraform-plugin-framework-validators v0.18.0 h1:OQnlOt98ua//rCw+QhBbSqfW3QbwtVrcdWeQN5gI3Hw=


### PR DESCRIPTION
This pull request includes minor dependency and tooling updates to ensure compatibility and stability in both the workflow and Go module configuration.

Dependency and tooling updates:

* Updated the installation command for `Microsoft.PowerApps.CLI.Tool` in `.github/workflows/run_tests.yml` to explicitly use version `1.47.1` for improved reliability in CI workflows.
* Downgraded the `terraform-plugin-framework` dependency from version `1.15.1` to `1.15.0` in `go.mod` to maintain compatibility with the project’s requirements.