### PR TITLE
Crash when importing powerplatform_environment_group_rule_set

### DIFF
--- a/.changes/unreleased/fixed-20260401-122341.yaml
+++ b/.changes/unreleased/fixed-20260401-122341.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Fixed crash when importing powerplatform_environment_group_rule_set caused by testify assert calls in production DTO conversion code
+time: 2026-04-01T12:23:41.850214Z
+custom:
+    Issue: "1112"

--- a/internal/services/environment_group_rule_set/dto.go
+++ b/internal/services/environment_group_rule_set/dto.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/stretchr/testify/assert"
 )
 
 type environmentGroupRuleSetDto struct {
@@ -447,9 +446,6 @@ func convertAiGenerativeSettingsDtoToModel(dto *environmentGroupRuleSetParameter
 		return types.ObjectType{AttrTypes: attrType}, types.ObjectNull(attrType), nil
 	}
 
-	assert.Equal(nil, AI_GENERATIVE_SETTINGS, dto.Type, fmt.Sprintf("Type should be %s", AI_GENERATIVE_SETTINGS))
-	assert.Equal(nil, NOT_SPECIFIED, dto.ResourceType, fmt.Sprintf("ResourceType should be %s", NOT_SPECIFIED))
-
 	crossGeoCopilotDataMovementEnabled := tryGetRuleValueFromDto(dto.Value, CROSS_GEO_COPILOT_DATA_MOVEMENT_ENABLED)
 	if crossGeoCopilotDataMovementEnabled == nil {
 		return types.ObjectType{AttrTypes: attrType}, types.ObjectNull(attrType), fmt.Errorf("%s value not found in response", CROSS_GEO_COPILOT_DATA_MOVEMENT_ENABLED)
@@ -475,9 +471,6 @@ func convertAiGeneratedDescDtoToModel(dto *environmentGroupRuleSetParameterDto) 
 		return types.ObjectType{AttrTypes: attrType}, types.ObjectNull(attrType), nil
 	}
 
-	assert.Equal(nil, AI_GENERATED_DESC, dto.Type, fmt.Sprintf("Type should be %s", AI_GENERATED_DESC))
-	assert.Equal(nil, APP, dto.ResourceType, fmt.Sprintf("ResourceType should be %s", APP))
-
 	aiDescriptionEnabled := tryGetRuleValueFromDto(dto.Value, DISABLE_AI_GENERATED_DESCRIPTIONS)
 	if aiDescriptionEnabled == nil {
 		return types.ObjectType{AttrTypes: attrType}, types.ObjectNull(attrType), fmt.Errorf("%s value not found in response", DISABLE_AI_GENERATED_DESCRIPTIONS)
@@ -497,9 +490,6 @@ func convertBackupRetentionDtoToModel(dto *environmentGroupRuleSetParameterDto) 
 	if dto == nil || len(dto.Value) == 0 {
 		return types.ObjectType{AttrTypes: attrType}, types.ObjectNull(attrType), nil
 	}
-
-	assert.Equal(nil, BACKUP_RETENTION, dto.Type, fmt.Sprintf("Type should be %s", BACKUP_RETENTION))
-	assert.Equal(nil, NOT_SPECIFIED, dto.ResourceType, fmt.Sprintf("ResourceType should be %s", NOT_SPECIFIED))
 
 	periodInDays := tryGetRuleValueFromDto(dto.Value, RETENTION_PERIOD)
 	if periodInDays == nil {
@@ -532,9 +522,6 @@ func convertSolutionCheckerEnforcementDtoToModel(dto *environmentGroupRuleSetPar
 		return types.ObjectType{AttrTypes: attrType}, types.ObjectNull(attrType), nil
 	}
 
-	assert.Equal(nil, SOLUTION_CHECKER_ENFORCEMENT, dto.Type, fmt.Sprintf("Type should be %s", SOLUTION_CHECKER_ENFORCEMENT))
-	assert.Equal(nil, NOT_SPECIFIED, dto.ResourceType, fmt.Sprintf("ResourceType should be %s", NOT_SPECIFIED))
-
 	solutionCheckerMode := tryGetRuleValueFromDto(dto.Value, SOLUTION_CHECKER_MODE)
 	if solutionCheckerMode == nil {
 		return types.ObjectType{AttrTypes: attrType}, types.ObjectNull(attrType), fmt.Errorf("%s value not found in response", SOLUTION_CHECKER_MODE)
@@ -561,9 +548,6 @@ func convertMakerWelcomeContentDtoToModel(dto *environmentGroupRuleSetParameterD
 		return types.ObjectType{AttrTypes: attrType}, types.ObjectNull(attrType), nil
 	}
 
-	assert.Equal(nil, MAKER_WELCOME_CONTENT, dto.Type, fmt.Sprintf("Type should be %s", MAKER_WELCOME_CONTENT))
-	assert.Equal(nil, NOT_SPECIFIED, dto.ResourceType, fmt.Sprintf("ResourceType should be %s", NOT_SPECIFIED))
-
 	makerOnboardingUrl := tryGetRuleValueFromDto(dto.Value, MAKER_ONBOARDING_URL)
 	if makerOnboardingUrl == nil {
 		return types.ObjectType{AttrTypes: attrType}, types.ObjectNull(attrType), fmt.Errorf("%s value not found in response", MAKER_ONBOARDING_URL)
@@ -588,9 +572,6 @@ func convertUsageInsightsDtoToModel(dto *environmentGroupRuleSetParameterDto) (b
 		return types.ObjectType{AttrTypes: attrType}, types.ObjectNull(attrType), nil
 	}
 
-	assert.Equal(nil, USAGE_INSIGHTS, dto.Type, fmt.Sprintf("Type should be %s", USAGE_INSIGHTS))
-	assert.Equal(nil, NOT_SPECIFIED, dto.ResourceType, fmt.Sprintf("ResourceType should be %s", NOT_SPECIFIED))
-
 	excludeEnvFromAnalisys := tryGetRuleValueFromDto(dto.Value, EXCLUDE_ENVIRONMENT_FROM_ANALYSIS)
 	if excludeEnvFromAnalisys == nil {
 		return types.ObjectType{AttrTypes: attrType}, types.ObjectNull(attrType), fmt.Errorf("%s value not found in response", EXCLUDE_ENVIRONMENT_FROM_ANALYSIS)
@@ -611,9 +592,6 @@ func convertSharingControlsDtoToModel(dto *environmentGroupRuleSetParameterDto) 
 		return types.ObjectType{AttrTypes: attrType}, types.ObjectNull(attrType), nil
 	}
 
-	assert.Equal(nil, SHARING, dto.Type, fmt.Sprintf("Type should be %s", SHARING))
-	assert.Equal(nil, APP, dto.ResourceType, fmt.Sprintf("ResourceType should be %s", APP))
-
 	canShareWithSecurityGroups := tryGetRuleValueFromDto(dto.Value, CAN_SHARE_WITH_SECURITY_GROUPS)
 	if canShareWithSecurityGroups == nil {
 		return types.ObjectType{AttrTypes: attrType}, types.ObjectNull(attrType), fmt.Errorf("%s value not found in response", CAN_SHARE_WITH_SECURITY_GROUPS)
@@ -626,8 +604,6 @@ func convertSharingControlsDtoToModel(dto *environmentGroupRuleSetParameterDto) 
 
 	attrValue := map[string]attr.Value{}
 	if canShareWithSecurityGroups.Value == NO_LIMIT {
-		assert.Equal(nil, -1.0, maxLimitValue, "Max limit value should be -1, when share mode is 'no limit'")
-
 		attrValue["share_mode"] = types.StringValue("no limit")
 		attrValue["share_max_limit"] = types.NumberNull() // -1 value is considered as null in terraform
 	} else {

--- a/internal/services/environment_group_rule_set/resource_environment_group_rule_set_test.go
+++ b/internal/services/environment_group_rule_set/resource_environment_group_rule_set_test.go
@@ -438,3 +438,128 @@ func TestUnitEnvironmentGroupRuleSetResource_Validate_Update(t *testing.T) {
 		},
 	})
 }
+
+func TestUnitEnvironmentGroupRuleSetResource_Validate_Import(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	mocks.ActivateEnvironmentHttpMocks()
+
+	httpmock.RegisterResponder("POST", `https://000000000000000000000000000000.01.tenant.api.powerplatform.com/governance/environmentGroups/00000000-0000-0000-0000-000000000000/ruleSets?api-version=2021-10-01-preview`,
+		func(_ *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(http.StatusCreated, httpmock.File("tests/Validate_Create/post_rule_set.json").String()), nil
+		})
+
+	httpmock.RegisterResponder("GET", `https://000000000000000000000000000000.01.tenant.api.powerplatform.com/governance/environmentGroups/00000000-0000-0000-0000-000000000000/ruleSets?api-version=2021-10-01-preview`,
+		func(_ *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(http.StatusOK, httpmock.File("tests/Validate_Create/get_rule_set.json").String()), nil
+		})
+
+	httpmock.RegisterResponder("DELETE", `https://000000000000000000000000000000.01.tenant.api.powerplatform.com/governance/ruleSets/?api-version=2021-10-01-preview`,
+		func(_ *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(http.StatusOK, ""), nil
+		})
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				resource "powerplatform_environment_group_rule_set" "example_group_rule_set" {
+					environment_group_id = "00000000-0000-0000-0000-000000000000"
+					rules = {
+						sharing_controls = {
+							share_mode      = "exclude sharing with security groups"
+							share_max_limit = 42
+						}
+						usage_insights = {
+							insights_enabled = false
+						}
+						maker_welcome_content = {
+							maker_onboarding_url      = "https://contoso.com/onboarding"
+							maker_onboarding_markdown = "## Welcome to the environment!\n\n**This is a markdown description.**"
+						}
+						solution_checker_enforcement = {
+							solution_checker_mode = "block"
+							send_emails_enabled   = true
+						}
+						backup_retention = {
+							period_in_days = 21
+						}
+						ai_generated_descriptions = {
+							ai_description_enabled = false
+						}
+						ai_generative_settings = {
+							move_data_across_regions_enabled = true
+							bing_search_enabled              = false
+						}
+					}
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("powerplatform_environment_group_rule_set.example_group_rule_set", "environment_group_id", "00000000-0000-0000-0000-000000000000"),
+				),
+			},
+			{
+				ResourceName:      "powerplatform_environment_group_rule_set.example_group_rule_set",
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     "00000000-0000-0000-0000-000000000000",
+			},
+		},
+	})
+}
+
+func TestUnitEnvironmentGroupRuleSetResource_Validate_Import_Empty_Ruleset(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	mocks.ActivateEnvironmentHttpMocks()
+
+	httpmock.RegisterResponder("POST", `https://000000000000000000000000000000.01.tenant.api.powerplatform.com/governance/environmentGroups/00000000-0000-0000-0000-000000000000/ruleSets?api-version=2021-10-01-preview`,
+		func(_ *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(http.StatusCreated, httpmock.File("tests/Validate_Import_Empty_Ruleset/post_rule_set.json").String()), nil
+		})
+
+	httpmock.RegisterResponder("GET", `https://000000000000000000000000000000.01.tenant.api.powerplatform.com/governance/environmentGroups/00000000-0000-0000-0000-000000000000/ruleSets?api-version=2021-10-01-preview`,
+		func(_ *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(http.StatusOK, httpmock.File("tests/Validate_Import_Empty_Ruleset/get_rule_set.json").String()), nil
+		})
+
+	httpmock.RegisterResponder("DELETE", `https://000000000000000000000000000000.01.tenant.api.powerplatform.com/governance/ruleSets/00000000-0000-0000-0000-000000000001?api-version=2021-10-01-preview`,
+		func(_ *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(http.StatusOK, ""), nil
+		})
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				resource "powerplatform_environment_group_rule_set" "example_group_rule_set" {
+					environment_group_id = "00000000-0000-0000-0000-000000000000"
+					rules = {
+						sharing_controls = {
+							share_mode      = "exclude sharing with security groups"
+							share_max_limit = 42
+						}
+						usage_insights = null
+						maker_welcome_content = null
+						solution_checker_enforcement = null
+						backup_retention = null
+						ai_generated_descriptions = null
+						ai_generative_settings = null
+					}
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("powerplatform_environment_group_rule_set.example_group_rule_set", "environment_group_id", "00000000-0000-0000-0000-000000000000"),
+				),
+			},
+			{
+				ResourceName:      "powerplatform_environment_group_rule_set.example_group_rule_set",
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     "00000000-0000-0000-0000-000000000000",
+			},
+		},
+	})
+}

