### PR TITLE
Fix: Handle missing parent environments for users

### DIFF
--- a/.changes/unreleased/fixed-20260407-182357.yaml
+++ b/.changes/unreleased/fixed-20260407-182357.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Handle missing parent environments for powerplatform_user resources during refresh and delete
+time: 2026-04-07T18:23:57.376847+10:00
+custom:
+    Issue: "1129"

--- a/docs/resources/solution.md
+++ b/docs/resources/solution.md
@@ -19,7 +19,7 @@ terraform {
       source = "microsoft/power-platform"
     }
     local = {
-      version = "2.7.0"
+      version = "2.8.0"
       source  = "hashicorp/local"
     }
   }

--- a/internal/services/authorization/resource_user.go
+++ b/internal/services/authorization/resource_user.go
@@ -250,6 +250,10 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	hasEnvDataverse, err := r.UserClient.EnvironmentHasDataverse(ctx, state.EnvironmentId.ValueString())
 	if err != nil {
+		if errors.Is(err, customerrors.ErrObjectNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.FullTypeName()), err.Error())
 		return
 	}
@@ -439,6 +443,9 @@ func (r *UserResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 	hasEnvDataverse, err := r.UserClient.EnvironmentHasDataverse(ctx, state.EnvironmentId.ValueString())
 	if err != nil {
+		if errors.Is(err, customerrors.ErrObjectNotFound) {
+			return
+		}
 		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s", r.FullTypeName()), err.Error())
 		return
 	}

--- a/internal/services/authorization/resource_user.go
+++ b/internal/services/authorization/resource_user.go
@@ -444,6 +444,7 @@ func (r *UserResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	hasEnvDataverse, err := r.UserClient.EnvironmentHasDataverse(ctx, state.EnvironmentId.ValueString())
 	if err != nil {
 		if errors.Is(err, customerrors.ErrObjectNotFound) {
+			resp.State.RemoveResource(ctx)
 			return
 		}
 		resp.Diagnostics.AddError(fmt.Sprintf("Client error when deleting %s", r.FullTypeName()), err.Error())
@@ -480,6 +481,7 @@ func (r *UserResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 			return
 		}
 	}
+	resp.State.RemoveResource(ctx)
 	tflog.Debug(ctx, fmt.Sprintf("DELETE RESOURCE END: %s", r.FullTypeName()))
 }
 

--- a/internal/services/authorization/resource_user_test.go
+++ b/internal/services/authorization/resource_user_test.go
@@ -144,6 +144,71 @@ func TestUnitUserResource_Validate_Create_Environment_User(t *testing.T) {
 	})
 }
 
+func TestUnitUserResource_Validate_Read_Removes_State_When_Parent_Environment_Is_Deleted(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	mocks.ActivateEnvironmentHttpMocks()
+
+	environmentDeleted := false
+
+	httpmock.RegisterResponder("GET", `https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/00000000-0000-0000-0000-000000000001?%24expand=permissions%2Cproperties.capacity%2Cproperties%2FbillingPolicy%2Cproperties%2FcopilotPolicies&api-version=2023-06-01`,
+		func(req *http.Request) (*http.Response, error) {
+			if environmentDeleted {
+				return httpmock.NewStringResponse(http.StatusNotFound, `{"error":{"code":"EnvironmentNotFound","message":"environment not found"}}`), nil
+			}
+			return httpmock.NewStringResponse(http.StatusOK, httpmock.File("tests/resource/user/Validate_Create_Env/get_environment_00000000-0000-0000-0000-000000000001.json").String()), nil
+		})
+
+	httpmock.RegisterResponder("POST", `https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/00000000-0000-0000-0000-000000000001/modifyRoleAssignments?api-version=2021-04-01`,
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(http.StatusOK, httpmock.File("tests/resource/user/Validate_Create_Env/modify_role_assignments_00000000-0000-0000-0000-000000000001.json").String()), nil
+		})
+
+	httpmock.RegisterResponder("GET", `https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/00000000-0000-0000-0000-000000000001/roleAssignments?api-version=2021-04-01`,
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(http.StatusOK, httpmock.File("tests/resource/user/Validate_Create_Env/role_assignments_00000000-0000-0000-0000-000000000001.json").String()), nil
+		})
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: "powerplatform_user.new_user",
+				Config: `
+				resource "powerplatform_user" "new_user" {
+					environment_id = "00000000-0000-0000-0000-000000000001"
+					security_roles = [
+					   "Environment Admin",
+					   "Environment Maker"
+					]
+					aad_id = "00000000-0000-0000-0000-000000000002"
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("powerplatform_user.new_user", "id", "00000000-0000-0000-0000-000000000002"),
+				),
+			},
+			{
+				PreConfig: func() {
+					environmentDeleted = true
+				},
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+				Config: `
+				resource "powerplatform_user" "new_user" {
+					environment_id = "00000000-0000-0000-0000-000000000001"
+					security_roles = [
+					   "Environment Admin",
+					   "Environment Maker"
+					]
+					aad_id = "00000000-0000-0000-0000-000000000002"
+				}`,
+			},
+		},
+	})
+}
+
 func TestAccUserResource_Validate_Update_Environment_User(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,


### PR DESCRIPTION
## Summary
- treat a missing parent environment as resource disappearance during `powerplatform_user` read
- exit delete cleanly when the parent environment is already gone
- add unit coverage for refresh after the parent environment has been deleted

## Testing
- go test ./internal/services/authorization/...

Closes #1129