### PR TITLE
power platform environment delete fails after environment is already gone because bapi 404 is surfaced as an error

### DIFF
--- a/.changes/unreleased/fixed-20260401-121623.yaml
+++ b/.changes/unreleased/fixed-20260401-121623.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Fix powerplatform_environment delete failing when lifecycle operation poll returns 404 after environment is already deleted
+time: 2026-04-01T12:16:23.22418013Z
+custom:
+    Issue: "1102"

--- a/.devcontainer/features/local_provider_dev/install.sh
+++ b/.devcontainer/features/local_provider_dev/install.sh
@@ -53,3 +53,11 @@ curl -fsSL https://aka.ms/install-azd.sh | bash
 # Turn off telemetry for azd
 export AZURE_DEV_COLLECT_TELEMETRY=no
 
+# Install Azure CLI via pipx (avoids distutils issues with Python 3.12+)
+if ! command -v az > /dev/null 2>&1; then
+    python3 -m ensurepip --upgrade
+    python3 -m pip install --quiet pipx
+    PIPX_HOME=/usr/local/pipx PIPX_BIN_DIR=/usr/local/bin python3 -m pipx install azure-cli
+fi
+az version
+

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -283,7 +283,7 @@ Use the Terraform plugin logger (`tflog`) for logging within resource implementa
 
 ## Tools
 
- - Developer.md file describes usage of mitmproxy for recording API interactions that is helpful for debugging and creating unit tests with realistic mock responses.You can use it to capture API calls made by the provider during acceptance tests, and save the relevant request/response pairs as JSON fixtures for unit tests.
+ - DEVELOPER.md file describes usage of mitmproxy for recording API interactions that is helpful for debugging and creating unit tests with realistic mock responses. You can use it to capture API calls made by the provider during acceptance tests, and save the relevant request/response pairs as JSON fixtures for unit tests.
 
 ### Changelog Management with Changie
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -283,6 +283,8 @@ Use the Terraform plugin logger (`tflog`) for logging within resource implementa
 
 ## Tools
 
