### PR TITLE
Fix acceptance test

### DIFF
--- a/.devcontainer/features/local_provider_dev/install.sh
+++ b/.devcontainer/features/local_provider_dev/install.sh
@@ -53,3 +53,10 @@ curl -fsSL https://aka.ms/install-azd.sh | bash
 # Turn off telemetry for azd
 export AZURE_DEV_COLLECT_TELEMETRY=no
 
+# Install Azure CLI via pipx (avoids distutils issues with Python 3.12+)
+if ! command -v az > /dev/null 2>&1; then
+    python3 -m ensurepip --upgrade
+    python3 -m pip install --quiet pipx
+    PIPX_HOME=/usr/local/pipx PIPX_BIN_DIR=/usr/local/bin python3 -m pipx install azure-cli
+fi
+az version

--- a/docs/resources/solution.md
+++ b/docs/resources/solution.md
@@ -19,7 +19,7 @@ terraform {
       source = "microsoft/power-platform"
     }
     local = {
-      version = "2.7.0"
+      version = "2.8.0"
       source  = "hashicorp/local"
     }
   }

--- a/internal/services/authorization/resource_user_test.go
+++ b/internal/services/authorization/resource_user_test.go
@@ -361,6 +361,9 @@ func TestAccUserResource_Validate_Create_Dataverse_User(t *testing.T) {
 				VersionConstraint: constants.RANDOM_PROVIDER_VERSION_CONSTRAINT,
 				Source:            "hashicorp/random",
 			},
+			"time": {
+				Source: "hashicorp/time",
+			},
 		},
 		Steps: []resource.TestStep{
 			{
@@ -412,6 +415,12 @@ func TestAccUserResource_Validate_Create_Dataverse_User(t *testing.T) {
 					}
 				}
 
+				resource "time_sleep" "wait_for_dataverse" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_environment.dataverse_user_example]
+				}
+
 				resource "powerplatform_user" "new_user" {
 					environment_id = powerplatform_environment.dataverse_user_example.id
 					security_roles = [
@@ -419,6 +428,8 @@ func TestAccUserResource_Validate_Create_Dataverse_User(t *testing.T) {
 					]
 					aad_id         =  element(split("/", azuread_user.test_user.id), 2)  
 					disable_delete = false
+
+					depends_on = [time_sleep.wait_for_dataverse]
 				}`,
 
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/internal/services/connection/resource_connection_test.go
+++ b/internal/services/connection/resource_connection_test.go
@@ -17,6 +17,11 @@ func TestAccConnectionsResource_Validate_Create(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 
 		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source: "hashicorp/time",
+			},
+		},
 		Steps: []resource.TestStep{
 			{
 				Config: `
@@ -29,6 +34,12 @@ func TestAccConnectionsResource_Validate_Create(t *testing.T) {
 							currency_code                             = "USD"
 							security_group_id 						  = "00000000-0000-0000-0000-000000000000"
 						}
+					}
+
+					resource "time_sleep" "wait_for_dataverse" {
+						create_duration = "120s"
+
+						depends_on = [powerplatform_environment.env]
 					}
 	
 					resource "powerplatform_connection" "azure_openai_connection" {
@@ -47,6 +58,8 @@ func TestAccConnectionsResource_Validate_Create(t *testing.T) {
 								connection_parameters
 							]
 						}
+
+						depends_on = [time_sleep.wait_for_dataverse]
 					}
 					`,
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/internal/services/data_record/resource_data_record_test.go
+++ b/internal/services/data_record/resource_data_record_test.go
@@ -24,6 +24,11 @@ import (
 func TestAccDataRecordResource_Validate_Create(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source: "hashicorp/time",
+			},
+		},
 		Steps: []resource.TestStep{
 			{
 				Config: `
@@ -36,6 +41,12 @@ func TestAccDataRecordResource_Validate_Create(t *testing.T) {
 					  currency_code     = "USD"
 					  security_group_id = "00000000-0000-0000-0000-000000000000"
 					}
+				}
+
+				resource "time_sleep" "wait_for_dataverse" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_environment.test_env]
 				}
 
 				resource "powerplatform_data_record" "data_record_sample_contact1" {
@@ -51,6 +62,8 @@ func TestAccDataRecordResource_Validate_Create(t *testing.T) {
 					  birthdate          = "2024-04-10"
 					  description        = "This is the description of the the terraform \n\nsample contact"
 					}
+
+					depends_on = [time_sleep.wait_for_dataverse]
 				}
 
 				resource "powerplatform_data_record" "data_record_account" {

--- a/internal/services/environment/resource_environment.go
+++ b/internal/services/environment/resource_environment.go
@@ -596,12 +596,6 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	updateDescription(plan, &environmentDto)
 	updateCadence(plan, &environmentDto)
 
-	err = r.updateAllowBingSearch(ctx, plan)
-	if err != nil {
-		resp.Diagnostics.AddError("Error when updating allow bing search", err.Error())
-		return
-	}
-
 	updateEnvironmentGroupId(plan, &environmentDto)
 	updateBillingPolicyId(plan, &environmentDto)
 
@@ -622,7 +616,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
-	envDto, err := r.EnvironmentClient.UpdateEnvironment(ctx, plan.Id.ValueString(), environmentDto)
+	_, err = r.EnvironmentClient.UpdateEnvironment(ctx, plan.Id.ValueString(), environmentDto)
 	if err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.FullTypeName()), err.Error())
 		return
