### PR TITLE
Remove three client methods nothing calls

### DIFF
--- a/.changes/unreleased/fixed-20260827-222204.yaml
+++ b/.changes/unreleased/fixed-20260827-222204.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Removed three internal API client methods that no resource or data source called
+time: 2026-08-27T22:22:04.000000000Z
+custom:
+    Issue: "1258"

--- a/internal/services/authorization/api_user.go
+++ b/internal/services/authorization/api_user.go
@@ -47,27 +47,6 @@ func (client *client) DataverseExists(ctx context.Context, environmentId string)
 	return env.Properties.LinkedEnvironmentMetadata.InstanceURL != "", nil
 }
 
-func (client *client) GetDataverseUsers(ctx context.Context, environmentId string) ([]userDto, error) {
-	environmentHost, err := client.GetEnvironmentHostById(ctx, environmentId)
-	if err != nil {
-		return nil, err
-	}
-
-	apiUrl := helpers.BuildDataverseApiUrl(environmentHost, "/api/data/v9.2/systemusers", nil)
-	userArray := userArrayDto{}
-	resp, err := client.Api.Execute(ctx, nil, "GET", apiUrl, nil, nil, []int{http.StatusOK, http.StatusForbidden, http.StatusNotFound}, &userArray)
-	if err != nil {
-		return nil, err
-	}
-	if err := client.Api.HandleForbiddenResponse(resp); err != nil {
-		return nil, err
-	}
-	if err := client.Api.HandleNotFoundResponse(resp); err != nil {
-		return nil, err
-	}
-	return userArray.Value, nil
-}
-
 func (client *client) GetDataverseUserBySystemUserId(ctx context.Context, environmentId, systemUserId string) (*userDto, error) {
 	environmentHost, err := client.GetEnvironmentHostById(ctx, environmentId)
 	if err != nil {
@@ -352,32 +331,6 @@ func (client *client) CreateDataverseUser(ctx context.Context, environmentId, aa
 		return nil, err
 	}
 
-	return user, nil
-}
-
-func (client *client) UpdateDataverseUser(ctx context.Context, environmentId, systemUserId string, userUpdate *userDto) (*userDto, error) {
-	environmentHost, err := client.GetEnvironmentHostById(ctx, environmentId)
-	if err != nil {
-		return nil, err
-	}
-
-	apiUrl := helpers.BuildDataverseApiUrl(environmentHost, "/api/data/v9.2/systemusers("+systemUserId+")", nil)
-
-	resp, err := client.Api.Execute(ctx, nil, "PATCH", apiUrl, nil, userUpdate, []int{http.StatusOK, http.StatusForbidden, http.StatusNotFound}, nil)
-	if err != nil {
-		return nil, err
-	}
-	if err := client.Api.HandleForbiddenResponse(resp); err != nil {
-		return nil, err
-	}
-	if err := client.Api.HandleNotFoundResponse(resp); err != nil {
-		return nil, err
-	}
-
-	user, err := client.GetDataverseUserBySystemUserId(ctx, environmentId, systemUserId)
-	if err != nil {
-		return nil, err
-	}
 	return user, nil
 }
 

--- a/internal/services/data_record/api_data_record.go
+++ b/internal/services/data_record/api_data_record.go
@@ -265,60 +265,6 @@ func (client *client) GetRelationData(ctx context.Context, environmentId, tableN
 	return value, nil
 }
 
-func (client *client) GetTableSingularNameFromPlural(ctx context.Context, environmentId, logicalCollectionName string) (*string, error) {
-	environmentHost, err := client.GetEnvironmentHostById(ctx, environmentId)
-	if err != nil {
-		return nil, err
-	}
-
-	apiUrl := &url.URL{
-		Scheme: constants.HTTPS,
-		Host:   environmentHost,
-		Path:   fmt.Sprintf("/api/data/%s/EntityDefinitions", constants.DATAVERSE_API_VERSION),
-	}
-	q := apiUrl.Query()
-	q.Add("$filter", fmt.Sprintf("LogicalCollectionName eq '%s'", logicalCollectionName))
-	q.Add("$select", "PrimaryIdAttribute,LogicalCollectionName,LogicalName")
-	apiUrl.RawQuery = q.Encode()
-
-	response, err := client.Api.Execute(ctx, nil, "GET", apiUrl.String(), nil, nil, []int{http.StatusOK, http.StatusForbidden, http.StatusNotFound}, nil)
-	if err != nil {
-		return nil, err
-	}
-	if err := client.Api.HandleForbiddenResponse(response); err != nil {
-		return nil, err
-	}
-	if err := client.Api.HandleNotFoundResponse(response); err != nil {
-		return nil, err
-	}
-
-	var mapResponse map[string]any
-	err = json.Unmarshal(response.BodyAsBytes, &mapResponse)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response for table singular name: %w", err)
-	}
-
-	var result string
-	if rawVal, exists := mapResponse["value"]; exists && rawVal != nil {
-		valueSlice, ok := rawVal.([]any)
-		if !ok {
-			return nil, errors.New("value field is not of type []any")
-		}
-		if len(valueSlice) > 0 {
-			if value, ok := valueSlice[0].(map[string]any); ok {
-				if logicalName, ok := value["LogicalName"].(string); ok {
-					result = logicalName
-				}
-			}
-		}
-	} else if logicalName, ok := mapResponse["LogicalName"].(string); ok {
-		result = logicalName
-	} else {
-		return nil, errors.New("logicalName field not found in result when retrieving table singular name")
-	}
-	return &result, nil
-}
-
 func getEntityRelationDefinitionOneToMany(mapResponse map[string]any, entityLogicalName, relationLogicalName string) (string, error) {
 	var tableName string
 	oneToMany, ok := mapResponse["OneToManyRelationships"].([]any)


### PR DESCRIPTION
`GetDataverseUsers`, `UpdateDataverseUser` and `GetTableSingularNameFromPlural` have no callers anywhere in the provider, including tests. Each is a live HTTP call we maintain, mock and reason about for no reader.

I found them by walking the call graph from every registered resource and data source down to every HTTP call site. These three were the only call sites nothing reached.

101 deletions, no behaviour change. `TestUnit` passes for `authorization` and `data_record`.