+ - Developer.md file describes usage of mitmproxy for recording API interactions that is helpful for debugging and creating unit tests with realistic mock responses.You can use it to capture API calls made by the provider during acceptance tests, and save the relevant request/response pairs as JSON fixtures for unit tests.
+
 ### Changelog Management with Changie
 
 - Use [Changie](https://changie.dev/) to create a single changelog entry for each pull request or change.

--- a/internal/api/lifecycle.go
+++ b/internal/api/lifecycle.go
@@ -70,12 +70,19 @@ func (client *Client) DoWaitForLifecycleOperationStatus(ctx context.Context, res
 
 	for {
 		lifecycleResponse := LifecycleDto{}
-		response, err = client.Execute(ctx, nil, "GET", locationHeader, nil, nil, []int{http.StatusOK, http.StatusConflict}, &lifecycleResponse)
+		response, err = client.Execute(ctx, nil, "GET", locationHeader, nil, nil, []int{http.StatusOK, http.StatusConflict, http.StatusNotFound}, &lifecycleResponse)
 		if err != nil {
 			return nil, err
+
 		}
 
 		tflog.Debug(ctx, "Lifecycle Operation HTTP Status: '"+response.HttpResponse.Status+"'")
+
+		if response.HttpResponse.StatusCode == http.StatusNotFound {
+			tflog.Info(ctx, "Lifecycle operation returned 404 - resource already gone, treating as success")
+			return nil, nil
+		}
+
 		if response.HttpResponse.StatusCode == http.StatusConflict {
 			err = client.SleepWithContext(ctx, waitFor)
 			if err != nil {
@@ -84,7 +91,6 @@ func (client *Client) DoWaitForLifecycleOperationStatus(ctx context.Context, res
 			continue
 		}
 		tflog.Debug(ctx, "Lifecycle Operation State: '"+lifecycleResponse.State.Id+"'")
-
 		if lifecycleResponse.State.Id == "Succeeded" || lifecycleResponse.State.Id == "Failed" {
 			return &lifecycleResponse, nil
 		}

--- a/internal/api/lifecycle.go
+++ b/internal/api/lifecycle.go
@@ -73,7 +73,6 @@ func (client *Client) DoWaitForLifecycleOperationStatus(ctx context.Context, res
 		response, err = client.Execute(ctx, nil, "GET", locationHeader, nil, nil, []int{http.StatusOK, http.StatusConflict, http.StatusNotFound}, &lifecycleResponse)
 		if err != nil {
 			return nil, err
-
 		}
 
 		tflog.Debug(ctx, "Lifecycle Operation HTTP Status: '"+response.HttpResponse.Status+"'")

--- a/internal/api/lifecycle.go
+++ b/internal/api/lifecycle.go
@@ -79,7 +79,7 @@ func (client *Client) DoWaitForLifecycleOperationStatus(ctx context.Context, res
 		tflog.Debug(ctx, "Lifecycle Operation HTTP Status: '"+response.HttpResponse.Status+"'")
 
 		if response.HttpResponse.StatusCode == http.StatusNotFound {
-			tflog.Info(ctx, "Lifecycle operation returned 404 - resource already gone, treating as success")
+			tflog.Debug(ctx, "Lifecycle operation returned 404 - resource already gone, treating as success")
 			// Return a non-nil LifecycleDto sentinel so callers can safely dereference the result.
 			lifecycleResponse.State.Id = "Succeeded"
 			return &lifecycleResponse, nil

--- a/internal/api/lifecycle.go
+++ b/internal/api/lifecycle.go
@@ -80,7 +80,9 @@ func (client *Client) DoWaitForLifecycleOperationStatus(ctx context.Context, res
 
 		if response.HttpResponse.StatusCode == http.StatusNotFound {
 			tflog.Info(ctx, "Lifecycle operation returned 404 - resource already gone, treating as success")
-			return nil, nil
+			// Return a non-nil LifecycleDto sentinel so callers can safely dereference the result.
+			lifecycleResponse.State.Id = "Succeeded"
+			return &lifecycleResponse, nil
 		}
 
 		if response.HttpResponse.StatusCode == http.StatusConflict {

--- a/internal/services/environment/resource_environment_test.go
+++ b/internal/services/environment/resource_environment_test.go
@@ -3148,3 +3148,68 @@ func TestUnitEnvironmentsResource_Validate_Create_No_Dataverse_Region_Not_Availa
 		},
 	})
 }
+
+// TestUnitEnvironmentsResource_Validate_Delete_With_Lifecycle_404 verifies that when the lifecycle
+// operation polling returns 404 (environment already gone), the provider treats this as a successful
+// deletion and removes the resource from state without surfacing an error (issue #1102).
+func TestUnitEnvironmentsResource_Validate_Delete_With_Lifecycle_404(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	mocks.ActivateEnvironmentHttpMocks()
+
+	// The lifecycle polling URL returns 404, simulating the environment being already deleted
+	httpmock.RegisterResponder("GET", "https://europe.api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/00000000-0000-0000-0000-000000000001?api-version=2023-06-01",
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(http.StatusNotFound, ""), nil
+		})
+
+	httpmock.RegisterResponder("GET", `=~^https://api\.bap\.microsoft\.com/providers/Microsoft\.BusinessAppPlatform/scopes/admin/environments/([\d-]+)\z`,
+		func(req *http.Request) (*http.Response, error) {
+			id := httpmock.MustGetSubmatch(req, 1)
+			return httpmock.NewStringResponse(http.StatusOK, httpmock.File(fmt.Sprintf("tests/resource/Validate_Delete_With_Lifecycle_404/get_environment_%s.json", id)).String()), nil
+		})
+
+	httpmock.RegisterResponder("DELETE", `=~^https://api\.bap\.microsoft\.com/providers/Microsoft\.BusinessAppPlatform/scopes/admin/environments/([\d-]+)\z`,
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(http.StatusAccepted, "")
+			resp.Header.Add("Location", "https://europe.api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/00000000-0000-0000-0000-000000000001?api-version=2023-06-01")
+			return resp, nil
+		})
+
+	httpmock.RegisterResponder("GET", "https://europe.api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/b03e1e6d-73db-4367-90e1-2e378bf7e2fc?api-version=2023-06-01",
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(http.StatusOK, httpmock.File("tests/resource/Validate_Delete_With_Lifecycle_404/get_lifecycle.json").String()), nil
+		})
+
+	httpmock.RegisterResponder("POST", "https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/environments?api-version=2023-06-01",
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(http.StatusAccepted, "")
+			resp.Header.Add("Location", "https://europe.api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/b03e1e6d-73db-4367-90e1-2e378bf7e2fc?api-version=2023-06-01")
+			return resp, nil
+		})
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				resource "powerplatform_environment" "development" {
+					display_name     = "displayname"
+					location         = "europe"
+					environment_type = "Sandbox"
+					dataverse = {
+						language_code     = "1033"
+						currency_code     = "PLN"
+						domain            = "00000000-0000-0000-0000-000000000001"
+						security_group_id = "00000000-0000-0000-0000-000000000000"
+					}
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("powerplatform_environment.development", "id", "00000000-0000-0000-0000-000000000001"),
+				),
+			},
+		},
+	})
+}

