### PR TITLE
Fixing useStateForUnknown modifier behavior after it changed in terraform-plugin-framework v1.15.1

### DIFF
--- a/.devcontainer/features/local_provider_dev/install.sh
+++ b/.devcontainer/features/local_provider_dev/install.sh
@@ -43,7 +43,7 @@ sh -c 'cat ~/.mitmproxy/mitmproxy-ca-cert.pem >> /etc/ssl/certs/ca-certificates.
 
 tfenv install latest
 
-go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0.1
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
 # Removing the golangci-lint binary from GOROOT/bin to avoid conflicts duplicated binaries
 rm -f "$(go env GOROOT)/bin/golangci-lint" || true
 

--- a/.devcontainer/features/local_provider_dev/install.sh
+++ b/.devcontainer/features/local_provider_dev/install.sh
@@ -54,3 +54,4 @@ az config set core.collect_telemetry=false
 curl -fsSL https://aka.ms/install-azd.sh | bash
 # Turn off telemetry for azd
 export AZURE_DEV_COLLECT_TELEMETRY=no
+

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -24,7 +24,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.1.6
+          version: v2.5.0
 
       - name: "Install Terraform"
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2  

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -30,4 +30,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.1.6
+          version: v2.5.0

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -141,7 +141,7 @@ jobs:
       if: success() || failure()
       shell: pwsh
       run: |
-        dotnet tool install --global Microsoft.PowerApps.CLI.Tool
+        dotnet tool install --global Microsoft.PowerApps.CLI.Tool --version 1.43.6
         pac auth create --githubFederated --tenant ${{ secrets.ACCEPTANCE_TESTS_ENV_TENANT_ID }} --applicationId ${{ secrets.ACCEPTANCE_TESTS_ENV_CLIENT_ID }}
         $environmentsList = (pac admin list --name "Test" --json | ConvertFrom-Json)
         $environmentsList | ForEach-Object -Parallel {

--- a/internal/modifiers/use_state_for_unknown_keep_non_null_state_modifier.go
+++ b/internal/modifiers/use_state_for_unknown_keep_non_null_state_modifier.go
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// terraform-plugin-framework v1.15.1 changed behaviour of UseStateForUnknown plan modifier.
+// Before the change, if new nested map, that contains Computed/Unknown elements is added to already created resource,
+// those elements are treated as Unknown.
+// After the change, those elements are treated as Null.
+// This breaks bulk operations, as the ID of newly created objects can never be set, as Terraform would expects them to be Null.
+// Ref: https://github.com/hashicorp/terraform-plugin-framework/issues/1211
+
+package modifiers
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+func UseStateForUnknownKeepNonNullStateModifier() planmodifier.String {
+	return &useStateForUnknownKeepNonNullStateModifier{}
+}
+
+type useStateForUnknownKeepNonNullStateModifier struct {
+}
+
+func (d *useStateForUnknownKeepNonNullStateModifier) Description(ctx context.Context) string {
+	return "Once set to a non-null value, the value of this attribute in state will not change."
+}
+
+func (d *useStateForUnknownKeepNonNullStateModifier) MarkdownDescription(ctx context.Context) string {
+	return d.Description(ctx)
+}
+
+func (d *useStateForUnknownKeepNonNullStateModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// Do nothing if there the state value is null.
+	if req.StateValue.IsNull() {
+		return
+	}
+
+	// Do nothing if there is a known planned value.
+	if !req.PlanValue.IsUnknown() {
+		return
+	}
+
+	// Do nothing if there is an unknown configuration value, otherwise interpolation gets messed up.
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	resp.PlanValue = req.StateValue
+}

--- a/internal/modifiers/use_state_for_unknown_keep_non_null_state_modifier.go
+++ b/internal/modifiers/use_state_for_unknown_keep_non_null_state_modifier.go
@@ -32,7 +32,7 @@ func (d *useStateForUnknownKeepNonNullStateModifier) MarkdownDescription(ctx con
 }
 
 func (d *useStateForUnknownKeepNonNullStateModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	// Do nothing if there the state value is null.
+	// Do nothing if the state value is null.
 	if req.StateValue.IsNull() {
 		return
 	}

--- a/internal/services/data_record/resource_data_record_test.go
+++ b/internal/services/data_record/resource_data_record_test.go
@@ -1124,6 +1124,8 @@ func TestUnitDataRecordResource_Validate_Update_Relationships(t *testing.T) {
 				contactId = "00000000-0000-0000-0000-000000000011"
 			case `{"firstname":"contact3"}`:
 				contactId = "00000000-0000-0000-0000-000000000012"
+			default:
+				contactId = "11111111-0000-0000-0000-000000000000"
 			}
 
 			resp := httpmock.NewStringResponse(http.StatusOK, "")

--- a/internal/services/environment/api_environment.go
+++ b/internal/services/environment/api_environment.go
@@ -514,6 +514,8 @@ func (client *Client) createEnvironmentWithRetry(ctx context.Context, environmen
 			return nil, errors.New("environment creation failed. provisioning state: " + envCreatedResponse.Properties.ProvisioningState)
 		}
 		createdEnvironmentId = envCreatedResponse.Name
+	default:
+		return nil, fmt.Errorf("unexpected HTTP status code: %d", apiResponse.HttpResponse.StatusCode)
 	}
 
 	env, err := client.GetEnvironment(ctx, createdEnvironmentId)

--- a/internal/services/environment/resource_environment.go
+++ b/internal/services/environment/resource_environment.go
@@ -283,7 +283,7 @@ func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 						MarkdownDescription: "Url of the environment",
 						Computed:            true,
 						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
+							modifiers.UseStateForUnknownKeepNonNullStateModifier(),
 							modifiers.SetStringAttributeUnknownOnlyIfSecondAttributeChange(path.Root("dataverse").AtName("domain")),
 						},
 					},