--- a/internal/services/environment_group_rule_set/tests/Validate_Import_Empty_Ruleset/get_rule_set.json
+++ b/internal/services/environment_group_rule_set/tests/Validate_Import_Empty_Ruleset/get_rule_set.json
@@ -1,0 +1,38 @@
+{
+    "value": [
+        {
+            "parameters": [
+                {
+                    "type": "Sharing",
+                    "resourceType": "App",
+                    "value": [
+                        {
+                            "id": "CanShareWithSecurityGroups",
+                            "value": "excludeSharingToSecurityGroups"
+                        },
+                        {
+                            "id": "IsGroupSharingDisabled",
+                            "value": "true"
+                        },
+                        {
+                            "id": "MaximumShareLimit",
+                            "value": "42"
+                        }
+                    ],
+                    "hasStagedChanges": true
+                }
+            ],
+            "id": "00000000-0000-0000-0000-000000000001",
+            "lastModified": "2024-10-24T07:30:08.241893Z",
+            "environmentFilter": {
+                "type": "Include",
+                "values": [
+                    {
+                        "id": "00000000-0000-0000-0000-000000000000",
+                        "type": "EnvironmentGroup"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/internal/services/environment_group_rule_set/tests/Validate_Import_Empty_Ruleset/post_rule_set.json
+++ b/internal/services/environment_group_rule_set/tests/Validate_Import_Empty_Ruleset/post_rule_set.json
@@ -1,0 +1,34 @@
+{
+    "parameters": [
+        {
+            "type": "Sharing",
+            "resourceType": "App",
+            "value": [
+                {
+                    "id": "CanShareWithSecurityGroups",
+                    "value": "excludeSharingToSecurityGroups"
+                },
+                {
+                    "id": "IsGroupSharingDisabled",
+                    "value": "true"
+                },
+                {
+                    "id": "MaximumShareLimit",
+                    "value": "42"
+                }
+            ],
+            "hasStagedChanges": true
+        }
+    ],
+    "id": "00000000-0000-0000-0000-000000000001",
+    "lastModified": "2024-10-24T07:30:08.241893Z",
+    "environmentFilter": {
+        "type": "Include",
+        "values": [
+            {
+                "id": "00000000-0000-0000-0000-000000000000",
+                "type": "EnvironmentGroup"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This pull request fixes a production crash when importing `powerplatform_environment_group_rule_set` resources, which was caused by the use of `testify` assert calls in DTO conversion code. The fix involves removing these test-only assertions from production code and improving test coverage for import scenarios, including cases with empty rulesets.

Key changes:

Bug fix and code cleanup:
- Removed all `testify/assert` calls from DTO conversion functions in `internal/services/environment_group_rule_set/dto.go`, preventing runtime panics in production environments. (`[[1]](diffhunk://#diff-a53f915f930dee925327900b40aabc5dbba7c40d7bc5135e58a6e8d32ca8056dL18)`, `[[2]](diffhunk://#diff-a53f915f930dee925327900b40aabc5dbba7c40d7bc5135e58a6e8d32ca8056dL450-L452)`, `[[3]](diffhunk://#diff-a53f915f930dee925327900b40aabc5dbba7c40d7bc5135e58a6e8d32ca8056dL478-L480)`, `[[4]](diffhunk://#diff-a53f915f930dee925327900b40aabc5dbba7c40d7bc5135e58a6e8d32ca8056dL501-L503)`, `[[5]](diffhunk://#diff-a53f915f930dee925327900b40aabc5dbba7c40d7bc5135e58a6e8d32ca8056dL535-L537)`, `[[6]](diffhunk://#diff-a53f915f930dee925327900b40aabc5dbba7c40d7bc5135e58a6e8d32ca8056dL564-L566)`, `[[7]](diffhunk://#diff-a53f915f930dee925327900b40aabc5dbba7c40d7bc5135e58a6e8d32ca8056dL591-L593)`, `[[8]](diffhunk://#diff-a53f915f930dee925327900b40aabc5dbba7c40d7bc5135e58a6e8d32ca8056dL614-L616)`, `[[9]](diffhunk://#diff-a53f915f930dee925327900b40aabc5dbba7c40d7bc5135e58a6e8d32ca8056dL629-L630)`)
- Updated the changelog to document the bug fix for issue 1112. (`[.changes/unreleased/fixed-20260401-122341.yamlR1-R5](diffhunk://#diff-71e49c78e563a4d4470cf9a9e84dfce09e44e8eb35eb10592695152c1edbae08R1-R5)`)

Testing improvements:
- Added new unit tests in `resource_environment_group_rule_set_test.go` to validate import functionality, including scenarios with both populated and empty rulesets. (`[internal/services/environment_group_rule_set/resource_environment_group_rule_set_test.goR441-R565](diffhunk://#diff-d348f699e1cb20a55b0de7efb4f4a911f061ec501cfa047a355f873f1c8b4cd2R441-R565)`)
- Introduced new test fixtures (`post_rule_set.json` and `get_rule_set.json`) for the empty ruleset import test case. (`[[1]](diffhunk://#diff-134f332a11ba9452ad3ea2aba63772623de17a3ef5286b3766b8adabbe4c4279R1-R38)`, `[[2]](diffhunk://#diff-c98e8a635530b11dc436b5f399ad57e2e8d0eaf32e87aa9f7b960abf9883c682R1-R34)`)