### PR TITLE
powerplatform_data_loss_prevention policy returns error with custom connector patterns

### DIFF
--- a/.changes/unreleased/fixed-20251006-152350.yaml
+++ b/.changes/unreleased/fixed-20251006-152350.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Fixed custom connector URL patterns in data loss prevention policies to maintain correct order based on rule order property
+time: 2025-10-06T15:23:50.926773984Z
+custom:
+    Issue: "943"

--- a/internal/services/dlp_policy/api_dlp_policy.go
+++ b/internal/services/dlp_policy/api_dlp_policy.go
@@ -239,8 +239,19 @@ func covertDlpPolicyToPolicyModel(policy dlpPolicyDto) (*dlpPolicyModelDto, erro
 	}
 
 	sort.Slice(policyModel.CustomConnectorUrlPatternsDefinition, func(i, j int) bool {
-		// Compare the Order of the first rule in each definition (assuming at least one rule per definition)
-		return policyModel.CustomConnectorUrlPatternsDefinition[i].Rules[0].Order < policyModel.CustomConnectorUrlPatternsDefinition[j].Rules[0].Order
+		// Safely compare the Order of the first rule in each definition, handling empty Rules slices
+		rulesI := policyModel.CustomConnectorUrlPatternsDefinition[i].Rules
+		rulesJ := policyModel.CustomConnectorUrlPatternsDefinition[j].Rules
+		if len(rulesI) == 0 && len(rulesJ) == 0 {
+			return i < j // stable sort for empty slices
+		}
+		if len(rulesI) == 0 {
+			return true // empty comes before non-empty
+		}
+		if len(rulesJ) == 0 {
+			return false // non-empty comes after empty
+		}
+		return rulesI[0].Order < rulesJ[0].Order
 	})
 
 	return &policyModel, nil

--- a/internal/services/dlp_policy/api_dlp_policy.go
+++ b/internal/services/dlp_policy/api_dlp_policy.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 
 	"github.com/microsoft/terraform-provider-power-platform/internal/api"
@@ -236,6 +237,11 @@ func covertDlpPolicyToPolicyModel(policy dlpPolicyDto) (*dlpPolicyModelDto, erro
 			Rules: append([]dlpConnectorUrlPatternsRuleDto{}, rule),
 		})
 	}
+
+	sort.Slice(policyModel.CustomConnectorUrlPatternsDefinition, func(i, j int) bool {
+		// Compare the Order of the first rule in each definition (assuming at least one rule per definition)
+		return policyModel.CustomConnectorUrlPatternsDefinition[i].Rules[0].Order < policyModel.CustomConnectorUrlPatternsDefinition[j].Rules[0].Order
+	})
 
 	return &policyModel, nil
 }

--- a/internal/services/dlp_policy/datasource_dlp_policy_test.go
+++ b/internal/services/dlp_policy/datasource_dlp_policy_test.go
@@ -91,9 +91,12 @@ func TestUnitDlpPolicyDataSource_Validate_Read(t *testing.T) {
 					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.environments.0", "be0eb809-e58a-ec1b-8fce-ea40b0e53442"),
 
 					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.custom_connectors_patterns.#", "2"),
-					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.custom_connectors_patterns.1.data_group", "NonBusiness"),
-					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.custom_connectors_patterns.1.host_url_pattern", "http://aaa.com"),
-					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.custom_connectors_patterns.1.order", "1"),
+					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.custom_connectors_patterns.0.order", "1"),
+					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.custom_connectors_patterns.0.data_group", "Business"),
+					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.custom_connectors_patterns.0.host_url_pattern", "http://aaa.com"),
+					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.custom_connectors_patterns.1.order", "2"),
+					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.custom_connectors_patterns.1.data_group", "Ignore"),
+					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.custom_connectors_patterns.1.host_url_pattern", "*"),
 				),
 			},
 		},