@@ -292,7 +292,7 @@ func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 						Optional:            true,
 						Computed:            true,
 						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
+							modifiers.UseStateForUnknownKeepNonNullStateModifier(),
 						},
 						Validators: []validator.String{
 							stringvalidator.LengthAtLeast(1),

--- a/internal/services/environment/resource_environment.go
+++ b/internal/services/environment/resource_environment.go
@@ -251,7 +251,7 @@ func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 						MarkdownDescription: "Unique name of the Dataverse environment",
 						Computed:            true,
 						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
+							modifiers.UseStateForUnknownKeepNonNullStateModifier(),
 						},
 					},
 					"administration_mode_enabled": schema.BoolAttribute{
@@ -302,7 +302,7 @@ func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 						MarkdownDescription: "Organization id (guid)",
 						Computed:            true,
 						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
+							modifiers.UseStateForUnknownKeepNonNullStateModifier(),
 						},
 					},
 					"security_group_id": schema.StringAttribute{
@@ -325,7 +325,7 @@ func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 						MarkdownDescription: "Version of the environment",
 						Computed:            true,
 						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
+							modifiers.UseStateForUnknownKeepNonNullStateModifier(),
 						},
 					},
 					"templates": schema.ListAttribute{
@@ -342,21 +342,21 @@ func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 						MarkdownDescription: "The type of the linked D365 application",
 						Computed:            true,
 						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
+							modifiers.UseStateForUnknownKeepNonNullStateModifier(),
 						},
 					},
 					"linked_app_id": schema.StringAttribute{
 						MarkdownDescription: "The GUID of the linked D365 application",
 						Computed:            true,
 						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
+							modifiers.UseStateForUnknownKeepNonNullStateModifier(),
 						},
 					},
 					"linked_app_url": schema.StringAttribute{
 						MarkdownDescription: "The URL of the linked D365 application",
 						Computed:            true,
 						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
+							modifiers.UseStateForUnknownKeepNonNullStateModifier(),
 						},
 					},
 				},

--- a/internal/services/environment_settings/models.go
+++ b/internal/services/environment_settings/models.go
@@ -253,6 +253,8 @@ func convertFromEnvironmentSettingsDto[T EnvironmentSettingsResourceModel | Envi
 			pluginTraceSettings = "Exception"
 		case 2:
 			pluginTraceSettings = "All"
+		default:
+			pluginTraceSettings = "Unknown"
 		}
 	}
 


### PR DESCRIPTION
This pull request introduces a custom plan modifier to address a breaking change in the `terraform-plugin-framework` regarding how unknown and null values are handled for computed string attributes. The new modifier ensures that once an attribute is set to a non-null value, it will not revert to null, maintaining compatibility with bulk operations and preventing issues with resource IDs.

**Plan modifier changes:**

* Added a new custom plan modifier `UseStateForUnknownKeepNonNullStateModifier` in `internal/modifiers/use_state_for_unknown_keep_non_null_state_modifier.go` to preserve non-null state values for string attributes, even when the plan value is unknown.
* Updated all relevant string attributes in `internal/services/environment/resource_environment.go` to use the new custom plan modifier instead of the default `UseStateForUnknown`. This change affects attributes such as `name`, `organization_id`, `version`, `linked_app_type`, `linked_app_id`, and `linked_app_url`. [[1]](diffhunk://#diff-f5dfd8b19cc74212734109f64e3404cb525bb247f0786830e21096a996c9e9adL254-R254) [[2]](diffhunk://#diff-f5dfd8b19cc74212734109f64e3404cb525bb247f0786830e21096a996c9e9adL305-R305) [[3]](diffhunk://#diff-f5dfd8b19cc74212734109f64e3404cb525bb247f0786830e21096a996c9e9adL328-R328) [[4]](diffhunk://#diff-f5dfd8b19cc74212734109f64e3404cb525bb247f0786830e21096a996c9e9adL345-R359)