@@ -630,11 +624,27 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 
 	// This is a temporary fix for the issue in BAPI where the display name is not propagated correctly on environment update
 	if plan.DisplayName.ValueString() != state.DisplayName.ValueString() {
-		envDto, err = r.EnvironmentClient.UpdateEnvironment(ctx, plan.Id.ValueString(), environmentDto)
+		_, err = r.EnvironmentClient.UpdateEnvironment(ctx, plan.Id.ValueString(), environmentDto)
 		if err != nil {
 			resp.Diagnostics.AddError(fmt.Sprintf("Client error when updating %s", r.FullTypeName()), err.Error())
 			return
 		}
+	}
+
+	err = r.updateAllowBingSearch(ctx, plan)
+	if err != nil {
+		resp.Diagnostics.AddError("Error when updating allow bing search", err.Error())
+		return
+	}
+
+	envDto, err := r.EnvironmentClient.GetEnvironment(ctx, plan.Id.ValueString())
+	if err != nil {
+		if errors.Is(err, customerrors.ErrObjectNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.FullTypeName()), err.Error())
+		return
 	}
 
 	var templateMetadata *createTemplateMetadataDto
@@ -802,7 +812,10 @@ func updateCadence(plan *SourceModel, environmentDto *EnvironmentDto) {
 }
 
 func (r *Resource) updateAllowBingSearch(ctx context.Context, plan *SourceModel) error {
-	if !plan.AllowBingSearch.IsNull() && !plan.AllowBingSearch.IsUnknown() {
+	allowBingSearchSet := !plan.AllowBingSearch.IsNull() && !plan.AllowBingSearch.IsUnknown()
+	allowMovingDataSet := !plan.AllowMovingDataAcrossRegions.IsNull() && !plan.AllowMovingDataAcrossRegions.IsUnknown()
+
+	if allowBingSearchSet || allowMovingDataSet {
 		err := r.updateEnvironmentAiFeatures(ctx, plan.Id.ValueString(), plan.AllowBingSearch.ValueBool(), plan.AllowMovingDataAcrossRegions.ValueBoolPointer())
 		if err != nil {
 			return err

--- a/internal/services/environment/tests/resource/Validate_Create_Environment_And_Dataverse/get_environment_8.json
+++ b/internal/services/environment/tests/resource/Validate_Create_Environment_And_Dataverse/get_environment_8.json
@@ -1,0 +1,158 @@
+    {
+        "id": "/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/00000000-0000-0000-0000-000000000001",
+        "type": "Microsoft.BusinessAppPlatform/scopes/environments",
+        "location": "europe",
+        "name": "00000000-0000-0000-0000-000000000001",
+        "properties": {
+            "tenantId": "123",
+            "azureRegion": "westeurope",
+            "displayName": "displayname",
+            "createdTime": "2023-09-27T07:08:27.6057592Z",
+            "createdBy": {
+                "id": "f99f844b-ce3b-49ae-86f3-e374ecae789c",
+                "displayName": "admin",
+                "email": "admin",
+                "type": "User",
+                "tenantId": "123",
+                "userPrincipalName": "admin"
+            },
+            "billingPolicy": {
+                "id": ""
+            },
+            "lastModifiedTime": "2023-09-27T07:08:34.9205145Z",
+            "provisioningState": "Succeeded",
+            "creationType": "User",
+            "environmentSku": "Sandbox",
+            "isDefault": false,
+            "capacity": [
+                {
+                    "capacityType": "Database",
+                    "actualConsumption": 885.0391,
+                    "ratedConsumption": 1024.0,
+                    "capacityUnit": "MB",
+                    "updatedOn": "2023-10-10T03:00:35Z"
+                },
+                {
+                    "capacityType": "File",
+                    "actualConsumption": 1187.142,
+                    "ratedConsumption": 1187.142,
+                    "capacityUnit": "MB",
+                    "updatedOn": "2023-10-10T03:00:35Z"
+                },
+                {
+                    "capacityType": "Log",
+                    "actualConsumption": 0.0,
+                    "ratedConsumption": 0.0,
+                    "capacityUnit": "MB",
+                    "updatedOn": "2023-10-10T03:00:35Z"
+                },
+                {
+                    "capacityType": "FinOpsDatabase",
+                    "actualConsumption": 0.0,
+                    "ratedConsumption": 0.0,
+                    "capacityUnit": "MB",
+                    "updatedOn": "2023-10-10T03:00:35Z"
+                },
+                {
+                    "capacityType": "FinOpsFile",
+                    "actualConsumption": 0.0,
+                    "ratedConsumption": 0.0,
+                    "capacityUnit": "MB",
+                    "updatedOn": "2023-10-10T03:00:35Z"
+                }
+            ],
+            "addons": [],
+            "clientUris": {
+                "admin": "https://admin.powerplatform.microsoft.com/environments/environment/456/hub",
+                "maker": "https://make.powerapps.com/environments/456/home"
+            },
+            "runtimeEndpoints": {
+                "microsoft.BusinessAppPlatform": "https://europe.api.bap.microsoft.com",
+                "microsoft.CommonDataModel": "https://europe.api.cds.microsoft.com",
+                "microsoft.PowerApps": "https://europe.api.powerapps.com",
+                "microsoft.PowerAppsAdvisor": "https://europe.api.advisor.powerapps.com",
+                "microsoft.PowerVirtualAgents": "https://powervamg.eu-il107.gateway.prod.island.powerapps.com",
+                "microsoft.ApiManagement": "https://management.EUROPE.azure-apihub.net",
+                "microsoft.Flow": "https://emea.api.flow.microsoft.com"
+            },
+            "databaseType": "CommonDataService",
+            "linkedEnvironmentMetadata": {
+                "resourceId": "orgid",
+                "friendlyName": "displayname",
+                "uniqueName": "00000000-0000-0000-0000-000000000001",
+                "domainName": "00000000-0000-0000-0000-000000000001",
+                "version": "9.2.23092.00206",
+                "instanceUrl": "https://00000000-0000-0000-0000-000000000001.crm4.dynamics.com/",
+                "instanceApiUrl": "https://00000000-0000-0000-0000-000000000001.api.crm4.dynamics.com",
+                "baseLanguage": 1033,
+                "instanceState": "Ready",
+                "createdTime": "2023-09-27T07:08:28.957Z",
+                "backgroundOperationsState": "Enabled",
+                "scaleGroup": "EURCRMLIVESG705",
+                "platformSku": "Standard",
+                "schemaType": "Standard"
+            },
+            "trialScenarioType": "None",
+            "notificationMetadata": {
+                "state": "NotSpecified",
+                "branding": "NotSpecific"
+            },
+            "retentionPeriod": "P7D",
+            "states": {
+                "management": {
+                    "id": "Ready"
+                },
+                "runtime": {
+                    "runtimeReasonCode": "NotSpecified",
+                    "requestedBy": {
+                        "displayName": "SYSTEM",
+                        "type": "NotSpecified"
+                    },
+                    "id": "Enabled"
+                }
+            },
+            "updateCadence": {
+                "id": "Moderate"
+            },
+            "retentionDetails": {
+                "retentionPeriod": "P7D",
+                "backupsAvailableFromDateTime": "2023-10-03T09:23:06.1717665Z"
+            },
+            "protectionStatus": {
+                "keyManagedBy": "Microsoft"
+            },
+            "cluster": {
+                "category": "Prod",
+                "number": "107",
+                "uriSuffix": "eu-il107.gateway.prod.island",
+                "geoShortName": "EU",
+                "environment": "Prod"
+            },
+            "connectedGroups": [],
+            "lifecycleOperationsEnforcement": {
+                "allowedOperations": [
+                    {
+                        "type": {
+                            "id": "DisableGovernanceConfiguration"
+                        },
+                        "reason": {
+                            "message": "DisableGovernanceConfiguration cannot be performed on Power Platform environment because of the governance configuration.",
+                            "type": "GovernanceConfig"
+                        }
+                    },
+                    {
+                        "type": {
+                            "id": "UpdateGovernanceConfiguration"
+                        },
+                        "reason": {
+                            "message": "UpdateGovernanceConfiguration cannot be performed on Power Platform environment because of the governance configuration.",
+                            "type": "GovernanceConfig"
+                        }
+                    }
+                ]
+            },
+            "governanceConfiguration": {
+                "protectionLevel": "Basic"
+            }
+        }
+    }

--- a/internal/services/environment/tests/resource/Validate_Update_Environment_Type/get_environment_10.json
+++ b/internal/services/environment/tests/resource/Validate_Update_Environment_Type/get_environment_10.json
@@ -1,0 +1,158 @@
+{
+    "id": "/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/00000000-0000-0000-0000-000000000001",
+    "type": "Microsoft.BusinessAppPlatform/scopes/environments",
+    "location": "europe",
+    "name": "00000000-0000-0000-0000-000000000001",
+    "properties": {
+        "tenantId": "123",
+        "azureRegion": "westeurope",
+        "displayName": "Example",
+        "createdTime": "2023-09-27T07:08:27.6057592Z",
+        "createdBy": {
+            "id": "f99f844b-ce3b-49ae-86f3-e374ecae789c",
+            "displayName": "admin",
+            "email": "admin",
+            "type": "User",
+            "tenantId": "123",
+            "userPrincipalName": "admin"
+        },
+        "billingPolicy": {
+            "id": ""
+        },
+        "lastModifiedTime": "2023-09-27T07:08:34.9205145Z",
+        "provisioningState": "Succeeded",
+        "creationType": "User",
+        "environmentSku": "Production",
+        "isDefault": false,
+        "capacity": [
+            {
+                "capacityType": "Database",
+                "actualConsumption": 885.0391,
+                "ratedConsumption": 1024.0,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            },
+            {
+                "capacityType": "File",
+                "actualConsumption": 1187.142,
+                "ratedConsumption": 1187.142,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            },
+            {
+                "capacityType": "Log",
+                "actualConsumption": 0.0,
+                "ratedConsumption": 0.0,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            },
+            {
+                "capacityType": "FinOpsDatabase",
+                "actualConsumption": 0.0,
+                "ratedConsumption": 0.0,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            },
+            {
+                "capacityType": "FinOpsFile",
+                "actualConsumption": 0.0,
+                "ratedConsumption": 0.0,
+                "capacityUnit": "MB",
+                "updatedOn": "2023-10-10T03:00:35Z"
+            }
+        ],
+        "addons": [],
+        "clientUris": {
+            "admin": "https://admin.powerplatform.microsoft.com/environments/environment/00000000-0000-0000-0000-000000000001/hub",
+            "maker": "https://make.powerapps.com/environments/00000000-0000-0000-0000-000000000001/home"
+        },
+        "runtimeEndpoints": {
+            "microsoft.BusinessAppPlatform": "https://europe.api.bap.microsoft.com",
+            "microsoft.CommonDataModel": "https://europe.api.cds.microsoft.com",
+            "microsoft.PowerApps": "https://europe.api.powerapps.com",
+            "microsoft.PowerAppsAdvisor": "https://europe.api.advisor.powerapps.com",
+            "microsoft.PowerVirtualAgents": "https://powervamg.eu-il107.gateway.prod.island.powerapps.com",
+            "microsoft.ApiManagement": "https://management.EUROPE.azure-apihub.net",
+            "microsoft.Flow": "https://emea.api.flow.microsoft.com"
+        },
+        "databaseType": "CommonDataService",
+        "linkedEnvironmentMetadata": {
+            "resourceId": "orgid",
+            "friendlyName": "displayname",
+            "uniqueName": "00000000-0000-0000-0000-000000000001",
+            "domainName": "domain123",
+            "version": "9.2.23092.00206",
+            "instanceUrl": "https://00000000-0000-0000-0000-000000000001.crm4.dynamics.com/",
+            "instanceApiUrl": "https://00000000-0000-0000-0000-000000000001.api.crm4.dynamics.com",
+            "baseLanguage": 1033,
+            "instanceState": "Ready",
+            "createdTime": "2023-09-27T07:08:28.957Z",
+            "backgroundOperationsState": "Enabled",
+            "scaleGroup": "EURCRMLIVESG705",
+            "platformSku": "Standard",
+            "schemaType": "Standard"
+        },
+        "trialScenarioType": "None",
+        "notificationMetadata": {
+            "state": "NotSpecified",
+            "branding": "NotSpecific"
+        },
+        "retentionPeriod": "P7D",
+        "states": {
+            "management": {
+                "id": "Ready"
+            },
+            "runtime": {
+                "runtimeReasonCode": "NotSpecified",
+                "requestedBy": {
+                    "displayName": "SYSTEM",
+                    "type": "NotSpecified"
+                },
+                "id": "Enabled"
+            }
+        },
+        "updateCadence": {
+            "id": "Moderate"
+        },
+        "retentionDetails": {
+            "retentionPeriod": "P7D",
+            "backupsAvailableFromDateTime": "2023-10-03T09:23:06.1717665Z"
+        },
+        "protectionStatus": {
+            "keyManagedBy": "Microsoft"
+        },
+        "cluster": {
+            "category": "Prod",
+            "number": "107",
+            "uriSuffix": "eu-il107.gateway.prod.island",
+            "geoShortName": "EU",
+            "environment": "Prod"
+        },
+        "connectedGroups": [],
+        "lifecycleOperationsEnforcement": {
+            "allowedOperations": [
+                {
+                    "type": {
+                        "id": "DisableGovernanceConfiguration"
+                    },
+                    "reason": {
+                        "message": "DisableGovernanceConfiguration cannot be performed on Power Platform environment because of the governance configuration.",
+                        "type": "GovernanceConfig"
+                    }
+                },
+                {
+                    "type": {
+                        "id": "UpdateGovernanceConfiguration"
+                    },
+                    "reason": {
+                        "message": "UpdateGovernanceConfiguration cannot be performed on Power Platform environment because of the governance configuration.",
+                        "type": "GovernanceConfig"
+                    }
+                }
+            ]
+        },
+        "governanceConfiguration": {
+            "protectionLevel": "Basic"
+        }
+    }
+}

--- a/internal/services/environment_settings/resource_environment_settings_test.go
+++ b/internal/services/environment_settings/resource_environment_settings_test.go
@@ -97,6 +97,11 @@ func TestAccTestEnvironmentSettingsResource_Validate_Create_Empty_Settings(t *te
 	resource.Test(t, resource.TestCase{
 		IsUnitTest:               false,
 		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source: "hashicorp/time",
+			},
+		},
 		Steps: []resource.TestStep{
 			{
 				Config: `
@@ -111,8 +116,16 @@ func TestAccTestEnvironmentSettingsResource_Validate_Create_Empty_Settings(t *te
 						}
 					}
 
+					resource "time_sleep" "wait_for_dataverse" {
+						create_duration = "120s"
+
+						depends_on = [powerplatform_environment.example_environment_settings]
+					}
+
 					resource "powerplatform_environment_settings" "settings" {
 						environment_id                         = powerplatform_environment.example_environment_settings.id
+
+						depends_on = [time_sleep.wait_for_dataverse]
 					}`,
 
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/internal/services/licensing/api_licensing.go
+++ b/internal/services/licensing/api_licensing.go
@@ -178,8 +178,13 @@ func (client *Client) AddEnvironmentsToBillingPolicy(ctx context.Context, billin
 	values.Add("api-version", "2022-03-01-preview")
 	apiUrl.RawQuery = values.Encode()
 
+	normalizedIds := make([]string, len(environmentIds))
+	for i, id := range environmentIds {
+		normalizedIds[i] = strings.ToLower(id)
+	}
+
 	environments := BillingPolicyEnvironmentsArrayDto{
-		EnvironmentIds: environmentIds,
+		EnvironmentIds: normalizedIds,
 	}
 	_, err := client.Api.Execute(ctx, nil, "POST", apiUrl.String(), nil, environments, []int{http.StatusOK}, nil)
 
@@ -198,10 +203,15 @@ func (client *Client) RemoveEnvironmentsToBillingPolicy(ctx context.Context, bil
 
 	values := url.Values{}
 	values.Add("api-version", "2022-03-01-preview")
+
+	normalizedIds := make([]string, len(environmentIds))
+	for i, id := range environmentIds {
+		normalizedIds[i] = strings.ToLower(id)
+	}
 	apiUrl.RawQuery = values.Encode()
 
 	environments := BillingPolicyEnvironmentsArrayDto{
-		EnvironmentIds: environmentIds,
+		EnvironmentIds: normalizedIds,
 	}
 	_, err := client.Api.Execute(ctx, nil, "POST", apiUrl.String(), nil, environments, []int{http.StatusOK}, nil)
 

--- a/internal/services/licensing/api_licensing.go
+++ b/internal/services/licensing/api_licensing.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/microsoft/terraform-provider-power-platform/internal/api"
@@ -158,7 +159,7 @@ func (client *Client) GetEnvironmentsForBillingPolicy(ctx context.Context, billi
 
 	environments := []string{}
 	for _, billingPolicyEnvironment := range billingPolicyEnvironments.Value {
-		environments = append(environments, billingPolicyEnvironment.EnvironmentId)
+		environments = append(environments, strings.ToLower(billingPolicyEnvironment.EnvironmentId))
 	}
 	return environments, err
 }

--- a/internal/services/licensing/datasource_billing_policies_environments_test.go
+++ b/internal/services/licensing/datasource_billing_policies_environments_test.go
@@ -26,6 +26,9 @@ func TestAccBillingPoliciesEnvironmentsDataSource_Validate_Read(t *testing.T) {
 				VersionConstraint: constants.AZAPI_PROVIDER_VERSION_CONSTRAINT,
 				Source:            "azure/azapi",
 			},
+			"time": {
+				Source: "hashicorp/time",
+			},
 		},
 		Steps: []resource.TestStep{
 			{
@@ -49,8 +52,16 @@ func TestAccBillingPoliciesEnvironmentsDataSource_Validate_Read(t *testing.T) {
 					}
 				}
 
+				resource "time_sleep" "wait_for_billing_policy" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_billing_policy.pay_as_you_go]
+				}
+
 				data "powerplatform_billing_policies_environments" "all_pay_as_you_go_policy_envs" {
 					billing_policy_id = powerplatform_billing_policy.pay_as_you_go.id
+
+					depends_on = [time_sleep.wait_for_billing_policy]
 				}`,
 
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/internal/services/licensing/resource_billing_policy_environment.go
+++ b/internal/services/licensing/resource_billing_policy_environment.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -120,7 +121,12 @@ func (r *BillingPolicyEnvironmentResource) Create(ctx context.Context, req resou
 		}
 	}
 
-	err = r.LicensingClient.AddEnvironmentsToBillingPolicy(ctx, plan.BillingPolicyId, plan.Environments)
+	normalizedPlanEnvs := make([]string, len(plan.Environments))
+	for i, env := range plan.Environments {
+		normalizedPlanEnvs[i] = strings.ToLower(env)
+	}
+
+	err = r.LicensingClient.AddEnvironmentsToBillingPolicy(ctx, plan.BillingPolicyId, normalizedPlanEnvs)
 	if err != nil {
 		addClientError(&resp.Diagnostics, r.FullTypeName(), "creating", err)
 		return
@@ -197,7 +203,12 @@ func (r *BillingPolicyEnvironmentResource) Update(ctx context.Context, req resou
 		return
 	}
 
-	err = r.LicensingClient.AddEnvironmentsToBillingPolicy(ctx, plan.BillingPolicyId, plan.Environments)
+	normalizedPlanEnvs := make([]string, len(plan.Environments))
+	for i, env := range plan.Environments {
+		normalizedPlanEnvs[i] = strings.ToLower(env)
+	}
+
+	err = r.LicensingClient.AddEnvironmentsToBillingPolicy(ctx, plan.BillingPolicyId, normalizedPlanEnvs)
 	if err != nil {
 		addClientError(&resp.Diagnostics, r.FullTypeName(), "updating", err)
 		return

--- a/internal/services/licensing/resource_billing_policy_environment.go
+++ b/internal/services/licensing/resource_billing_policy_environment.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -121,12 +120,7 @@ func (r *BillingPolicyEnvironmentResource) Create(ctx context.Context, req resou
 		}
 	}
 
-	normalizedPlanEnvs := make([]string, len(plan.Environments))
-	for i, env := range plan.Environments {
-		normalizedPlanEnvs[i] = strings.ToLower(env)
-	}
-
-	err = r.LicensingClient.AddEnvironmentsToBillingPolicy(ctx, plan.BillingPolicyId, normalizedPlanEnvs)
+	err = r.LicensingClient.AddEnvironmentsToBillingPolicy(ctx, plan.BillingPolicyId, plan.Environments)
 	if err != nil {
 		addClientError(&resp.Diagnostics, r.FullTypeName(), "creating", err)
 		return
@@ -203,12 +197,7 @@ func (r *BillingPolicyEnvironmentResource) Update(ctx context.Context, req resou
 		return
 	}
 
-	normalizedPlanEnvs := make([]string, len(plan.Environments))
-	for i, env := range plan.Environments {
-		normalizedPlanEnvs[i] = strings.ToLower(env)
-	}
-
-	err = r.LicensingClient.AddEnvironmentsToBillingPolicy(ctx, plan.BillingPolicyId, normalizedPlanEnvs)
+	err = r.LicensingClient.AddEnvironmentsToBillingPolicy(ctx, plan.BillingPolicyId, plan.Environments)
 	if err != nil {
 		addClientError(&resp.Diagnostics, r.FullTypeName(), "updating", err)
 		return

--- a/internal/services/licensing/resource_billing_policy_environment_test.go
+++ b/internal/services/licensing/resource_billing_policy_environment_test.go
@@ -144,6 +144,9 @@ func TestAccBillingPolicyResourceEnvironment_Validate_Update(t *testing.T) {
 				VersionConstraint: constants.AZAPI_PROVIDER_VERSION_CONSTRAINT,
 				Source:            "azure/azapi",
 			},
+			"time": {
+				Source: "hashicorp/time",
+			},
 		},
 		Steps: []resource.TestStep{
 			{
@@ -187,9 +190,17 @@ func TestAccBillingPolicyResourceEnvironment_Validate_Update(t *testing.T) {
 					environment_type = "Sandbox"
 				}
 
+				resource "time_sleep" "wait_for_environments" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_environment.env1, powerplatform_environment.env2, powerplatform_environment.env3]
+				}
+
 				resource "powerplatform_billing_policy_environment" "pay_as_you_go_policy_envs" {
 					billing_policy_id = powerplatform_billing_policy.pay_as_you_go.id
 					environments      = [powerplatform_environment.env1.id]
+
+					depends_on = [time_sleep.wait_for_environments]
 				}`,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("powerplatform_billing_policy_environment.pay_as_you_go_policy_envs", "billing_policy_id", regexp.MustCompile(helpers.GuidRegex)),
@@ -241,9 +252,17 @@ func TestAccBillingPolicyResourceEnvironment_Validate_Update(t *testing.T) {
 					billing_policy_id = powerplatform_billing_policy.pay_as_you_go.id
 				}
 
+				resource "time_sleep" "wait_for_environments" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_environment.env1, powerplatform_environment.env2, powerplatform_environment.env3]
+				}
+
 				resource "powerplatform_billing_policy_environment" "pay_as_you_go_policy_envs" {
 					billing_policy_id = powerplatform_billing_policy.pay_as_you_go.id
 					environments      = [powerplatform_environment.env1.id, powerplatform_environment.env2.id, powerplatform_environment.env3.id]
+
+					depends_on = [time_sleep.wait_for_environments]
 				}`,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("powerplatform_billing_policy_environment.pay_as_you_go_policy_envs", "billing_policy_id", regexp.MustCompile(helpers.GuidRegex)),
@@ -293,9 +312,17 @@ func TestAccBillingPolicyResourceEnvironment_Validate_Update(t *testing.T) {
 					billing_policy_id = powerplatform_billing_policy.pay_as_you_go.id
 				}
 
+				resource "time_sleep" "wait_for_environments" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_environment.env1, powerplatform_environment.env2, powerplatform_environment.env3]
+				}
+
 				resource "powerplatform_billing_policy_environment" "pay_as_you_go_policy_envs" {
 					billing_policy_id = powerplatform_billing_policy.pay_as_you_go.id
 					environments      = [powerplatform_environment.env1.id, powerplatform_environment.env3.id]
+
+					depends_on = [time_sleep.wait_for_environments]
 				}`,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("powerplatform_billing_policy_environment.pay_as_you_go_policy_envs", "billing_policy_id", regexp.MustCompile(helpers.GuidRegex)),

--- a/internal/services/licensing/resource_billing_policy_environment_test.go
+++ b/internal/services/licensing/resource_billing_policy_environment_test.go
@@ -20,7 +20,6 @@ import (
 )
 
 func TestAccBillingPolicyResourceEnvironment_Validate_Create(t *testing.T) {
-	t.Setenv("TF_ACC", "true")
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,
 		ExternalProviders: map[string]resource.ExternalProvider{

--- a/internal/services/licensing/resource_billing_policy_environment_test.go
+++ b/internal/services/licensing/resource_billing_policy_environment_test.go
@@ -20,12 +20,16 @@ import (
 )
 
 func TestAccBillingPolicyResourceEnvironment_Validate_Create(t *testing.T) {
+	t.Setenv("TF_ACC", "true")
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"azapi": {
 				VersionConstraint: constants.AZAPI_PROVIDER_VERSION_CONSTRAINT,
 				Source:            "azure/azapi",
+			},
+			"time": {
+				Source: "hashicorp/time",
 			},
 		},
 		Steps: []resource.TestStep{
@@ -66,9 +70,17 @@ func TestAccBillingPolicyResourceEnvironment_Validate_Create(t *testing.T) {
 					billing_policy_id = powerplatform_billing_policy.pay_as_you_go.id
 				}
 
+				resource "time_sleep" "wait_for_environments" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_environment.env1, powerplatform_environment.env2]
+				}
+
 				resource "powerplatform_billing_policy_environment" "pay_as_you_go_policy_envs" {
 					billing_policy_id = powerplatform_billing_policy.pay_as_you_go.id
 					environments      = [powerplatform_environment.env1.id, powerplatform_environment.env2.id]
+
+					depends_on = [time_sleep.wait_for_environments]
 				}
 				`,
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/internal/services/managed_environment/resource_managed_environment_test.go
+++ b/internal/services/managed_environment/resource_managed_environment_test.go
@@ -18,6 +18,11 @@ import (
 func TestAccManagedEnvironmentsResource_Validate_Create(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source: "hashicorp/time",
+			},
+		},
 		Steps: []resource.TestStep{
 			{
 				Config: `
@@ -30,6 +35,12 @@ func TestAccManagedEnvironmentsResource_Validate_Create(t *testing.T) {
 						currency_code    = "USD"
 						security_group_id = "00000000-0000-0000-0000-000000000000"
 					}
+				}
+
+				resource "time_sleep" "wait_for_dataverse" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_environment.development]
 				}
 				
 				resource "powerplatform_managed_environment" "managed_development" {
@@ -45,6 +56,8 @@ func TestAccManagedEnvironmentsResource_Validate_Create(t *testing.T) {
   					copilot_allow_grant_editor_permissions_when_shared = false
   					copilot_limit_sharing_mode                         = "ExcludeSharingToSecurityGroups"
   					copilot_max_limit_user_sharing                     = 55
+
+					depends_on = [time_sleep.wait_for_dataverse]
 				}`,
 
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -74,6 +87,11 @@ func TestAccManagedEnvironmentsResource_Validate_Create(t *testing.T) {
 func TestAccManagedEnvironmentsResource_Validate_Update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source: "hashicorp/time",
+			},
+		},
 		Steps: []resource.TestStep{
 			{
 				Config: `
@@ -87,6 +105,12 @@ func TestAccManagedEnvironmentsResource_Validate_Update(t *testing.T) {
 						security_group_id = "00000000-0000-0000-0000-000000000000"
 					}
 				}
+
+				resource "time_sleep" "wait_for_dataverse" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_environment.development]
+				}
 				
 				resource "powerplatform_managed_environment" "managed_development" {
 					environment_id             = powerplatform_environment.development.id
@@ -97,7 +121,8 @@ func TestAccManagedEnvironmentsResource_Validate_Update(t *testing.T) {
 					solution_checker_mode      = "None"
 					suppress_validation_emails = true
 					solution_checker_rule_overrides = toset(["meta-remove-dup-reg", "meta-avoid-reg-no-attribute"])
-					
+
+					depends_on = [time_sleep.wait_for_dataverse]
 				}`,
 
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -115,6 +140,12 @@ func TestAccManagedEnvironmentsResource_Validate_Update(t *testing.T) {
 						currency_code    = "USD"
 						security_group_id = "00000000-0000-0000-0000-000000000000"
 					}
+				}
+
+				resource "time_sleep" "wait_for_dataverse" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_environment.development]
 				}
 				
 				resource "powerplatform_managed_environment" "managed_development" {
@@ -145,6 +176,12 @@ func TestAccManagedEnvironmentsResource_Validate_Update(t *testing.T) {
 						security_group_id = "00000000-0000-0000-0000-000000000000"
 					}
 				}
+
+				resource "time_sleep" "wait_for_dataverse" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_environment.development]
+				}
 				
 				resource "powerplatform_managed_environment" "managed_development" {
 					environment_id             = powerplatform_environment.development.id
@@ -173,6 +210,12 @@ func TestAccManagedEnvironmentsResource_Validate_Update(t *testing.T) {
 						currency_code    = "USD"
 						security_group_id = "00000000-0000-0000-0000-000000000000"
 					}
+				}
+
+				resource "time_sleep" "wait_for_dataverse" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_environment.development]
 				}
 				
 				resource "powerplatform_managed_environment" "managed_development" {
@@ -203,6 +246,12 @@ func TestAccManagedEnvironmentsResource_Validate_Update(t *testing.T) {
 						security_group_id = "00000000-0000-0000-0000-000000000000"
 					}
 				}
+
+				resource "time_sleep" "wait_for_dataverse" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_environment.development]
+				}
 				
 				resource "powerplatform_managed_environment" "managed_development" {
 					environment_id             = powerplatform_environment.development.id
@@ -231,6 +280,12 @@ func TestAccManagedEnvironmentsResource_Validate_Update(t *testing.T) {
 						currency_code    = "USD"
 						security_group_id = "00000000-0000-0000-0000-000000000000"
 					}
+				}
+
+				resource "time_sleep" "wait_for_dataverse" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_environment.development]
 				}
 				
 				resource "powerplatform_managed_environment" "managed_development" {
@@ -261,6 +316,12 @@ func TestAccManagedEnvironmentsResource_Validate_Update(t *testing.T) {
 						security_group_id = "00000000-0000-0000-0000-000000000000"
 					}
 				}
+
+				resource "time_sleep" "wait_for_dataverse" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_environment.development]
+				}
 				
 				resource "powerplatform_managed_environment" "managed_development" {
 					environment_id             = powerplatform_environment.development.id
@@ -289,6 +350,12 @@ func TestAccManagedEnvironmentsResource_Validate_Update(t *testing.T) {
 						currency_code    = "USD"
 						security_group_id = "00000000-0000-0000-0000-000000000000"
 					}
+				}
+
+				resource "time_sleep" "wait_for_dataverse" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_environment.development]
 				}
 				
 				resource "powerplatform_managed_environment" "managed_development" {
@@ -320,6 +387,12 @@ func TestAccManagedEnvironmentsResource_Validate_Update(t *testing.T) {
 						security_group_id = "00000000-0000-0000-0000-000000000000"
 					}
 				}
+
+				resource "time_sleep" "wait_for_dataverse" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_environment.development]
+				}
 				
 				resource "powerplatform_managed_environment" "managed_development" {
 					environment_id             = powerplatform_environment.development.id
@@ -349,6 +422,12 @@ func TestAccManagedEnvironmentsResource_Validate_Update(t *testing.T) {
 						currency_code    = "USD"
 						security_group_id = "00000000-0000-0000-0000-000000000000"
 					}
+				}
+
+				resource "time_sleep" "wait_for_dataverse" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_environment.development]
 				}
 				
 				resource "powerplatform_managed_environment" "managed_development" {
@@ -380,6 +459,12 @@ func TestAccManagedEnvironmentsResource_Validate_Update(t *testing.T) {
 						security_group_id = "00000000-0000-0000-0000-000000000000"
 					}
 				}
+
+				resource "time_sleep" "wait_for_dataverse" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_environment.development]
+				}
 				
 				resource "powerplatform_managed_environment" "managed_development" {
 					environment_id             = powerplatform_environment.development.id
@@ -410,6 +495,12 @@ func TestAccManagedEnvironmentsResource_Validate_Update(t *testing.T) {
 						currency_code    = "USD"
 						security_group_id = "00000000-0000-0000-0000-000000000000"
 					}
+				}
+
+				resource "time_sleep" "wait_for_dataverse" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_environment.development]
 				}
 				
 				resource "powerplatform_managed_environment" "managed_development" {
@@ -442,6 +533,12 @@ func TestAccManagedEnvironmentsResource_Validate_Update(t *testing.T) {
 						currency_code    = "USD"
 						security_group_id = "00000000-0000-0000-0000-000000000000"
 					}
+				}
+
+				resource "time_sleep" "wait_for_dataverse" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_environment.development]
 				}
 				
 				resource "powerplatform_managed_environment" "managed_development" {

--- a/internal/services/rest/resource_rest_test.go
+++ b/internal/services/rest/resource_rest_test.go
@@ -18,6 +18,11 @@ func TestAccTestRest_Validate_Create(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {
+				Source: "hashicorp/time",
+			},
+		},
 		Steps: []resource.TestStep{
 			{
 				Config: `
@@ -31,6 +36,12 @@ func TestAccTestRest_Validate_Create(t *testing.T) {
 						currency_code     = "USD"
 						security_group_id = "00000000-0000-0000-0000-000000000000"
 					}
+				}
+
+				resource "time_sleep" "wait_for_dataverse" {
+					create_duration = "120s"
+
+					depends_on = [powerplatform_environment.env]
 				}
 
 				locals {
@@ -89,7 +100,7 @@ func TestAccTestRest_Validate_Create(t *testing.T) {
 						method = "DELETE"
 					}
 
-					depends_on = [powerplatform_environment.env]
+					depends_on = [time_sleep.wait_for_dataverse]
 
 					lifecycle {
 						ignore_changes = [
@@ -113,6 +124,12 @@ func TestAccTestRest_Validate_Create(t *testing.T) {
 					currency_code     = "USD"
 					security_group_id = "00000000-0000-0000-0000-000000000000"
 				}
+			}
+
+			resource "time_sleep" "wait_for_dataverse" {
+				create_duration = "120s"
+
+				depends_on = [powerplatform_environment.env]
 			}
 
 				locals {
@@ -171,7 +188,7 @@ func TestAccTestRest_Validate_Create(t *testing.T) {
 						method = "DELETE"
 					}
 
-					depends_on = [powerplatform_environment.env]
+					depends_on = [time_sleep.wait_for_dataverse]
 
 					lifecycle {
 						ignore_changes = [


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to environment ID normalization, test reliability, and dependency management for the Azure CLI. The main focus is on ensuring consistent lowercasing of environment IDs in licensing operations, adding appropriate delays in acceptance tests to handle resource propagation, and updating the development container setup for better compatibility.

**Environment ID normalization and consistency:**

* All environment IDs are now consistently lowercased before being sent to or returned from licensing APIs, reducing case-sensitivity issues in resource management (`resource_billing_policy_environment.go`, `api_licensing.go`). [[1]](diffhunk://#diff-c542e8a0560cbcaca1cc053acf2ca0864e1cfd22507667edcd98846147111288L123-R129) [[2]](diffhunk://#diff-c542e8a0560cbcaca1cc053acf2ca0864e1cfd22507667edcd98846147111288L200-R211) [[3]](diffhunk://#diff-b8f872508a7999d1c6dc7bd6b6f48b34461446f39d319fd3214b7ba9b802ec3bL161-R162)

**Acceptance test reliability improvements:**

* Added the `time` provider and `time_sleep` resources to acceptance tests for both user and billing policy environment resources, introducing explicit delays to ensure dependent resources are fully provisioned before proceeding. [[1]](diffhunk://#diff-94ce10f88549ebab76dc7ab36885a035ae36dbaf8da42a5488e81d8bbb7ff63bR364-R366) [[2]](diffhunk://#diff-94ce10f88549ebab76dc7ab36885a035ae36dbaf8da42a5488e81d8bbb7ff63bR418-R432) [[3]](diffhunk://#diff-ec8182b39b46e318d6544bc6b0db0ba9537fdb8eb9c673caabd0679d6e1a7af6R23-R33) [[4]](diffhunk://#diff-ec8182b39b46e318d6544bc6b0db0ba9537fdb8eb9c673caabd0679d6e1a7af6R73-R83)

**Development environment update:**

* Updated the `.devcontainer` setup script to install Azure CLI via `pipx` instead of the default installer, improving compatibility with Python 3.12+ and avoiding `distutils` issues.