@@ -101,8 +104,6 @@ func TestUnitDlpPolicyDataSource_Validate_Read(t *testing.T) {
 }
 
 func TestAccDlpPolicyDataSource_Validate_Read(t *testing.T) {
-	t.Skip("Skipping due to inconsistent connectors results")
-
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -189,8 +190,8 @@ func TestAccDlpPolicyDataSource_Validate_Read(t *testing.T) {
 					custom_connectors_patterns = toset([
 					  {
 						order            = 1
-						host_url_pattern = "https://*.contoso.com"
-						data_group       = "Blocked"
+						host_url_pattern = "https://*.contoso.com/*"
+						data_group       = "Business"
 					  },
 					  {
 						order            = 2
@@ -212,8 +213,8 @@ func TestAccDlpPolicyDataSource_Validate_Read(t *testing.T) {
 					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.0.environments.#", "0"),
 
 					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.0.custom_connectors_patterns.#", "2"),
-					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.0.custom_connectors_patterns.0.data_group", "Blocked"),
-					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.0.custom_connectors_patterns.0.host_url_pattern", "https://*.contoso.com"),
+					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.0.custom_connectors_patterns.0.data_group", "Business"),
+					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.0.custom_connectors_patterns.0.host_url_pattern", "https://*.contoso.com/*"),
 					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.0.custom_connectors_patterns.0.order", "1"),
 					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.0.custom_connectors_patterns.1.data_group", "Ignore"),
 					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.0.custom_connectors_patterns.1.host_url_pattern", "*"),
@@ -237,36 +238,6 @@ func TestAccDlpPolicyDataSource_Validate_Read(t *testing.T) {
 					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.0.business_connectors.0.endpoint_rules.1.order", "2"),
 					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.0.business_connectors.0.endpoint_rules.1.behavior", "Deny"),
 					resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.0.business_connectors.0.endpoint_rules.1.endpoint", "*"),
-
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.blocked_connectors.#", "0"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.non_business_connectors.#", "4"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.business_connectors.#", "2"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.business_connectors.1.id", "/providers/Microsoft.PowerApps/apis/shared_office365users"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.business_connectors.1.default_action_rule_behavior", ""),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.business_connectors.1.action_rules.#", "0"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.business_connectors.1.endpoint_rules.#", "0"),
-
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.business_connectors.0.id", "/providers/Microsoft.PowerApps/apis/shared_azureblob"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.business_connectors.0.default_action_rule_behavior", "Block"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.business_connectors.0.action_rules.#", "13"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.business_connectors.0.action_rules.0.action_id", "CreateFile_V2"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.business_connectors.0.action_rules.0.behavior", "Allow"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.business_connectors.0.endpoint_rules.#", "1"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.business_connectors.0.endpoint_rules.0.behavior", "Deny"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.business_connectors.0.endpoint_rules.0.endpoint", "*"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.business_connectors.0.endpoint_rules.0.order", "1"),
-
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.created_by", "admin"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.created_time", "2023-10-02T07:38:56.6864176Z"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.default_connectors_classification", "General"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.id", "00000000-0000-0000-0000-000000000002"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.display_name", "a2"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.last_modified_by", "admin"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.last_modified_time", "2023-10-02T07:56:43.9700369Z"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.environment_type", "ExceptEnvironments"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.environments.#", "1"),
-					// resource.TestCheckResourceAttr("data.powerplatform_data_loss_prevention_policies.all", "policies.1.environments.0", "be0eb809-e58a-ec1b-8fce-ea40b0e53442"),
-
 				),
 			},
 		},

--- a/internal/services/dlp_policy/helpers.go
+++ b/internal/services/dlp_policy/helpers.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -245,7 +246,6 @@ func convertToDlpCustomConnectorUrlPatternsDefinition(ctx context.Context, diags
 		return nil, errors.New("client error when converting DlpCustomConnectorUrlPatternsDefinition")
 	}
 
-	//customConnectorsPatterns = sortCustomConnectorPatternsByOrder(customConnectorsPatterns)
 	customConnectorUrlPatternsDefinition := make([]dlpConnectorUrlPatternsDefinitionDto, 0)
 	for _, customConnectorPattern := range customConnectorsPatterns {
 		urlPattern := dlpConnectorUrlPatternsDefinitionDto{
@@ -258,6 +258,10 @@ func convertToDlpCustomConnectorUrlPatternsDefinition(ctx context.Context, diags
 		})
 		customConnectorUrlPatternsDefinition = append(customConnectorUrlPatternsDefinition, urlPattern)
 	}
+	sort.Slice(customConnectorUrlPatternsDefinition, func(i, j int) bool {
+		return customConnectorUrlPatternsDefinition[i].Rules[0].Order < customConnectorUrlPatternsDefinition[j].Rules[0].Order
+	})
+
 	return customConnectorUrlPatternsDefinition, nil
 }
 

--- a/internal/services/dlp_policy/helpers.go
+++ b/internal/services/dlp_policy/helpers.go
@@ -259,6 +259,13 @@ func convertToDlpCustomConnectorUrlPatternsDefinition(ctx context.Context, diags
 		customConnectorUrlPatternsDefinition = append(customConnectorUrlPatternsDefinition, urlPattern)
 	}
 	sort.Slice(customConnectorUrlPatternsDefinition, func(i, j int) bool {
+		// Defensive: If either Rules slice is empty, treat empty as "greater" (sort to end)
+		if len(customConnectorUrlPatternsDefinition[i].Rules) == 0 {
+			return false
+		}
+		if len(customConnectorUrlPatternsDefinition[j].Rules) == 0 {
+			return true
+		}
 		return customConnectorUrlPatternsDefinition[i].Rules[0].Order < customConnectorUrlPatternsDefinition[j].Rules[0].Order
 	})
 

--- a/internal/services/dlp_policy/helpers.go
+++ b/internal/services/dlp_policy/helpers.go
@@ -76,14 +76,14 @@ func covertDlpPolicyToPolicyModelDto(policy dlpPolicyDto) (*dlpPolicyModelDto, e
 
 func convertConnectorRuleClassificationValues(value string) string {
 	switch value {
-	case "Business":
-		return "General"
 	case "NonBusiness":
-		return "Confidential"
+		return "General"
 	case "General":
-		return "Business"
-	case "Confidential":
 		return "NonBusiness"
+	case "Confidential":
+		return "Business"
+	case "Business":
+		return "Confidential"
 	default:
 		return value
 	}
@@ -245,6 +245,7 @@ func convertToDlpCustomConnectorUrlPatternsDefinition(ctx context.Context, diags
 		return nil, errors.New("client error when converting DlpCustomConnectorUrlPatternsDefinition")
 	}
 
+	//customConnectorsPatterns = sortCustomConnectorPatternsByOrder(customConnectorsPatterns)
 	customConnectorUrlPatternsDefinition := make([]dlpConnectorUrlPatternsDefinitionDto, 0)
 	for _, customConnectorPattern := range customConnectorsPatterns {
 		urlPattern := dlpConnectorUrlPatternsDefinitionDto{

--- a/internal/services/dlp_policy/resource_dlp_policy_test.go
+++ b/internal/services/dlp_policy/resource_dlp_policy_test.go
@@ -918,8 +918,6 @@ func TestUnitDataLossPreventionPolicyResource_Validate_Create(t *testing.T) {
 }
 
 func TestAccDataLossPreventionPolicyResource_Validate_Create(t *testing.T) {
-	t.Skip("Skipping as there is inconsistency in API in connectors returned")
-
 	resource.Test(t, resource.TestCase{
 		IsUnitTest:               false,
 		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,


### PR DESCRIPTION
This pull request addresses an issue with the ordering of custom connector URL patterns within data loss prevention (DLP) policies. The main improvement is ensuring that these patterns are consistently sorted according to the `Order` property of their rules, which affects both how policies are processed and how they are validated in tests. Additionally, there are updates to connector classification value mappings and test cleanups to reflect the corrected behavior.

**Custom Connector URL Pattern Ordering:**

* Added sorting of `CustomConnectorUrlPatternsDefinition` by the `Order` property of the first rule in both `api_dlp_policy.go` and `helpers.go` to ensure correct policy order. [[1]](diffhunk://#diff-7a5f1be55057b8a44b869242e9b5768dc1892ba81867e2724d8ff5afb411f7edR241-R245) [[2]](diffhunk://#diff-9adcdc83017f4ea451fa0018cfff562fb0669da78bb4c1fae595c5edfe1386f9R261-R264)

**Connector Classification Value Mapping:**

* Updated the `convertConnectorRuleClassificationValues` function to correctly map connector classification values, swapping the previous mappings for "Business", "NonBusiness", "General", and "Confidential".

**Test Updates and Cleanups:**

* Modified acceptance and unit tests in `datasource_dlp_policy_test.go` to validate the new ordering and classification mappings, including changes to expected attribute values and removal of test skips. [[1]](diffhunk://#diff-18f726e8fab3b93ea092d01b3badadd893e2074ae6d450ae22b1b5fdcb9f71b9L94-L105) [[2]](diffhunk://#diff-18f726e8fab3b93ea092d01b3badadd893e2074ae6d450ae22b1b5fdcb9f71b9L192-R194) [[3]](diffhunk://#diff-18f726e8fab3b93ea092d01b3badadd893e2074ae6d450ae22b1b5fdcb9f71b9L215-R217) [[4]](diffhunk://#diff-18f726e8fab3b93ea092d01b3badadd893e2074ae6d450ae22b1b5fdcb9f71b9L240-L269) [[5]](diffhunk://#diff-47a9201d3bd5f97820c6fd779ebfeae4a92470955897ed6128f718979aea7ed2L921-L922)

**Bug Fix Documentation:**

* Added a changelog entry documenting the fix for custom connector URL pattern ordering in DLP policies.