### PR TITLE
Fix 409 handling for managed environment disable and enterprise policy operations

### DIFF
--- a/.changes/unreleased/fixed-20260826-025449.yaml
+++ b/.changes/unreleased/fixed-20260826-025449.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Managed environment disable and enterprise policy operations now verify the requested state before treating a 409 response as success.
+time: 2026-08-26T02:54:49.000000+09:00
+custom:
+    Issue: "1240"

--- a/internal/services/enterprise_policy/api_enterprise_policy.go
+++ b/internal/services/enterprise_policy/api_enterprise_policy.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/microsoft/terraform-provider-power-platform/internal/api"
@@ -44,6 +45,10 @@ func (client *Client) buildEnterprisePolicyURL(environmentId, environmentType, a
 
 // executePolicyOperation executes a policy operation (link/unlink) with common retry logic.
 func (client *Client) executePolicyOperation(ctx context.Context, environmentId, environmentType, systemId, action string) error {
+	return client.executePolicyOperationWithRetry(ctx, environmentId, environmentType, systemId, action, 0)
+}
+
+func (client *Client) executePolicyOperationWithRetry(ctx context.Context, environmentId, environmentType, systemId, action string, retryCount int) error {
 	apiUrl := client.buildEnterprisePolicyURL(environmentId, environmentType, action)
 
 	linkEnterprosePolicyDto := linkEnterprosePolicyDto{
@@ -56,6 +61,26 @@ func (client *Client) executePolicyOperation(ctx context.Context, environmentId,
 	}
 
 	tflog.Debug(ctx, fmt.Sprintf("Policy %s Operation HTTP Status: '%s'", action, apiResponse.HttpResponse.Status))
+
+	if apiResponse.HttpResponse.StatusCode == http.StatusConflict {
+		env, envErr := client.EnvironmentClient.GetEnvironment(ctx, environmentId)
+		if envErr != nil {
+			return envErr
+		}
+		if enterprisePolicyOperationDesiredStateExists(env, environmentType, systemId, action) {
+			tflog.Debug(ctx, fmt.Sprintf("Policy %s desired state already exists, nothing to do", action))
+			return nil
+		}
+		if retryCount >= constants.MAX_RETRY_COUNT {
+			return fmt.Errorf("maximum retries (%d) reached for enterprise policy %s: the operation kept returning 409 and the requested state was not established", constants.MAX_RETRY_COUNT, action)
+		}
+		if err := client.Api.SleepWithContext(ctx, api.DefaultRetryAfter()); err != nil {
+			return err
+		}
+		tflog.Info(ctx, fmt.Sprintf("Policy %s operation was rejected with 409 and the requested state is not established. Retrying...", action))
+		return client.executePolicyOperationWithRetry(ctx, environmentId, environmentType, systemId, action, retryCount+1)
+	}
+
 	tflog.Debug(ctx, "Waiting for operation to complete")
 
 	lifecycleResponse, err := client.Api.DoWaitForLifecycleOperationStatus(ctx, apiResponse)
@@ -70,6 +95,36 @@ func (client *Client) executePolicyOperation(ctx context.Context, environmentId,
 		return client.executePolicyOperation(ctx, environmentId, environmentType, systemId, action)
 	}
 	return nil
+}
+
+func enterprisePolicyOperationDesiredStateExists(env *environment.EnvironmentDto, environmentType, systemId, action string) bool {
+	var policy *environment.EnterprisePolicyDto
+	switch environmentType {
+	case NETWORK_INJECTION_POLICY_TYPE:
+		if env.Properties.EnterprisePolicies != nil {
+			policy = env.Properties.EnterprisePolicies.Vnets
+		}
+	case ENCRYPTION_POLICY_TYPE:
+		if env.Properties.EnterprisePolicies != nil {
+			policy = env.Properties.EnterprisePolicies.CustomerManagedKeys
+		}
+	case IDENTITY_POLICY_TYPE:
+		if env.Properties.EnterprisePolicies != nil {
+			policy = env.Properties.EnterprisePolicies.Identity
+		}
+	default:
+		return false
+	}
+
+	requestedPolicyIsPresent := policy != nil && strings.EqualFold(policy.SystemId, systemId)
+	switch action {
+	case "link":
+		return requestedPolicyIsPresent && strings.EqualFold(policy.LinkStatus, "Linked")
+	case "unlink":
+		return !requestedPolicyIsPresent || strings.EqualFold(policy.LinkStatus, "Unlinked")
+	default:
+		return false
+	}
 }
 
 func (client *Client) LinkEnterprisePolicy(ctx context.Context, environmentId, environmentType, systemId string) error {

--- a/internal/services/enterprise_policy/api_enterprise_policy_conflict_internal_test.go
+++ b/internal/services/enterprise_policy/api_enterprise_policy_conflict_internal_test.go
@@ -1,0 +1,200 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package enterprise_policy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/microsoft/terraform-provider-power-platform/internal/api"
+	"github.com/microsoft/terraform-provider-power-platform/internal/config"
+	"github.com/microsoft/terraform-provider-power-platform/internal/constants"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	enterprisePolicyConflictTestEnvironmentID = "00000000-0000-0000-0000-000000000001"
+	enterprisePolicyConflictTestSystemID      = "/regions/europe/providers/Microsoft.PowerPlatform/enterprisePolicies/00000000-0000-0000-0000-000000000002"
+)
+
+func TestUnitEnterprisePolicyOperation_ConflictUsesObservedDesiredState(t *testing.T) {
+	tests := []struct {
+		name             string
+		action           string
+		firstState       string
+		wantPostAttempts int
+	}{
+		{
+			name:             "link retries when the requested policy is absent",
+			action:           "link",
+			firstState:       enterprisePolicyEnvironmentWithoutPolicy(),
+			wantPostAttempts: 2,
+		},
+		{
+			name:             "link is idempotent when the requested policy is linked",
+			action:           "link",
+			firstState:       enterprisePolicyEnvironmentWithLinkedPolicy(),
+			wantPostAttempts: 1,
+		},
+		{
+			name:             "unlink retries while the requested policy remains linked",
+			action:           "unlink",
+			firstState:       enterprisePolicyEnvironmentWithLinkedPolicy(),
+			wantPostAttempts: 2,
+		},
+		{
+			name:             "unlink is idempotent when the requested policy is absent",
+			action:           "unlink",
+			firstState:       enterprisePolicyEnvironmentWithoutPolicy(),
+			wantPostAttempts: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			httpmock.Activate()
+			defer httpmock.DeactivateAndReset()
+
+			client := newEnterprisePolicyConflictTestClient()
+			postAttempts := 0
+			environmentReads := 0
+
+			httpmock.RegisterNoResponder(func(req *http.Request) (*http.Response, error) {
+				return nil, fmt.Errorf("no responder found for %s %s", req.Method, req.URL)
+			})
+			httpmock.RegisterResponder(
+				http.MethodPost,
+				client.buildEnterprisePolicyURL(enterprisePolicyConflictTestEnvironmentID, NETWORK_INJECTION_POLICY_TYPE, test.action),
+				func(_ *http.Request) (*http.Response, error) {
+					postAttempts++
+					if postAttempts == 1 {
+						return httpmock.NewStringResponse(http.StatusConflict, ""), nil
+					}
+					return httpmock.NewStringResponse(http.StatusAccepted, ""), nil
+				},
+			)
+			httpmock.RegisterResponder(
+				http.MethodGet,
+				"https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/"+enterprisePolicyConflictTestEnvironmentID+"?%24expand=permissions%2Cproperties.capacity%2Cproperties%2FbillingPolicy%2Cproperties%2FcopilotPolicies&api-version=2023-06-01",
+				func(_ *http.Request) (*http.Response, error) {
+					environmentReads++
+					return httpmock.NewStringResponse(http.StatusOK, test.firstState), nil
+				},
+			)
+
+			err := client.executePolicyOperation(
+				context.Background(),
+				enterprisePolicyConflictTestEnvironmentID,
+				NETWORK_INJECTION_POLICY_TYPE,
+				enterprisePolicyConflictTestSystemID,
+				test.action,
+			)
+
+			require.NoError(t, err)
+			require.Equal(t, test.wantPostAttempts, postAttempts)
+			require.Equal(t, 1, environmentReads, "a 409 may be success only after observing the requested desired state")
+		})
+	}
+}
+
+func TestUnitEnterprisePolicyOperation_PersistentConflictTerminatesWithoutFalseSuccess(t *testing.T) {
+	tests := []struct {
+		name        string
+		action      string
+		remoteState string
+	}{
+		{
+			name:        "link remains absent",
+			action:      "link",
+			remoteState: enterprisePolicyEnvironmentWithoutPolicy(),
+		},
+		{
+			name:        "unlink remains linked",
+			action:      "unlink",
+			remoteState: enterprisePolicyEnvironmentWithLinkedPolicy(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			httpmock.Activate()
+			defer httpmock.DeactivateAndReset()
+
+			client := newEnterprisePolicyConflictTestClient()
+			postAttempts := 0
+			environmentReads := 0
+
+			httpmock.RegisterNoResponder(func(req *http.Request) (*http.Response, error) {
+				return nil, fmt.Errorf("no responder found for %s %s", req.Method, req.URL)
+			})
+			httpmock.RegisterResponder(
+				http.MethodPost,
+				client.buildEnterprisePolicyURL(enterprisePolicyConflictTestEnvironmentID, NETWORK_INJECTION_POLICY_TYPE, test.action),
+				func(_ *http.Request) (*http.Response, error) {
+					postAttempts++
+					return httpmock.NewStringResponse(http.StatusConflict, ""), nil
+				},
+			)
+			httpmock.RegisterResponder(
+				http.MethodGet,
+				"https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/"+enterprisePolicyConflictTestEnvironmentID+"?%24expand=permissions%2Cproperties.capacity%2Cproperties%2FbillingPolicy%2Cproperties%2FcopilotPolicies&api-version=2023-06-01",
+				func(_ *http.Request) (*http.Response, error) {
+					environmentReads++
+					return httpmock.NewStringResponse(http.StatusOK, test.remoteState), nil
+				},
+			)
+
+			err := client.executePolicyOperation(
+				context.Background(),
+				enterprisePolicyConflictTestEnvironmentID,
+				NETWORK_INJECTION_POLICY_TYPE,
+				enterprisePolicyConflictTestSystemID,
+				test.action,
+			)
+
+			require.Error(t, err)
+			require.ErrorContains(t, err, "maximum retries")
+			require.Equal(t, constants.MAX_RETRY_COUNT+1, postAttempts)
+			require.Equal(t, constants.MAX_RETRY_COUNT+1, environmentReads)
+		})
+	}
+}
+
+func newEnterprisePolicyConflictTestClient() Client {
+	cfg := &config.ProviderConfig{
+		TestMode: true,
+		Urls: config.ProviderConfigUrls{
+			BapiUrl:        "api.bap.microsoft.com",
+			PowerAppsUrl:   "api.bap.microsoft.com",
+			PowerAppsScope: "scope",
+		},
+	}
+	return newEnterprisePolicyClient(api.NewApiClientBase(cfg, api.NewAuthBase(cfg)))
+}
+
+func enterprisePolicyEnvironmentWithoutPolicy() string {
+	return fmt.Sprintf(`{
+  "id": %q,
+  "name": "env",
+  "properties": {"enterprisePolicies": {}}
+}`, enterprisePolicyConflictTestEnvironmentID)
+}
+
+func enterprisePolicyEnvironmentWithLinkedPolicy() string {
+	return fmt.Sprintf(`{
+  "id": %q,
+  "name": "env",
+  "properties": {
+    "enterprisePolicies": {
+      "vnets": {
+        "systemId": %q,
+        "linkStatus": "Linked"
+      }
+    }
+  }
+}`, enterprisePolicyConflictTestEnvironmentID, enterprisePolicyConflictTestSystemID)
+}

--- a/internal/services/managed_environment/api_managed_environment.go
+++ b/internal/services/managed_environment/api_managed_environment.go
@@ -119,6 +119,26 @@ func (client *client) disableManagedEnvironmentWithRetry(ctx context.Context, en
 	}
 
 	tflog.Debug(ctx, "Managed Environment Disablement Operation HTTP Status: '"+apiResponse.HttpResponse.Status+"'")
+
+	if apiResponse.HttpResponse.StatusCode == http.StatusConflict {
+		env, envErr := client.environmentClient.GetEnvironment(ctx, environmentId)
+		if envErr != nil {
+			return envErr
+		}
+		if env.Properties.GovernanceConfiguration != nil && env.Properties.GovernanceConfiguration.ProtectionLevel == managedEnv.ProtectionLevel {
+			tflog.Debug(ctx, "Managed Environment is already disabled, nothing to do")
+			return nil
+		}
+		if retryCount >= constants.MAX_RETRY_COUNT {
+			return fmt.Errorf("maximum retries (%d) reached for DisableManagedEnvironment: the environment kept rejecting the request with 409 and the requested Basic protection level was not established", constants.MAX_RETRY_COUNT)
+		}
+		if err := client.Api.SleepWithContext(ctx, api.DefaultRetryAfter()); err != nil {
+			return err
+		}
+		tflog.Info(ctx, "Managed Environment Disablement was rejected with 409 and the requested Basic protection level is not established. Retrying...")
+		return client.disableManagedEnvironmentWithRetry(ctx, environmentId, retryCount+1)
+	}
+
 	tflog.Debug(ctx, "Waiting for Managed Environment Disablement Operation to complete")
 
 	lifecycleResponse, err := client.Api.DoWaitForLifecycleOperationStatus(ctx, apiResponse)

--- a/internal/services/managed_environment/api_managed_environment_conflict_internal_test.go
+++ b/internal/services/managed_environment/api_managed_environment_conflict_internal_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package managed_environment
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/microsoft/terraform-provider-power-platform/internal/api"
+	"github.com/microsoft/terraform-provider-power-platform/internal/config"
+	"github.com/microsoft/terraform-provider-power-platform/internal/constants"
+	"github.com/stretchr/testify/require"
+)
+
+const managedEnvironmentConflictTestEnvironmentID = "00000000-0000-0000-0000-000000000001"
+
+func TestUnitDisableManagedEnvironment_ConflictWhileStillManagedRetries(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	client := newManagedEnvironmentConflictTestClient()
+	disableAttempts := 0
+	environmentReads := 0
+
+	registerDisableManagedEnvironmentResponder(t, func(_ *http.Request) (*http.Response, error) {
+		disableAttempts++
+		if disableAttempts == 1 {
+			return httpmock.NewStringResponse(http.StatusConflict, ""), nil
+		}
+		return httpmock.NewStringResponse(http.StatusAccepted, ""), nil
+	})
+	registerManagedEnvironmentStateResponder(t, func(_ *http.Request) (*http.Response, error) {
+		environmentReads++
+		return managedEnvironmentStateResponse(constants.PROTECTION_LEVEL_STANDARD), nil
+	})
+
+	err := client.DisableManagedEnvironment(context.Background(), managedEnvironmentConflictTestEnvironmentID)
+
+	require.NoError(t, err)
+	require.Equal(t, 2, disableAttempts, "a 409 while the environment is still managed must be retried")
+	require.Equal(t, 1, environmentReads, "the provider must read the environment before deciding that a 409 is success")
+}
+
+func TestUnitDisableManagedEnvironment_ConflictWhenAlreadyDisabledIsIdempotent(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	client := newManagedEnvironmentConflictTestClient()
+	disableAttempts := 0
+	environmentReads := 0
+
+	registerDisableManagedEnvironmentResponder(t, func(_ *http.Request) (*http.Response, error) {
+		disableAttempts++
+		return httpmock.NewStringResponse(http.StatusConflict, ""), nil
+	})
+	registerManagedEnvironmentStateResponder(t, func(_ *http.Request) (*http.Response, error) {
+		environmentReads++
+		return managedEnvironmentStateResponse("Basic"), nil
+	})
+
+	err := client.DisableManagedEnvironment(context.Background(), managedEnvironmentConflictTestEnvironmentID)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, disableAttempts, "an already-disabled environment must not be retried")
+	require.Equal(t, 1, environmentReads, "idempotent success must be based on the observed desired state")
+}
+
+func TestUnitDisableManagedEnvironment_PersistentConflictTerminatesWithoutFalseSuccess(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	client := newManagedEnvironmentConflictTestClient()
+	disableAttempts := 0
+	environmentReads := 0
+
+	registerDisableManagedEnvironmentResponder(t, func(_ *http.Request) (*http.Response, error) {
+		disableAttempts++
+		return httpmock.NewStringResponse(http.StatusConflict, ""), nil
+	})
+	registerManagedEnvironmentStateResponder(t, func(_ *http.Request) (*http.Response, error) {
+		environmentReads++
+		return managedEnvironmentStateResponse(constants.PROTECTION_LEVEL_STANDARD), nil
+	})
+
+	err := client.DisableManagedEnvironment(context.Background(), managedEnvironmentConflictTestEnvironmentID)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "maximum retries")
+	require.Equal(t, constants.MAX_RETRY_COUNT+1, disableAttempts)
+	require.Equal(t, constants.MAX_RETRY_COUNT+1, environmentReads)
+}
+
+func newManagedEnvironmentConflictTestClient() client {
+	cfg := &config.ProviderConfig{
+		TestMode: true,
+		Urls: config.ProviderConfigUrls{
+			BapiUrl:        "api.bap.microsoft.com",
+			PowerAppsUrl:   "api.bap.microsoft.com",
+			PowerAppsScope: "scope",
+		},
+	}
+	return newManagedEnvironmentClient(api.NewApiClientBase(cfg, api.NewAuthBase(cfg)))
+}
+
+func registerDisableManagedEnvironmentResponder(t *testing.T, responder httpmock.Responder) {
+	t.Helper()
+	httpmock.RegisterNoResponder(func(req *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("no responder found for %s %s", req.Method, req.URL)
+	})
+	httpmock.RegisterResponder(
+		http.MethodPost,
+		"https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/environments/"+managedEnvironmentConflictTestEnvironmentID+"/governanceConfiguration?api-version=2021-04-01",
+		responder,
+	)
+}
+
+func registerManagedEnvironmentStateResponder(t *testing.T, responder httpmock.Responder) {
+	t.Helper()
+	httpmock.RegisterResponder(
+		http.MethodGet,
+		"https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/"+managedEnvironmentConflictTestEnvironmentID+"?%24expand=permissions%2Cproperties.capacity%2Cproperties%2FbillingPolicy%2Cproperties%2FcopilotPolicies&api-version=2023-06-01",
+		responder,
+	)
+}
+
+func managedEnvironmentStateResponse(protectionLevel string) *http.Response {
+	return httpmock.NewStringResponse(http.StatusOK, fmt.Sprintf(`{
+  "id": %q,
+  "name": "env",
+  "properties": {
+    "governanceConfiguration": {"protectionLevel": %q}
+  }
+}`, managedEnvironmentConflictTestEnvironmentID, protectionLevel))
+}

