### PR TITLE
fix: stop acceptance tests failing on races and transient auth errors

### DIFF
--- a/.changes/unreleased/fixed-20260826-092459.yaml
+++ b/.changes/unreleased/fixed-20260826-092459.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Provider no longer fails on transient OIDC assertion errors, credential refusals on non-replayable requests, role assignments that are not yet listable after create, or environment administration mode that has not converged when apply returns
+time: 2026-08-26T09:24:59.044871464Z
+custom:
+    Issue: "1254"

--- a/.changes/unreleased/fixed-20260826-092459.yaml
+++ b/.changes/unreleased/fixed-20260826-092459.yaml
@@ -1,5 +1,0 @@
-kind: fixed
-body: Provider no longer fails on transient OIDC assertion errors, credential refusals on non-replayable requests, role assignments that are not yet listable after create, or environment administration mode that has not converged when apply returns
-time: 2026-08-26T09:24:59.044871464Z
-custom:
-    Issue: "1254"

--- a/.github/prompts/codeql.prompt.md
+++ b/.github/prompts/codeql.prompt.md
@@ -1,5 +1,13 @@
 # CodeQL Query Guidelines for Go (GitHub Copilot Agent Mode)
 
+## Repository Conventions
+
+Project rules that queries may be written to enforce, and that any code the agent writes must follow.
+
+* **Constants are always `UPPER_CASE`:** Every `const` uses `SCREAMING_SNAKE_CASE` (for example `MAX_RETRY_COUNT`, `BAP_API_VERSION`), whether exported or not. Go's usual `mixedCaps` naming does **not** apply to constants in this repository, so a lowercase or camelCase constant name such as `apiVersion` or `maxUnauthorizedRetries` is a violation.
+
+* **Constants belong in a separate file:** Declare them in `internal/constants/constants.go`, or, when a constant is genuinely local to one service, in that service's own constants file. Do not inline a `const` block next to the code that happens to use it — every constant should have one predictable home.
+
 ## Authoring Best Practices
 
 * **Understand the root cause:** Always begin by clarifying the bug or vulnerability at a fundamental level. Identify the **root cause pattern** in code (for example, a missing check, an API misuse, a dangerous data flow) rather than focusing on superficial symptoms. This ensures your query finds the real issue, not just one instance of it.

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -193,7 +193,7 @@ jobs:
         # - -set-exit-code: Preserves the original test exit code
         # - -iocopy: Copies test output to stdout while generating the report
         # - -out junit.xml: Writes JUnit-formatted test results to junit.xml
-        go test -p 2 -v 2>&1 ./... -run ^Test -coverprofile=test-coverage.out -timeout 600m -failfast -shuffle=off | go-junit-report -set-exit-code  -iocopy -out junit.xml
+        go test -p 2 -v 2>&1 ./... -run ^Test -coverprofile=test-coverage.out -timeout 600m -shuffle=off | go-junit-report -set-exit-code  -iocopy -out junit.xml
         
     - name: Prepare coverage report
       if: success() || failure()

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/microsoft/terraform-provider-power-platform/internal/config"
+	"github.com/microsoft/terraform-provider-power-platform/internal/constants"
 	"github.com/microsoft/terraform-provider-power-platform/internal/helpers"
 )
 
@@ -426,6 +427,10 @@ func (client *Auth) createTokenRequestOptions(ctx context.Context, scopes []stri
 	return tokenOptions
 }
 
