### PR TITLE
fix(user): update import syntax to require composite format for powerplatform_user resource

### DIFF
--- a/.changes/unreleased/breaking-20260402-143307.yaml
+++ b/.changes/unreleased/breaking-20260402-143307.yaml
@@ -1,0 +1,5 @@
+kind: breaking
+body: 'Fix powerplatform_user import: import ID now requires composite format environment_id/user_aad_id instead of just user_aad_id'
+time: 2026-04-02T14:33:07.1375459Z
+custom:
+    Issue: "1121"

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -154,6 +154,6 @@ Import is supported using the following syntax:
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-# User resource can be imported using the Entra Object Id (replace with a real Entra Object Id)
-terraform import powerplatform_user.example 00000000-0000-0000-0000-000000000000
+# User resource can be imported using the environment ID and Entra Object Id (replace with real values)
+terraform import powerplatform_user.example 00000000-0000-0000-0000-000000000001/00000000-0000-0000-0000-000000000002
 ```

--- a/examples/resources/powerplatform_user/import.sh
+++ b/examples/resources/powerplatform_user/import.sh
@@ -1,3 +1,2 @@
-# User resource can be imported using the Entra Object Id (replace with a real Entra Object Id)
-terraform import powerplatform_user.example 00000000-0000-0000-0000-000000000000
-
+# User resource can be imported using the environment ID and Entra Object Id (replace with real values)
+terraform import powerplatform_user.example 00000000-0000-0000-0000-000000000001/00000000-0000-0000-0000-000000000002

--- a/internal/services/authorization/resource_user.go
+++ b/internal/services/authorization/resource_user.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -480,7 +481,19 @@ func (r *UserResource) ImportState(ctx context.Context, req resource.ImportState
 	ctx, exitContext := helpers.EnterRequestContext(ctx, r.TypeInfo, req)
 	defer exitContext()
 
+	// Import ID format: {environment_id}/{aad_id}
+	idParts := strings.Split(req.ID, "/")
+	if len(idParts) != 2 {
+		resp.Diagnostics.AddError(
+			"Invalid import ID",
+			fmt.Sprintf("Expected import ID in format 'environment_id/aad_id', got '%s'", req.ID),
+		)
+		return
+	}
+
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("environment_id"), idParts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("aad_id"), idParts[1])...)
 }
 
 // validateRequiredStringField validates that a string field is not null or unknown and adds an error diagnostic if invalid.


### PR DESCRIPTION
This pull request introduces a breaking change to the import process for the `powerplatform_user` resource. The import now requires a composite ID in the format `environment_id/user_aad_id` instead of just the user AAD ID. Documentation and example scripts have been updated to reflect this change, and the import logic has been modified to parse and validate the new format.

**Breaking Change:**

* Importing a `powerplatform_user` resource now requires the composite format `environment_id/user_aad_id` instead of just the AAD ID. This is a breaking change and users must update their import commands accordingly. (.changes/unreleased/breaking-20260402-143307.yaml)

**Documentation and Example Updates:**

* Updated the import example in the documentation (`docs/resources/user.md`) to use the new composite ID format.
* Updated the example import script (`examples/resources/powerplatform_user/import.sh`) to demonstrate the new required format.

**Code Changes:**

* Modified the import logic in `resource_user.go` to parse and validate the composite import ID, extracting and setting both `environment_id` and `aad_id` attributes. [[1]](diffhunk://#diff-1f9c90c2f35775511acace8d916e9e0e5cf18d4c0f5323ee6b568b01d8df19a7R11) [[2]](diffhunk://#diff-1f9c90c2f35775511acace8d916e9e0e5cf18d4c0f5323ee6b568b01d8df19a7R484-R496)