--- a/internal/services/managed_environment/resource_managed_environment_test.go
+++ b/internal/services/managed_environment/resource_managed_environment_test.go
@@ -791,7 +791,10 @@ func TestUnitManagedEnvironmentsResource_Validate_Create_Conflict_When_Already_M
 	httpmock.RegisterResponder("POST", "https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/environments/00000000-0000-0000-0000-000000000001/governanceConfiguration?api-version=2021-04-01",
 		func(req *http.Request) (*http.Response, error) {
 			enableAttempts++
-			return httpmock.NewStringResponse(http.StatusConflict, ""), nil
+			if enableAttempts == 1 {
+				return httpmock.NewStringResponse(http.StatusConflict, ""), nil
+			}
+			return httpmock.NewStringResponse(http.StatusAccepted, ""), nil
 		})
 
 	// The environment is already managed, so the 409 is a no-op rather than a rejection.


### PR DESCRIPTION
## Summary

HTTP 409 can mean either that the requested state is already established or that the operation was rejected because the environment is busy. The managed environment disable and enterprise policy link/unlink paths previously passed 409 responses into the lifecycle waiter and could return success without verifying the requested state.

On 409, these paths now re-read remote state:

- already-achieved state remains an idempotent success
- non-converged state retries up to the existing retry limit and ultimately returns an error
- managed environment disable checks for the `Basic` protection level
- enterprise policy operations compare the requested `systemId` with the relevant policy slot and link state

HTTP 202 behavior, the lifecycle waiter, and unrelated 409 handling are unchanged.

Fixes #1240

## Testing

- focused conflict tests pass with `-count=3`
- `go test ./internal/services/managed_environment ./internal/services/enterprise_policy -count=1`
- `go test ./internal/... -run '^TestUnit' -count=1`
- `go vet ./internal/services/managed_environment ./internal/services/enterprise_policy`