--- a/internal/services/environment/tests/resource/Validate_Delete_With_Lifecycle_404/get_environment_00000000-0000-0000-0000-000000000001.json
+++ b/internal/services/environment/tests/resource/Validate_Delete_With_Lifecycle_404/get_environment_00000000-0000-0000-0000-000000000001.json
@@ -1,0 +1,158 @@
+{
+    "id": "/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/00000000-0000-0000-0000-000000000001",
+    "type": "Microsoft.BusinessAppPlatform/scopes/environments",
+    "location": "europe",
+    "name": "00000000-0000-0000-0000-000000000001",
+    "properties": {
+        "tenantId": "123",
+        "azureRegion": "westeurope",
+        "displayName": "displayname",
+        "createdTime": "2023-09-27T07:08:27.6057592Z",
+        "createdBy": {
+            "id": "f99f844b-ce3b-49ae-86f3-e374ecae789c",
+            "displayName": "admin",
+            "email": "admin",
+            "type": "User",
+            "tenantId": "123",
+            "userPrincipalName": "admin"
+        },
+        "billingPolicy": {
+            "id": ""
+        },
+        "lastModifiedTime": "2023-09-27T07:08:34.9205145Z",
+        "provisioningState": "Succeeded",
+        "creationType": "User",
+        "environmentSku": "Sandbox",
+        "isDefault": false,
+        "capacity": [
+            {
+                "capacityType": "Database",
+                "actualConsumption": 885.0391,
+                "ratedConsumption": 1024.0,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            },
+            {
+                "capacityType": "File",
+                "actualConsumption": 1187.142,
+                "ratedConsumption": 1187.142,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            },
+            {
+                "capacityType": "Log",
+                "actualConsumption": 0.0,
+                "ratedConsumption": 0.0,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            },
+            {
+                "capacityType": "FinOpsDatabase",
+                "actualConsumption": 0.0,
+                "ratedConsumption": 0.0,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            },
+            {
+                "capacityType": "FinOpsFile",
+                "actualConsumption": 0.0,
+                "ratedConsumption": 0.0,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            }
+        ],
+        "addons": [],
+        "clientUris": {
+            "admin": "https://admin.powerplatform.microsoft.com/environments/environment/456/hub",
+            "maker": "https://make.powerapps.com/environments/456/home"
+        },
+        "runtimeEndpoints": {
+            "microsoft.BusinessAppPlatform": "https://europe.api.bap.microsoft.com",
+            "microsoft.CommonDataModel": "https://europe.api.cds.microsoft.com",
+            "microsoft.PowerApps": "https://europe.api.powerapps.com",
+            "microsoft.PowerAppsAdvisor": "https://europe.api.advisor.powerapps.com",
+            "microsoft.PowerVirtualAgents": "https://powervamg.eu-il107.gateway.prod.island.powerapps.com",
+            "microsoft.ApiManagement": "https://management.EUROPE.azure-apihub.net",
+            "microsoft.Flow": "https://emea.api.flow.microsoft.com"
+        },
+        "databaseType": "CommonDataService",
+        "linkedEnvironmentMetadata": {
+            "resourceId": "orgid",
+            "friendlyName": "displayname",
+            "uniqueName": "00000000-0000-0000-0000-000000000001",
+            "domainName": "00000000-0000-0000-0000-000000000001",
+            "version": "9.2.23092.00206",
+            "instanceUrl": "https://00000000-0000-0000-0000-000000000001.crm4.dynamics.com/",
+            "instanceApiUrl": "https://00000000-0000-0000-0000-000000000001.api.crm4.dynamics.com",
+            "baseLanguage": 1033,
+            "instanceState": "Ready",
+            "createdTime": "2023-09-27T07:08:28.957Z",
+            "backgroundOperationsState": "Enabled",
+            "scaleGroup": "EURCRMLIVESG705",
+            "platformSku": "Standard",
+            "schemaType": "Standard"
+        },
+        "trialScenarioType": "None",
+        "notificationMetadata": {
+            "state": "NotSpecified",
+            "branding": "NotSpecific"
+        },
+        "retentionPeriod": "P7D",
+        "states": {
+            "management": {
+                "id": "Ready"
+            },
+            "runtime": {
+                "runtimeReasonCode": "NotSpecified",
+                "requestedBy": {
+                    "displayName": "SYSTEM",
+                    "type": "NotSpecified"
+                },
+                "id": "Enabled"
+            }
+        },
+        "updateCadence": {
+            "id": "Moderate"
+        },
+        "retentionDetails": {
+            "retentionPeriod": "P7D",
+            "backupsAvailableFromDateTime": "2023-10-03T09:23:06.1717665Z"
+        },
+        "protectionStatus": {
+            "keyManagedBy": "Microsoft"
+        },
+        "cluster": {
+            "category": "Prod",
+            "number": "107",
+            "uriSuffix": "eu-il107.gateway.prod.island",
+            "geoShortName": "EU",
+            "environment": "Prod"
+        },
+        "connectedGroups": [],
+        "lifecycleOperationsEnforcement": {
+            "allowedOperations": [
+                {
+                    "type": {
+                        "id": "DisableGovernanceConfiguration"
+                    },
+                    "reason": {
+                        "message": "DisableGovernanceConfiguration cannot be performed on Power Platform environment because of the governance configuration.",
+                        "type": "GovernanceConfig"
+                    }
+                },
+                {
+                    "type": {
+                        "id": "UpdateGovernanceConfiguration"
+                    },
+                    "reason": {
+                        "message": "UpdateGovernanceConfiguration cannot be performed on Power Platform environment because of the governance configuration.",
+                        "type": "GovernanceConfig"
+                    }
+                }
+            ]
+        },
+        "governanceConfiguration": {
+            "protectionLevel": "Basic"
+        }
+    }
+}