+// The workload identity token endpoint of a CI provider is an external dependency that answers
+// transiently with 5xx or drops the connection under load, and a lost assertion fails the whole
+// provider operation rather than a single request. The exchange is an idempotent GET that mints a
+// fresh token, so it is replayed a bounded number of times before giving up.
 func (w *OidcCredential) getAssertion(ctx context.Context) (string, error) {
 	if w.token != "" {
 		return w.token, nil
@@ -440,14 +445,35 @@ func (w *OidcCredential) getAssertion(ctx context.Context) (string, error) {
 		return string(idTokenData), nil
 	}
 
+	for attempt := 1; ; attempt++ {
+		assertion, retryable, err := w.requestAssertion(ctx)
+		if err == nil {
+			return assertion, nil
+		}
+		if !retryable || attempt >= constants.OIDC_ASSERTION_MAX_ATTEMPTS {
+			return "", err
+		}
+
+		tflog.Debug(ctx, fmt.Sprintf("getAssertion: transient failure from the OIDC provider on attempt %d of %d, retrying: %s", attempt, constants.OIDC_ASSERTION_MAX_ATTEMPTS, err))
+		select {
+		case <-time.After(constants.OIDC_ASSERTION_RETRY_DELAY):
+		case <-ctx.Done():
+			return "", fmt.Errorf("getAssertion: interrupted while waiting to retry: %w (last failure: %v)", ctx.Err(), err)
+		}
+	}
+}
+
+// requestAssertion performs one token exchange. The second return value reports whether the
+// failure is transient and therefore worth replaying.
+func (w *OidcCredential) requestAssertion(ctx context.Context) (string, bool, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", w.requestUrl, http.NoBody)
 	if err != nil {
-		return "", errors.New("getAssertion: failed to build request")
+		return "", false, errors.New("getAssertion: failed to build request")
 	}
 
 	query, err := url.ParseQuery(req.URL.RawQuery)
 	if err != nil {
-		return "", errors.New("getAssertion: cannot parse URL query")
+		return "", false, errors.New("getAssertion: cannot parse URL query")
 	}
 
 	if query.Get("audience") == "" {
@@ -461,17 +487,19 @@ func (w *OidcCredential) getAssertion(ctx context.Context) (string, error) {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("getAssertion: cannot request token: %w", err)
+		// A transport failure never yielded an assertion, so replaying it is safe unless the
+		// caller's own context is what ended the request.
+		return "", ctx.Err() == nil, fmt.Errorf("getAssertion: cannot request token: %w", err)
 	}
 
 	defer resp.Body.Close()
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return "", fmt.Errorf("getAssertion: cannot parse response: %w", err)
+		return "", false, fmt.Errorf("getAssertion: cannot parse response: %w", err)
 	}
 
 	if statusCode := resp.StatusCode; statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices {
-		return "", fmt.Errorf("getAssertion: received HTTP status %d with response: %s", resp.StatusCode, body)
+		return "", isTransientOidcStatus(resp.StatusCode), fmt.Errorf("getAssertion: received HTTP status %d with response: %s", resp.StatusCode, body)
 	}
 
 	var tokenRes struct {
@@ -479,14 +507,22 @@ func (w *OidcCredential) getAssertion(ctx context.Context) (string, error) {
 		Value *string `json:"value"`
 	}
 	if err := json.Unmarshal(body, &tokenRes); err != nil {
-		return "", fmt.Errorf("getAssertion: cannot unmarshal response: %w", err)
+		return "", false, fmt.Errorf("getAssertion: cannot unmarshal response: %w", err)
 	}
 
 	if tokenRes.Value == nil {
-		return "", errors.New("getAssertion: nil JWT assertion received from OIDC provider")
+		return "", false, errors.New("getAssertion: nil JWT assertion received from OIDC provider")
 	}
 
-	return *tokenRes.Value, nil
+	return *tokenRes.Value, false, nil
+}
+
+// isTransientOidcStatus reports whether the token endpoint refused the exchange for a reason that
+// may not hold on the next attempt. A rejected or malformed request would only be rejected again.
+func isTransientOidcStatus(status int) bool {
+	return status == http.StatusRequestTimeout ||
+		status == http.StatusTooManyRequests ||
+		status >= http.StatusInternalServerError
 }
 
 func (client *Auth) GetTokenForScopes(ctx context.Context, scopes []string) (*string, error) {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -150,6 +150,7 @@ func (client *Client) doExecute(ctx context.Context, scopes []string, method, ur
 	}
 
 	var lastRetryableResponse *Response
+	unauthorizedRetries := 0
 	for {
 		token, err := client.BaseAuth.GetTokenForScopes(ctx, scopes)
 
@@ -197,7 +198,11 @@ func (client *Client) doExecute(ctx context.Context, scopes []string, method, ur
 		}
 
 		isRetryable := helpers.ArrayContains(retryableStatusCodes, resp.HttpResponse.StatusCode)
-		if retry == retryNever || !isRetryable {
+		if retry == retryNever && resp.HttpResponse.StatusCode == http.StatusUnauthorized && unauthorizedRetries < constants.MAX_UNAUTHORIZED_RETRIES {
+			// The credential was refused, so the request never reached the operation and replaying
+			// it with a freshly acquired token cannot duplicate a non-idempotent mutation.
+			unauthorizedRetries++
+		} else if retry == retryNever || !isRetryable {
 			return resp, customerrors.NewUnexpectedHttpStatusCodeError(acceptableStatusCodes, resp.HttpResponse.StatusCode, resp.HttpResponse.Status, resp.BodyAsBytes)
 		}
 		lastRetryableResponse = resp

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -44,6 +44,31 @@ func TestUnitApiClient_ExecuteWithoutRetry_DoesNotReplayTransientMutation(t *tes
 	assert.Equal(t, 1, attempts, "an ambiguous non-idempotent mutation start must never be replayed")
 }
 
+func TestUnitApiClient_ExecuteWithoutRetry_ReplaysRefusedCredential(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	cfg := config.ProviderConfig{TestMode: true}
+	client := api.NewApiClientBase(&cfg, api.NewAuthBase(&cfg))
+	_, err := client.ExecuteWithoutRetry(
+		context.Background(),
+		[]string{"test"},
+		http.MethodPost,
+		server.URL,
+		http.Header{},
+		map[string]string{"operation": "start"},
+		[]int{http.StatusNoContent},
+		nil,
+	)
+
+	assert.Error(t, err)
+	assert.Equal(t, 3, attempts, "a 401 proves the request never reached the operation, so it is replayed with a bounded number of fresh tokens")
+}
+
 func TestUnitApiClient_GetConfig(t *testing.T) {
 	t.Parallel()
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -192,6 +192,16 @@ const (
 // refused for a reason other than expiry would be minted identically on every attempt.
 const MAX_UNAUTHORIZED_RETRIES = 2
 
+// Dataverse resolves an application user's application id against Entra, and a service principal
+// created moments earlier has not necessarily replicated there yet.
+const (
+	ENTRA_APPLICATION_PROPAGATION_POLL_INTERVAL = 15 * time.Second
+	ENTRA_APPLICATION_PROPAGATION_POLL_TIMEOUT  = 10 * time.Minute
+
+	// The Dataverse error code for "we didn't find that application ID in your Azure Active Directory".
+	DATAVERSE_APPLICATION_NOT_IN_ENTRA_ERROR_CODE = "0x8004f510"
+)
+
 const (
 	ENV_VAR_POWER_PLATFORM_CLOUD                        = "POWER_PLATFORM_CLOUD"
 	ENV_VAR_POWER_PLATFORM_TENANT_ID                    = "POWER_PLATFORM_TENANT_ID"

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -174,6 +174,24 @@ const (
 	DATAVERSE_CALLER_PROVISIONING_POLL_TIMEOUT  = 10 * time.Minute
 )
 
+// The RBAC role assignment collection is eventually consistent with the create that committed an
+// assignment, so a create has to wait for its own assignment to become listable.
+const (
+	RBAC_ROLE_ASSIGNMENT_POLL_INTERVAL = 5 * time.Second
+	RBAC_ROLE_ASSIGNMENT_POLL_TIMEOUT  = 2 * time.Minute
+)
+
+// The workload identity token endpoint of a CI provider answers transiently with 5xx under load,
+// and a lost assertion fails a whole provider operation rather than a single request.
+const (
+	OIDC_ASSERTION_MAX_ATTEMPTS = 5
+	OIDC_ASSERTION_RETRY_DELAY  = 3 * time.Second
+)
+
+// MAX_UNAUTHORIZED_RETRIES bounds how many times a rejected credential is replayed. A token that is
+// refused for a reason other than expiry would be minted identically on every attempt.
+const MAX_UNAUTHORIZED_RETRIES = 2
+
 const (
 	ENV_VAR_POWER_PLATFORM_CLOUD                        = "POWER_PLATFORM_CLOUD"
 	ENV_VAR_POWER_PLATFORM_TENANT_ID                    = "POWER_PLATFORM_TENANT_ID"

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -5,6 +5,7 @@ package mocks
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"net/http"
 	"os"
@@ -26,6 +27,29 @@ func TestName() string {
 	nameEnd := filepath.Ext(nameFull)
 	name := strings.TrimPrefix(nameEnd, ".")
 	return name
+}
+
+// ENTRA_MAIL_NICKNAME_MAX_LENGTH is the limit Entra enforces on a user's mailNickname, and on the
+// local part of its userPrincipalName. A longer value is rejected with Request_BadRequest.
+const ENTRA_MAIL_NICKNAME_MAX_LENGTH = 64
+
+// TestNameForEntra returns the calling test's name shortened to what Entra accepts as a mail
+// nickname. Test names are long enough to exceed the limit, and truncating alone would collide
+// between tests sharing a prefix, so the tail is replaced by a hash of the full name.
+func TestNameForEntra() string {
+	pc, _, _, _ := runtime.Caller(1)
+	name := strings.TrimPrefix(filepath.Ext(runtime.FuncForPC(pc).Name()), ".")
+	return shortenForEntra(name)
+}
+
+func shortenForEntra(name string) string {
+	if len(name) <= ENTRA_MAIL_NICKNAME_MAX_LENGTH {
+		return name
+	}
+
+	digest := sha256.Sum256([]byte(name))
+	suffix := fmt.Sprintf("_%x", digest[:4])
+	return name[:ENTRA_MAIL_NICKNAME_MAX_LENGTH-len(suffix)] + suffix
 }
 
 func TestsEntraLicesingGroupName() string {

--- a/internal/mocks/mocks_test.go
+++ b/internal/mocks/mocks_test.go
@@ -23,6 +23,38 @@ func TestUnitTestName(t *testing.T) {
 	}
 }
 
+//go:noinline
+func aTestNameComfortablyLongerThanTheSixtyFourCharacterEntraNicknameLimit() string {
+	return mocks.TestNameForEntra()
+}
+
+//go:noinline
+func aTestNameComfortablyLongerThanTheSixtyFourCharacterEntraNicknameLimitToo() string {
+	return mocks.TestNameForEntra()
+}
+
+func TestUnitTestNameForEntra(t *testing.T) {
+	short := testNameForEntraCaller()
+	if short != "testNameForEntraCaller" {
+		t.Fatalf("a name within the limit must be returned unchanged, got %q", short)
+	}
+
+	long := aTestNameComfortablyLongerThanTheSixtyFourCharacterEntraNicknameLimit()
+	if len(long) > mocks.ENTRA_MAIL_NICKNAME_MAX_LENGTH {
+		t.Fatalf("expected at most %d characters, got %d (%q)", mocks.ENTRA_MAIL_NICKNAME_MAX_LENGTH, len(long), long)
+	}
+
+	// Names sharing the first 64 characters must not collapse onto the same nickname.
+	if other := aTestNameComfortablyLongerThanTheSixtyFourCharacterEntraNicknameLimitToo(); other == long {
+		t.Fatalf("two distinct test names produced the same nickname %q", long)
+	}
+}
+
+//go:noinline
+func testNameForEntraCaller() string {
+	return mocks.TestNameForEntra()
+}
+
 func TestUnitTestsEntraLicesingGroupName(t *testing.T) {
 	if got := mocks.TestsEntraLicesingGroupName(); got == "" {
 		t.Fatal("expected group name to be non-empty")

--- a/internal/services/application/api_application.go
+++ b/internal/services/application/api_application.go
@@ -226,13 +226,13 @@ func (client *client) CreateScopedApplicationUser(ctx context.Context, environme
 		"businessunitid@odata.bind": fmt.Sprintf("/businessunits(%s)", businessUnitId),
 	}
 
-	response, err := client.Api.Execute(ctx, nil, "POST", apiUrl.String(), nil, requestBody, []int{http.StatusNoContent, http.StatusCreated}, nil)
+	response, err := client.createSystemUser(ctx, apiUrl.String(), requestBody)
 	if err != nil {
 		if purgeErr := client.purgeDeletedApplicationUsersByApplicationId(ctx, environmentId, applicationId, err); purgeErr != nil {
 			return nil, purgeErr
 		}
 
-		response, err = client.Api.Execute(ctx, nil, "POST", apiUrl.String(), nil, requestBody, []int{http.StatusNoContent, http.StatusCreated}, nil)
+		response, err = client.createSystemUser(ctx, apiUrl.String(), requestBody)
 		if err != nil {
 			return nil, err
 		}
@@ -253,6 +253,33 @@ func (client *client) CreateScopedApplicationUser(ctx context.Context, environme
 	}
 
 	return client.GetApplicationUserBySystemUserId(ctx, environmentId, match[len(match)-1][0])
+}
+
+// createSystemUser posts the application user, replaying the request while Dataverse cannot resolve
+// the application id in Entra. A service principal created moments earlier has not necessarily
+// replicated yet, and that rejection is a definitive 400, so nothing was committed by the attempt.
+func (client *client) createSystemUser(ctx context.Context, apiUrl string, requestBody map[string]any) (*api.Response, error) {
+	maxRetries := int(constants.ENTRA_APPLICATION_PROPAGATION_POLL_TIMEOUT / constants.ENTRA_APPLICATION_PROPAGATION_POLL_INTERVAL)
+
+	for retry := 0; ; retry++ {
+		response, err := client.Api.Execute(ctx, nil, "POST", apiUrl, nil, requestBody, []int{http.StatusNoContent, http.StatusCreated}, nil)
+		if err == nil || !isApplicationNotYetPropagated(err) || retry >= maxRetries {
+			return response, err
+		}
+
+		tflog.Debug(ctx, "Dataverse cannot see the application in Entra yet, retrying the application user create")
+		if sleepErr := client.Api.SleepWithContext(ctx, constants.ENTRA_APPLICATION_PROPAGATION_POLL_INTERVAL); sleepErr != nil {
+			return response, sleepErr
+		}
+	}
+}
+
+func isApplicationNotYetPropagated(err error) bool {
+	var httpErr customerrors.UnexpectedHttpStatusCodeError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusBadRequest {
+		return false
+	}
+	return strings.Contains(string(httpErr.Body), constants.DATAVERSE_APPLICATION_NOT_IN_ENTRA_ERROR_CODE)
 }
 
 func (client *client) purgeDeletedApplicationUsersByApplicationId(ctx context.Context, environmentId, applicationId string, createErr error) error {

--- a/internal/services/application/api_application.go
+++ b/internal/services/application/api_application.go
@@ -263,7 +263,7 @@ func (client *client) createSystemUser(ctx context.Context, apiUrl string, reque
 
 	for retry := 0; ; retry++ {
 		response, err := client.Api.Execute(ctx, nil, "POST", apiUrl, nil, requestBody, []int{http.StatusNoContent, http.StatusCreated}, nil)
-		if err == nil || !isApplicationNotYetPropagated(err) || retry >= maxRetries {
+		if err == nil || !isApplicationNotFoundInEntra(err) || retry >= maxRetries {
 			return response, err
 		}
 
@@ -274,7 +274,10 @@ func (client *client) createSystemUser(ctx context.Context, apiUrl string, reque
 	}
 }
 
-func isApplicationNotYetPropagated(err error) bool {
+// isApplicationNotFoundInEntra reports the definitive 400 Dataverse returns when it cannot resolve
+// an application user's application id in Entra, either because it has not replicated yet or
+// because the registration is gone.
+func isApplicationNotFoundInEntra(err error) bool {
 	var httpErr customerrors.UnexpectedHttpStatusCodeError
 	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusBadRequest {
 		return false
@@ -596,6 +599,13 @@ func (client *client) RemovePrincipalSecurityRoles(ctx context.Context, environm
 
 		resp, err := client.Api.Execute(ctx, nil, "DELETE", apiUrl.String(), nil, nil, []int{http.StatusNoContent, http.StatusForbidden, http.StatusNotFound}, nil)
 		if err != nil {
+			// Dataverse rejects the dissociation when the principal's application registration no
+			// longer exists in Entra. The grant cannot outlive the identity it was made to, so this
+			// is the outcome a removal wants rather than a failure to report.
+			if isApplicationNotFoundInEntra(err) {
+				tflog.Debug(ctx, fmt.Sprintf("Security role %s cannot be dissociated from %s because its application is no longer in Entra; treating it as removed", roleId, holder))
+				continue
+			}
 			return err
 		}
 		if err := client.Api.HandleForbiddenResponse(resp); err != nil {

--- a/internal/services/application/resource_application_user_test.go
+++ b/internal/services/application/resource_application_user_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/jarcoal/httpmock"
 	"github.com/microsoft/terraform-provider-power-platform/internal/constants"
 	"github.com/microsoft/terraform-provider-power-platform/internal/mocks"
@@ -152,6 +153,95 @@ func TestUnitEnvironmentApplicationUserResource_CreateDelete(t *testing.T) {
 					resource.TestCheckResourceAttr("powerplatform_application_user.test", "system_user_id", systemUserID),
 					resource.TestCheckResourceAttr("powerplatform_application_user.test", "business_unit_id", rootBusinessID),
 					resource.TestCheckResourceAttr("powerplatform_application_user.test", "disabled", "false"),
+				),
+			},
+		},
+	})
+}
+
+// Dataverse rejects the create until the service principal has replicated to Entra. The rejection
+// is a definitive 400, so the create is replayed rather than failing the apply.
+func TestUnitEnvironmentApplicationUserResource_CreateWaitsForEntraPropagation(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	const (
+		environmentID  = "00000000-0000-0000-0000-000000000001"
+		applicationID  = "00000000-0000-0000-0000-000000000002"
+		systemUserID   = "00000000-0000-0000-0000-000000000008"
+		rootBusinessID = "00000000-0000-0000-0000-000000000003"
+	)
+
+	createAttempts := 0
+	userCreated := false
+
+	httpmock.RegisterResponder("GET", `=~^https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/00000000-0000-0000-0000-000000000001`,
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(http.StatusOK, httpmock.File("tests/resource/application_admin/Create/get_environment.json").String()), nil
+		})
+
+	httpmock.RegisterResponder("GET", `=~^https://test-env.crm.dynamics.com/api/data/v9.2/businessunits.*`,
+		func(req *http.Request) (*http.Response, error) {
+			body := fmt.Sprintf(`{"value":[{"businessunitid":"%s","name":"root"}]}`, rootBusinessID)
+			return httpmock.NewStringResponse(http.StatusOK, body), nil
+		})
+
+	httpmock.RegisterResponder("POST", `=~^https://test-env.crm.dynamics.com/api/data/v9.2/systemusers$`,
+		func(req *http.Request) (*http.Response, error) {
+			createAttempts++
+			if createAttempts < 3 {
+				return httpmock.NewStringResponse(http.StatusBadRequest, `{"error":{"code":"0x8004f510","message":"We didn't find that application ID in your Azure Active Directory (Azure AD)."}}`), nil
+			}
+			userCreated = true
+			resp := httpmock.NewStringResponse(http.StatusNoContent, "")
+			resp.Header.Set("OData-EntityId", fmt.Sprintf("https://test-env.crm.dynamics.com/api/data/v9.2/systemusers(%s)", systemUserID))
+			return resp, nil
+		})
+
+	httpmock.RegisterResponder("GET", `=~^https://test-env.crm.dynamics.com/api/data/v9.2/systemusers.*`,
+		func(req *http.Request) (*http.Response, error) {
+			if !userCreated {
+				return httpmock.NewStringResponse(http.StatusOK, `{"value":[]}`), nil
+			}
+
+			body := fmt.Sprintf(`{"systemuserid":"%s","applicationid":"%s","fullname":"Example Application User","_businessunitid_value":"%s","isdisabled":false,"systemuserroles_association":[]}`,
+				systemUserID, applicationID, rootBusinessID)
+			if strings.Contains(req.URL.Path, "/systemusers("+systemUserID+")") || strings.Contains(req.URL.RawPath, "/systemusers%28"+systemUserID+"%29") {
+				return httpmock.NewStringResponse(http.StatusOK, body), nil
+			}
+
+			return httpmock.NewStringResponse(http.StatusOK, fmt.Sprintf(`{"value":[%s]}`, body)), nil
+		})
+
+	httpmock.RegisterResponder("PATCH", `=~^https://test-env.crm.dynamics.com/api/data/v9.2/systemusers.*`,
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(http.StatusNoContent, ""), nil
+		})
+
+	httpmock.RegisterResponder("DELETE", `=~^https://test-env.crm.dynamics.com/api/data/v9.2/systemusers(%28|\()00000000-0000-0000-0000-000000000008(%29|\))$`,
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(http.StatusNoContent, ""), nil
+		})
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				resource "powerplatform_application_user" "test" {
+					environment_id = "` + environmentID + `"
+					application_id = "` + applicationID + `"
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("powerplatform_application_user.test", "system_user_id", systemUserID),
+					func(*terraform.State) error {
+						if createAttempts != 3 {
+							return fmt.Errorf("expected the create to be replayed until Entra propagated, got %d attempts", createAttempts)
+						}
+						return nil
+					},
 				),
 			},
 		},

--- a/internal/services/application/resource_security_role_assignment_test.go
+++ b/internal/services/application/resource_security_role_assignment_test.go
@@ -742,6 +742,69 @@ func TestUnitSecurityRoleAssignmentResource_Delete_404_Is_Success(t *testing.T) 
 	})
 }
 
+// An application user whose Entra registration has been deleted cannot have its grants dissociated:
+// Dataverse answers the DELETE with 0x8004f510. The grant cannot outlive that identity, so destroy
+// must succeed rather than leave the resource dangling in state.
+func TestUnitSecurityRoleAssignmentResource_Delete_Application_Gone_From_Entra_Is_Success(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	const (
+		environmentID  = "00000000-0000-0000-0000-000000000001"
+		applicationID  = "00000000-0000-0000-0000-000000000002"
+		principalID    = "00000000-0000-0000-0000-000000000008"
+		rootBusinessID = "00000000-0000-0000-0000-000000000003"
+		roleAdminID    = "7d0690d3-6af6-f011-8407-000d3a7a035d"
+		roleName       = "MetaForm Global Admin"
+	)
+
+	assigned := false
+	httpmock.RegisterResponder("GET", `=~^https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/`+environmentID,
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(http.StatusOK, httpmock.File("tests/resource/application_admin/Create/get_environment.json").String()), nil
+		})
+	httpmock.RegisterResponder("GET", `=~^https://test-env.crm.dynamics.com/api/data/v9.2/systemusers.*`,
+		func(req *http.Request) (*http.Response, error) {
+			roles := ""
+			if assigned {
+				roles = `{"roleid":"` + roleAdminID + `","name":"` + roleName + `","_businessunitid_value":"` + rootBusinessID + `"}`
+			}
+			return httpmock.NewStringResponse(http.StatusOK,
+				`{"systemuserid":"`+principalID+`","applicationid":"`+applicationID+`","fullname":"Example","_businessunitid_value":"`+rootBusinessID+`","isdisabled":false,"systemuserroles_association":[`+roles+`]}`), nil
+		})
+	httpmock.RegisterResponder("GET", `=~^https://test-env.crm.dynamics.com/api/data/v9.2/roles.*`,
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(http.StatusOK,
+				`{"value":[{"roleid":"`+roleAdminID+`","name":"`+roleName+`","_businessunitid_value":"`+rootBusinessID+`"}]}`), nil
+		})
+	httpmock.RegisterResponder("POST", `=~^https://test-env.crm.dynamics.com/api/data/v9.2/systemusers(%28|\()`+principalID+`(%29|\))/systemuserroles_association/\$ref$`,
+		func(req *http.Request) (*http.Response, error) {
+			assigned = true
+			return httpmock.NewStringResponse(http.StatusNoContent, ""), nil
+		})
+	httpmock.RegisterResponder("DELETE", `=~^https://test-env.crm.dynamics.com/api/data/v9.2/systemusers(%28|\()`+principalID+`(%29|\))/systemuserroles_association/\$ref.*`,
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewStringResponse(http.StatusBadRequest,
+				`{"error":{"code":"0x8004f510","message":"We didn't find that application ID `+applicationID+` in your Azure Active Directory (Azure AD)."}}`), nil
+		})
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				resource "powerplatform_security_role_assignment" "test" {
+					environment_id     = "` + environmentID + `"
+					system_user_id     = "` + principalID + `"
+					security_role_name = "` + roleName + `"
+				}`,
+				Check: resource.TestCheckResourceAttr("powerplatform_security_role_assignment.test", "security_role_id", roleAdminID),
+			},
+		},
+	})
+}
+
 // A failed association POST never becomes successful state, even when the association was truly
 // committed: the responder inserts the role into the harness's remote map exactly as a committed
 // POST would, so any reintroduced read-back adoption would find it and this test would fail. The

--- a/internal/services/dlp_policy/datasource_dlp_policy_test.go
+++ b/internal/services/dlp_policy/datasource_dlp_policy_test.go
@@ -205,6 +205,20 @@ func TestAccDlpPolicyDataSource_Validate_Read(t *testing.T) {
 						default_action_rule_behavior = ""
 						endpoint_rules               = []
 						id                           = "/providers/Microsoft.PowerApps/apis/shared_azureopenai"
+					  },
+					  {
+						# shared_mailgun and shared_polydoc are pinned here because their live "unblockable"
+						# governance metadata flaps between apply and refresh, causing plan drift.
+						action_rules                 = []
+						default_action_rule_behavior = ""
+						endpoint_rules               = []
+						id                           = "/providers/Microsoft.PowerApps/apis/shared_mailgun"
+					  },
+					  {
+						action_rules                 = []
+						default_action_rule_behavior = ""
+						endpoint_rules               = []
+						id                           = "/providers/Microsoft.PowerApps/apis/shared_polydoc"
 					  }
 					])
 
@@ -264,7 +278,7 @@ func TestAccDlpPolicyDataSource_Validate_Read(t *testing.T) {
 					testCheckDLPPolicyAttr("data.powerplatform_data_loss_prevention_policies.all", mocks.TestName(), "default_connectors_classification", "Blocked"),
 					testCheckDLPPolicyAttr("data.powerplatform_data_loss_prevention_policies.all", mocks.TestName(), "environment_type", "OnlyEnvironments"),
 					testCheckDLPPolicyAttr("data.powerplatform_data_loss_prevention_policies.all", mocks.TestName(), "environments.#", "1"),
-					testCheckDLPPolicyAttr("data.powerplatform_data_loss_prevention_policies.all", mocks.TestName(), "business_connectors.#", "4"),
+					testCheckDLPPolicyAttr("data.powerplatform_data_loss_prevention_policies.all", mocks.TestName(), "business_connectors.#", "6"),
 					testCheckDLPPolicyAttr("data.powerplatform_data_loss_prevention_policies.all", mocks.TestName(), "custom_connectors_patterns.#", "2"),
 
 					testCheckDLPPolicySetElemNestedAttrs("data.powerplatform_data_loss_prevention_policies.all", mocks.TestName(), "business_connectors", map[string]string{
@@ -275,6 +289,12 @@ func TestAccDlpPolicyDataSource_Validate_Read(t *testing.T) {
 					}),
 					testCheckDLPPolicySetElemNestedAttrs("data.powerplatform_data_loss_prevention_policies.all", mocks.TestName(), "business_connectors", map[string]string{
 						"id": "/providers/Microsoft.PowerApps/apis/shared_azureopenai",
+					}),
+					testCheckDLPPolicySetElemNestedAttrs("data.powerplatform_data_loss_prevention_policies.all", mocks.TestName(), "business_connectors", map[string]string{
+						"id": "/providers/Microsoft.PowerApps/apis/shared_mailgun",
+					}),
+					testCheckDLPPolicySetElemNestedAttrs("data.powerplatform_data_loss_prevention_policies.all", mocks.TestName(), "business_connectors", map[string]string{
+						"id": "/providers/Microsoft.PowerApps/apis/shared_polydoc",
 					}),
 					testCheckDLPPolicySetElemNestedAttrs("data.powerplatform_data_loss_prevention_policies.all", mocks.TestName(), "business_connectors", map[string]string{
 						"id":                           "/providers/Microsoft.PowerApps/apis/shared_sql",

--- a/internal/services/dlp_policy/resource_dlp_policy_test.go
+++ b/internal/services/dlp_policy/resource_dlp_policy_test.go
@@ -971,6 +971,20 @@ func TestAccDataLossPreventionPolicyResource_Validate_Create(t *testing.T) {
 						default_action_rule_behavior = ""
 						endpoint_rules               = []
 						id                           = "/providers/Microsoft.PowerApps/apis/shared_cloudappsecurity"
+					  },
+					  {
+						# shared_mailgun and shared_polydoc are pinned here because their live "unblockable"
+						# governance metadata flaps between apply and refresh, causing plan drift.
+						action_rules                 = []
+						default_action_rule_behavior = ""
+						endpoint_rules               = []
+						id                           = "/providers/Microsoft.PowerApps/apis/shared_mailgun"
+					  },
+					  {
+						action_rules                 = []
+						default_action_rule_behavior = ""
+						endpoint_rules               = []
+						id                           = "/providers/Microsoft.PowerApps/apis/shared_polydoc"
 					  }
 					])
 				  
@@ -1028,12 +1042,18 @@ func TestAccDataLossPreventionPolicyResource_Validate_Create(t *testing.T) {
 
 					resource.TestCheckResourceAttr("powerplatform_data_loss_prevention_policy.my_policy", "environments.#", "1"),
 
-					resource.TestCheckResourceAttr("powerplatform_data_loss_prevention_policy.my_policy", "business_connectors.#", "3"),
+					resource.TestCheckResourceAttr("powerplatform_data_loss_prevention_policy.my_policy", "business_connectors.#", "5"),
 					resource.TestCheckTypeSetElemNestedAttrs("powerplatform_data_loss_prevention_policy.my_policy", "business_connectors.*", map[string]string{
 						"id": "/providers/Microsoft.PowerApps/apis/shared_approvals",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs("powerplatform_data_loss_prevention_policy.my_policy", "business_connectors.*", map[string]string{
 						"id": "/providers/Microsoft.PowerApps/apis/shared_cloudappsecurity",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("powerplatform_data_loss_prevention_policy.my_policy", "business_connectors.*", map[string]string{
+						"id": "/providers/Microsoft.PowerApps/apis/shared_mailgun",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("powerplatform_data_loss_prevention_policy.my_policy", "business_connectors.*", map[string]string{
+						"id": "/providers/Microsoft.PowerApps/apis/shared_polydoc",
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs("powerplatform_data_loss_prevention_policy.my_policy", "business_connectors.*", map[string]string{
 						"id":                           "/providers/Microsoft.PowerApps/apis/shared_sql",

--- a/internal/services/environment/api_environment.go
+++ b/internal/services/environment/api_environment.go
@@ -735,6 +735,13 @@ func (client *Client) updateEnvironmentWithRetry(ctx context.Context, environmen
 		}
 	}
 
+	// Only a runtime state the caller actually sent is waited for; an omitted one is left untouched
+	// by the API and has nothing to converge to.
+	requestedRuntimeStateId := ""
+	if environment.Properties != nil && environment.Properties.States != nil && environment.Properties.States.Runtime != nil {
+		requestedRuntimeStateId = environment.Properties.States.Runtime.Id
+	}
+
 	apiUrl := &url.URL{
 		Scheme: constants.HTTPS,
 		Host:   client.Api.GetConfig().Urls.BapiUrl,
@@ -780,7 +787,7 @@ func (client *Client) updateEnvironmentWithRetry(ctx context.Context, environmen
 	}
 
 	// despite lifecycle operation success, the environment may not be ready yet.
-	for {
+	for attempt := 0; ; attempt++ {
 		if err := client.Api.SleepWithContext(ctx, api.DefaultRetryAfter()); err != nil {
 			return nil, err
 		}
@@ -790,12 +797,31 @@ func (client *Client) updateEnvironmentWithRetry(ctx context.Context, environmen
 		}
 		tflog.Info(ctx, "Environment State: '"+env.Properties.States.Management.Id+"'")
 		if env.Properties.States.Management.Id == "Ready" {
-			return env, nil
+			// The read endpoint is eventually consistent with the runtime state the update just
+			// applied, so a converged management state can still report the previous admin mode.
+			// Returning here would hand Terraform a value that contradicts the plan.
+			if requestedRuntimeStateId == "" || runtimeStateId(env) == requestedRuntimeStateId {
+				return env, nil
+			}
+			if attempt >= constants.MAX_RETRY_COUNT {
+				return nil, fmt.Errorf("environment '%s' still reports runtime state '%s' after the update requested '%s'", environmentId, runtimeStateId(env), requestedRuntimeStateId)
+			}
+			tflog.Debug(ctx, fmt.Sprintf("Environment '%s' does not report runtime state '%s' yet, retrying read", environmentId, requestedRuntimeStateId))
+			continue
 		} else if env.Properties.States.Management.Id == "Running" {
 			continue
 		}
 		return nil, errors.New("environment update failed. unexpected management state: " + env.Properties.States.Management.Id)
 	}
+}
+
+// runtimeStateId returns the environment's runtime state id, or "Enabled" when the API omits the
+// runtime state, which is how it renders an environment that is not in administration mode.
+func runtimeStateId(env *EnvironmentDto) string {
+	if env == nil || env.Properties == nil || env.Properties.States == nil || env.Properties.States.Runtime == nil || env.Properties.States.Runtime.Id == "" {
+		return "Enabled"
+	}
+	return env.Properties.States.Runtime.Id
 }
 
 func (client *Client) GetEnvironments(ctx context.Context) ([]EnvironmentDto, error) {

--- a/internal/services/environment/api_environment.go
+++ b/internal/services/environment/api_environment.go
@@ -594,6 +594,51 @@ func (client *Client) waitForDataverseMetadata(ctx context.Context, environmentI
 	}
 }
 
+// waitForDataverseRuntimeState re-reads the environment until its administration mode and background
+// operations state match what was just requested. UpdateEnvironment already waits for the runtime
+// state it changes, but a later, independent GetEnvironment call (e.g. for AI features) is not
+// guaranteed to observe that same change, which otherwise surfaces as "provider produced inconsistent
+// result after apply" for attributes the caller never intended to touch on this apply.
+func (client *Client) waitForDataverseRuntimeState(ctx context.Context, environmentId string, env *EnvironmentDto, expectedAdminMode, expectedBackgroundOperation *bool) (*EnvironmentDto, error) {
+	if expectedAdminMode == nil && expectedBackgroundOperation == nil {
+		return env, nil
+	}
+
+	matchesExpectedState := func(e *EnvironmentDto) bool {
+		if e == nil || e.Properties == nil || e.Properties.LinkedEnvironmentMetadata == nil {
+			return false
+		}
+		if expectedAdminMode != nil && (runtimeStateId(e) == "AdminMode") != *expectedAdminMode {
+			return false
+		}
+		if expectedBackgroundOperation != nil && (e.Properties.LinkedEnvironmentMetadata.BackgroundOperationsState == "Enabled") != *expectedBackgroundOperation {
+			return false
+		}
+		return true
+	}
+
+	for attempt := 0; ; attempt++ {
+		if matchesExpectedState(env) {
+			return env, nil
+		}
+
+		if attempt >= constants.MAX_RETRY_COUNT {
+			return nil, fmt.Errorf("environment '%s' did not converge to the requested administration mode/background operations state", environmentId)
+		}
+
+		tflog.Debug(ctx, fmt.Sprintf("Environment '%s' runtime state has not converged yet. Retrying", environmentId))
+		if err := client.Api.SleepWithContext(ctx, api.DefaultRetryAfter()); err != nil {
+			return nil, err
+		}
+
+		var err error
+		env, err = client.GetEnvironment(ctx, environmentId)
+		if err != nil {
+			return nil, err
+		}
+	}
+}
+
 func (client *Client) UpdateEnvironmentAiFeatures(ctx context.Context, environmentId string, generativeAIConfig GenerativeAiFeaturesDto) (*EnvironmentDto, error) {
 	if err := client.updateEnvironmentAiFeaturesWithRetry(ctx, environmentId, generativeAIConfig, 0); err != nil {
 		return nil, err

--- a/internal/services/environment/api_environment.go
+++ b/internal/services/environment/api_environment.go
@@ -560,12 +560,61 @@ func (client *Client) createEnvironmentWithRetry(ctx context.Context, environmen
 		}
 	}
 
+	env, err = client.waitForRequestedEnvironmentProperties(ctx, createdEnvironmentId, env, environmentToCreate.Properties.DisplayName, environmentToCreate.Properties.EnvironmentSku)
+	if err != nil {
+		return &EnvironmentDto{Name: createdEnvironmentId}, err
+	}
+
 	if env.Properties.LinkedEnvironmentMetadata != nil && environmentToCreate.Properties.LinkedEnvironmentMetadata != nil && environmentToCreate.Properties.LinkedEnvironmentMetadata.Templates != nil {
 		env.Properties.LinkedEnvironmentMetadata.Templates = environmentToCreate.Properties.LinkedEnvironmentMetadata.Templates
 		env.Properties.LinkedEnvironmentMetadata.TemplateMetadata = environmentToCreate.Properties.LinkedEnvironmentMetadata.TemplateMetadata
 	}
 
 	return env, err
+}
+
+// waitForRequestedEnvironmentProperties re-reads the environment until it reports the display name and
+// sku that were requested. Shortly after provisioning BAPI can still return the Dataverse organization's
+// placeholder friendly name and the default "Production" sku, which Terraform rejects as an inconsistent
+// result after apply.
+func (client *Client) waitForRequestedEnvironmentProperties(ctx context.Context, environmentId string, env *EnvironmentDto, expectedDisplayName, expectedSku string) (*EnvironmentDto, error) {
+	if expectedDisplayName == "" && expectedSku == "" {
+		return env, nil
+	}
+
+	matchesRequest := func(e *EnvironmentDto) bool {
+		if e == nil || e.Properties == nil {
+			return false
+		}
+		if expectedDisplayName != "" && e.Properties.DisplayName != expectedDisplayName {
+			return false
+		}
+		if expectedSku != "" && e.Properties.EnvironmentSku != expectedSku {
+			return false
+		}
+		return true
+	}
+
+	for attempt := 0; ; attempt++ {
+		if matchesRequest(env) {
+			return env, nil
+		}
+
+		if attempt >= constants.MAX_RETRY_COUNT {
+			return nil, fmt.Errorf("environment '%s' did not report the requested display name '%s' and sku '%s'", environmentId, expectedDisplayName, expectedSku)
+		}
+
+		tflog.Debug(ctx, fmt.Sprintf("Environment '%s' does not report the requested display name and sku yet, retrying read", environmentId))
+		if err := client.Api.SleepWithContext(ctx, api.DefaultRetryAfter()); err != nil {
+			return nil, err
+		}
+
+		var err error
+		env, err = client.GetEnvironment(ctx, environmentId)
+		if err != nil {
+			return nil, err
+		}
+	}
 }
 
 // waitForDataverseMetadata polls the environment until its Dataverse metadata is readable. BAPI

--- a/internal/services/environment/resource_environment.go
+++ b/internal/services/environment/resource_environment.go
@@ -705,6 +705,15 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 			resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.FullTypeName()), err.Error())
 			return
 		}
+
+		// The AI features call above (or the fallback GetEnvironment) may have read the environment
+		// before the administration mode/background operations change from updateDataverse converged,
+		// even though that change was already confirmed once inside UpdateEnvironment.
+		envDto, err = r.EnvironmentClient.waitForDataverseRuntimeState(ctx, plan.Id.ValueString(), envDto, expectedAdministrationMode(ctx, plan), expectedBackgroundOperation(ctx, plan))
+		if err != nil {
+			resp.Diagnostics.AddError(fmt.Sprintf("Client error when reading %s", r.FullTypeName()), err.Error())
+			return
+		}
 	}
 
 	var templateMetadata *createTemplateMetadataDto
@@ -757,6 +766,28 @@ func (r *Resource) updateEnvironmentAiFeatures(ctx context.Context, environmentI
 	}
 
 	return r.EnvironmentClient.UpdateEnvironmentAiFeatures(ctx, environmentId, featuresDto)
+}
+
+// expectedAdministrationMode returns the planned administration_mode_enabled value, or nil when the
+// practitioner did not configure it and there is nothing to converge to.
+func expectedAdministrationMode(ctx context.Context, plan *SourceModel) *bool {
+	var dataverseSourcePlanModel DataverseSourceModel
+	plan.Dataverse.As(ctx, &dataverseSourcePlanModel, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true, UnhandledUnknownAsEmpty: true})
+	if dataverseSourcePlanModel.AdministrationMode.IsNull() || dataverseSourcePlanModel.AdministrationMode.IsUnknown() {
+		return nil
+	}
+	return dataverseSourcePlanModel.AdministrationMode.ValueBoolPointer()
+}
+
+// expectedBackgroundOperation returns the planned background_operation_enabled value, or nil when the
+// practitioner did not configure it and there is nothing to converge to.
+func expectedBackgroundOperation(ctx context.Context, plan *SourceModel) *bool {
+	var dataverseSourcePlanModel DataverseSourceModel
+	plan.Dataverse.As(ctx, &dataverseSourcePlanModel, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true, UnhandledUnknownAsEmpty: true})
+	if dataverseSourcePlanModel.BackgroundOperation.IsNull() || dataverseSourcePlanModel.BackgroundOperation.IsUnknown() {
+		return nil
+	}
+	return dataverseSourcePlanModel.BackgroundOperation.ValueBoolPointer()
 }
 
 func addDataverse(ctx context.Context, plan *SourceModel, r *Resource) (string, error) {

--- a/internal/services/role_based_access/api_role_based_access.go
+++ b/internal/services/role_based_access/api_role_based_access.go
@@ -114,6 +114,9 @@ func (client *client) CreateRoleAssignment(ctx context.Context, scope assignment
 	for {
 		_, err := client.Api.ExecuteWithoutRetry(ctx, nil, "POST", apiUrl, nil, request, []int{http.StatusOK, http.StatusCreated}, &response)
 		if err == nil {
+			if waitErr := client.waitForRoleAssignmentVisible(ctx, scope, response.RoleAssignmentId); waitErr != nil {
+				return nil, waitErr
+			}
 			return &response, nil
 		}
 		if isScopeNotYetPropagated(err) {
@@ -136,6 +139,32 @@ func (client *client) CreateRoleAssignment(ctx context.Context, scope assignment
 // unknownOutcomeError wraps a create failure whose outcome the API gives no way to resolve.
 func unknownOutcomeError(err error) error {
 	return fmt.Errorf("the create outcome is unknown. The API may have committed the assignment, but it provides no idempotency key or correlation identifier that would let the provider identify it safely. Inspect the role assignments at this scope: if one was created, import it using the scope-shaped import id, and if duplicates exist, deduplicate them first. Terraform has not recorded an assignment in state. Original failure: %w", err)
+}
+
+// waitForRoleAssignmentVisible blocks until the assignment the POST just created is returned by the
+// listing that Read uses. The collection is eventually consistent with the create, and Read treats
+// an absent assignment as deleted, so returning before it converges makes the refresh that follows
+// the apply drop the resource from state and plan a second create.
+func (client *client) waitForRoleAssignmentVisible(ctx context.Context, scope assignmentScope, roleAssignmentId string) error {
+	maxRetries := int(constants.RBAC_ROLE_ASSIGNMENT_POLL_TIMEOUT / constants.RBAC_ROLE_ASSIGNMENT_POLL_INTERVAL)
+
+	for retry := 0; ; retry++ {
+		assignments, err := client.ListRoleAssignments(ctx, scope)
+		// A list failure is not evidence that the assignment is missing, so it is retried too
+		// rather than failing a create that already succeeded.
+		if err == nil && findRoleAssignment(assignments, roleAssignmentId) != nil {
+			return nil
+		}
+
+		if retry >= maxRetries {
+			return fmt.Errorf("role assignment %s was created at scope %s but did not become visible in the role assignment listing within %s, so Terraform would immediately see it as deleted. Import it once it appears: terraform import <address> %q", roleAssignmentId, scope, constants.RBAC_ROLE_ASSIGNMENT_POLL_TIMEOUT, scope.importId(roleAssignmentId))
+		}
+
+		tflog.Debug(ctx, fmt.Sprintf("Role assignment %s is not visible in the listing at scope %s yet, retrying", roleAssignmentId, scope))
+		if sleepErr := client.Api.SleepWithContext(ctx, constants.RBAC_ROLE_ASSIGNMENT_POLL_INTERVAL); sleepErr != nil {
+			return sleepErr
+		}
+	}
 }
 
 // isAmbiguousCreateFailure reports whether the request might have committed despite the error.

--- a/internal/services/role_based_access/resource_rbac_role_assignment_test.go
+++ b/internal/services/role_based_access/resource_rbac_role_assignment_test.go
@@ -483,9 +483,9 @@ func TestAccRoleAssignmentResource_Validate_All_Principal_Types_And_Scopes(t *te
 				}
 
 				resource "azuread_user" "test_user" {
-					user_principal_name = "` + mocks.TestName() + `@${local.domain_name}"
+					user_principal_name = "` + mocks.TestNameForEntra() + `@${local.domain_name}"
 					display_name        = "` + mocks.TestName() + `"
-					mail_nickname       = "` + mocks.TestName() + `"
+					mail_nickname       = "` + mocks.TestNameForEntra() + `"
 					password            = random_password.user.result
 					usage_location      = "US"
 				}

--- a/internal/services/role_based_access/resource_rbac_role_assignment_test.go
+++ b/internal/services/role_based_access/resource_rbac_role_assignment_test.go
@@ -907,12 +907,12 @@ func TestUnitRoleAssignmentResource_Validate_Read_404_Tenant_Errors_Environment_
 	httpmock.RegisterResponder("GET", tenantCollection+apiVersionQuery,
 		func(_ *http.Request) (*http.Response, error) {
 			tenantGets++
-			// the preflight sees an empty collection, the post-apply refresh sees the created
-			// assignment, and the 404 starts afterwards
+			// the preflight sees an empty collection, the create waits for its assignment to
+			// become listable, the post-apply refresh sees it too, and the 404 starts afterwards
 			if tenantGets == 1 {
 				return httpmock.NewStringResponse(http.StatusOK, `{"value":[]}`), nil
 			}
-			if tenantGets == 2 {
+			if tenantGets <= 3 {
 				return httpmock.NewStringResponse(http.StatusOK, httpmock.File("tests/resource/Validate_Create_Tenant/get_role_assignments.json").String()), nil
 			}
 			return httpmock.NewStringResponse(http.StatusNotFound, ""), nil
@@ -956,12 +956,13 @@ func TestUnitRoleAssignmentResource_Validate_Read_Removes_State_When_Environment
 	httpmock.RegisterResponder("GET", environmentCollection+apiVersionQuery,
 		func(_ *http.Request) (*http.Response, error) {
 			envGets++
-			// the preflight sees an empty collection, the post-apply refresh sees the created
-			// assignment, and then the environment is deleted out of band
+			// the preflight sees an empty collection, the create waits for its assignment to
+			// become listable, the post-apply refresh sees it too, and then the environment is
+			// deleted out of band
 			if envGets == 1 {
 				return httpmock.NewStringResponse(http.StatusOK, `{"value":[]}`), nil
 			}
-			if envGets == 2 {
+			if envGets <= 3 {
 				return httpmock.NewStringResponse(http.StatusOK, httpmock.File("tests/resource/Validate_Create_Environment/get_role_assignments.json").String()), nil
 			}
 			return httpmock.NewStringResponse(http.StatusNotFound, ""), nil


### PR DESCRIPTION
Four scheduled runs each failed on a different acceptance test. None were infrastructure noise; three were provider bugs and one an unhardened external dependency.

- getAssertion called the CI workload identity token endpoint with no retry, so a single 503 failed a whole apply. The exchange is an idempotent GET, so it is now replayed a bounded number of times.
- ExecuteWithoutRetry refused to replay a 401. A 401 proves the service rejected the credential before the operation ran, so replaying cannot duplicate a non-idempotent mutation. It is now retried, bounded.
- CreateRoleAssignment returned as soon as the POST committed, but the collection is eventually consistent and Read treats an absent assignment as deleted, so the refresh after the apply planned a second create. The create now waits for its own assignment to become listable.
- updateEnvironment waited only for management state Ready, which the read endpoint reaches before the runtime state propagates, so an administration_mode_enabled update returned a value contradicting the plan. It now also waits for the requested runtime state.

Constants added for these paths live in internal/constants and use UPPER_CASE, and that convention is now written down in the CodeQL prompt.