### PR TITLE
Fix: environment creation fails outside the EU data boundary

### DIFF
--- a/.changes/unreleased/fixed-20260818-193500.yaml
+++ b/.changes/unreleased/fixed-20260818-193500.yaml
@@ -2,4 +2,4 @@ kind: fixed
 body: Environment creation outside the EU data boundary no longer fails when `allow_flex_routing` is unset; unknown Optional+Computed copilot policy attributes are no longer sent as `false`
 time: 2026-08-18T19:35:00.000000+10:00
 custom:
-    Issue: "1209"
+    Issue: "1237"

--- a/.changes/unreleased/fixed-20260818-193500.yaml
+++ b/.changes/unreleased/fixed-20260818-193500.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Environment creation outside the EU data boundary no longer fails when `allow_flex_routing` is unset; unknown Optional+Computed copilot policy attributes are no longer sent as `false`
+time: 2026-08-18T19:35:00.000000+10:00
+custom:
+    Issue: "1209"

--- a/internal/services/environment/resource_environment.go
+++ b/internal/services/environment/resource_environment.go
@@ -689,9 +689,18 @@ func (r *Resource) updateEnvironmentAiFeatures(ctx context.Context, environmentI
 		},
 	}
 
-	copilotPolicies := CopilotPoliciesDto{
-		CrossGeoCopilotDataMovementEnabled:      plan.AllowMovingDataAcrossRegions.ValueBoolPointer(),
-		CrossBoundaryCopilotDataMovementEnabled: plan.AllowFlexRouting.ValueBoolPointer(),
+	// Only send a copilot policy the configuration actually specifies. Both attributes are
+	// Optional+Computed, so on create an unset attribute is UNKNOWN, and ValueBoolPointer()
+	// returns nil only for null - an unknown value yields a pointer to false. Sending
+	// crossBoundaryCopilotDataMovementEnabled at all is rejected outside the EU data boundary
+	// ("can only be set for environments within an EU data boundary location"), so an unset
+	// attribute would otherwise fail every environment creation outside the EU.
+	copilotPolicies := CopilotPoliciesDto{}
+	if !plan.AllowMovingDataAcrossRegions.IsNull() && !plan.AllowMovingDataAcrossRegions.IsUnknown() {
+		copilotPolicies.CrossGeoCopilotDataMovementEnabled = plan.AllowMovingDataAcrossRegions.ValueBoolPointer()
+	}
+	if !plan.AllowFlexRouting.IsNull() && !plan.AllowFlexRouting.IsUnknown() {
+		copilotPolicies.CrossBoundaryCopilotDataMovementEnabled = plan.AllowFlexRouting.ValueBoolPointer()
 	}
 	if copilotPolicies.CrossGeoCopilotDataMovementEnabled != nil || copilotPolicies.CrossBoundaryCopilotDataMovementEnabled != nil {
 		featuresDto.Properties.CopilotPolicies = &copilotPolicies


### PR DESCRIPTION
## Description

Creating an environment fails in any region outside the EU data boundary. The API returns:

```
400 BadRequest
CrossBoundaryCopilotDataMovementEnabled can only be set for environments within an EU data boundary location.
```

You don't have to set anything to hit this. I hit it creating a normal environment in Australia with no copilot settings anywhere in my config.

## What is happening

`allow_flex_routing` (added in #1209) is Optional + Computed. When you don't set it, its value during create is **unknown**, not null.

`ValueBoolPointer()` only returns nil for a **null** value. For an **unknown** value it returns a pointer to `false`. So this always produces a non-nil pointer on create:

```go
copilotPolicies := CopilotPoliciesDto{
    CrossGeoCopilotDataMovementEnabled:      plan.AllowMovingDataAcrossRegions.ValueBoolPointer(),
    CrossBoundaryCopilotDataMovementEnabled: plan.AllowFlexRouting.ValueBoolPointer(),
}
```

And then this check passes, so the policies get sent:

```go
if copilotPolicies.CrossGeoCopilotDataMovementEnabled != nil || copilotPolicies.CrossBoundaryCopilotDataMovementEnabled != nil {
    featuresDto.Properties.CopilotPolicies = &copilotPolicies
}
```

The result is that the provider sends `crossBoundaryCopilotDataMovementEnabled: false` even though the user never asked for it, and the API rejects that field outright outside the EU. There is no way to avoid it from config: leaving the attribute out is exactly what triggers it.

`allow_moving_data_across_regions` has the same bug. It just doesn't fail, because that field is accepted in every region.

## The fix

Only send a copilot policy when the config actually specifies it, meaning the value is known and not null. If neither attribute is set, no copilot policies are sent and environment creation behaves as it did before #1209.

## How I found it

I deleted three environments in a test tenant in Australia East, then recreated them from the same terraform config that had been working. Every create failed with the error above. Same config, same region, no copilot settings in it.

## Testing

- `go test ./internal/services/environment/...` passes
- Building the provider from this branch and re-running the environment creation that failed, in Australia East. I'll confirm here once it completes.

## Checklist

- [x] Fix in `internal/services/environment/resource_environment.go`
- [x] Changelog entry
- [x] Build / unit tests clean locally