--- a/internal/services/environment/tests/resource/Validate_Delete_With_Lifecycle_404/get_lifecycle.json
+++ b/internal/services/environment/tests/resource/Validate_Delete_With_Lifecycle_404/get_lifecycle.json
@@ -1,0 +1,64 @@
+{
+    "id": "b03e1e6d-73db-4367-90e1-2e378bf7e2fc",
+    "links": {
+        "self": {
+            "path": "/providers/Microsoft.BusinessAppPlatform/lifecycleOperations/b03e1e6d-73db-4367-90e1-2e378bf7e2fc"
+        },
+        "environment": {
+            "path": "/providers/Microsoft.BusinessAppPlatform/environments/00000000-0000-0000-0000-000000000001"
+        }
+    },
+    "type": {
+        "id": "Create"
+    },
+    "typeDisplayName": "Create",
+    "state": {
+        "id": "Succeeded"
+    },
+    "createdDateTime": "2023-10-11T07:45:25.3761337Z",
+    "lastActionDateTime": "2023-10-11T07:45:43.4915067Z",
+    "requestedBy": {
+        "id": "8784d9fb-deb0-4811-96ce-fbf21cf3a1fc",
+        "displayName": "ServicePrincipal",
+        "type": "ServicePrincipal",
+        "tenantId": "123"
+    },
+    "stages": [
+        {
+            "id": "Validate",
+            "name": "Validate",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:25.9230185Z",
+            "lastActionDateTime": "2023-10-11T07:45:25.9230185Z"
+        },
+        {
+            "id": "Prepare",
+            "name": "Prepare",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:25.9230185Z",
+            "lastActionDateTime": "2023-10-11T07:45:25.9230185Z"
+        },
+        {
+            "id": "Run",
+            "name": "Run",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:26.0011473Z",
+            "lastActionDateTime": "2023-10-11T07:45:33.2570938Z"
+        },
+        {
+            "id": "Finalize",
+            "name": "Finalize",
+            "state": {
+                "id": "Succeeded"
+            },
+            "firstActionDateTime": "2023-10-11T07:45:33.3352196Z",
+            "lastActionDateTime": "2023-10-11T07:45:43.4915067Z"
+        }
+    ]
+}


### PR DESCRIPTION
This pull request addresses an issue where deleting a `powerplatform_environment` resource could fail if the lifecycle operation polling returned a 404 status, which indicates the environment was already deleted. The changes ensure that a 404 response during deletion is now treated as a successful deletion rather than an error. Additionally, the PR adds a unit test to verify this behavior and improves the development environment setup and documentation.

**Bug fix and improved deletion handling:**

* Updated the `DoWaitForLifecycleOperationStatus` method in `internal/api/lifecycle.go` to treat HTTP 404 responses during lifecycle operation polling as a successful deletion, resolving issue #1102.
* Added a changelog entry describing the fix for the deletion issue when a 404 is returned. (.changes/unreleased/fixed-20260401-121623.yaml)

**Testing improvements:**

* Added a new unit test `TestUnitEnvironmentsResource_Validate_Delete_With_Lifecycle_404` in `internal/services/environment/resource_environment_test.go` to verify that a 404 response during deletion is handled as success, including relevant test fixtures. [[1]](diffhunk://#diff-07ad5067382ca0f319e0f77b1f72649a105aa53a05b7231cb67b9249f2bad472R3151-R3215) [[2]](diffhunk://#diff-7cafc71785bfadd21abe35f5478696a334703673ecd7b0a3fc706414e6fa6c91R1-R158) [[3]](diffhunk://#diff-d3a0998449cb84bbcb4ff24c48e05801d5525be9cfe56c06ff69e7be82a0ef2eR1-R64)

**Development environment and documentation:**

* Updated the development container setup script to install Azure CLI via pipx, improving compatibility with Python 3.12+. (.devcontainer/features/local_provider_dev/install.sh)
* Added documentation on using mitmproxy for recording API interactions to assist with debugging and creating unit tests. (.github/copilot-instructions.md)