### PR TITLE
fix(environment_settings): omit unconfigured security updates

### DIFF
--- a/.changes/unreleased/fixed-20260909-112507.yaml
+++ b/.changes/unreleased/fixed-20260909-112507.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Fix unintended IP firewall updates when configuring product features on non-managed environments
+time: 2026-09-09T11:25:07.199582724Z
+custom:
+    Issue: "1113"

--- a/docs/resources/environment_settings.md
+++ b/docs/resources/environment_settings.md
@@ -173,7 +173,7 @@ Optional:
 
 - `behavior_settings` (Attributes) Behavior Settings.See [Behavior Settings Overview](https://learn.microsoft.com/power-platform/admin/settings-behavior) for more details. (see [below for nested schema](#nestedatt--product--behavior_settings))
 - `features` (Attributes) Features. See [Features Overview](https://learn.microsoft.com/power-platform/admin/settings-features) for more details. (see [below for nested schema](#nestedatt--product--features))
-- `security` (Attributes) Security. See [Security Overview](https://learn.microsoft.com/en-us/power-platform/admin/settings-privacy-security) for more details. (see [below for nested schema](#nestedatt--product--security))
+- `security` (Attributes) Security. When omitted or set to null, existing security settings are read but are not sent in updates. Omit this block when configuring product features on a non-managed environment, as IP firewall settings require a Managed Environment. See [Security Overview](https://learn.microsoft.com/en-us/power-platform/admin/settings-privacy-security) for more details. (see [below for nested schema](#nestedatt--product--security))
 
 <a id="nestedatt--product--behavior_settings"></a>
 ### Nested Schema for `product.behavior_settings`

--- a/internal/services/environment_settings/models.go
+++ b/internal/services/environment_settings/models.go
@@ -125,7 +125,7 @@ type SecuritySourceModel struct {
 	ReverseProxyIpAddresses              types.Set  `tfsdk:"reverse_proxy_ip_addresses"`
 }
 
-func convertFromEnvironmentSettingsModel(ctx context.Context, environmentSettingsModel EnvironmentSettingsResourceModel) (*environmentSettings, error) {
+func convertFromEnvironmentSettingsModel(ctx context.Context, environmentSettingsModel EnvironmentSettingsResourceModel, config EnvironmentSettingsResourceModel) (*environmentSettings, error) {
 	environmentSettings := &environmentSettings{
 		BackendSettings: &environmentBackendSettingsValueDto{},
 		OrgSettings:     &environmentOrgSettingsDto{},
@@ -189,8 +189,11 @@ func convertFromEnvironmentSettingsModel(ctx context.Context, environmentSetting
 	if err := convertFromEnvironmentFeatureSettings(ctx, environmentSettingsModel, environmentSettings); err != nil {
 		return nil, err
 	}
-	if err := convertFromEnvironmentSecuritySettings(ctx, environmentSettingsModel, environmentSettings.OrgSettings); err != nil {
-		return nil, err
+	security := config.Product.Attributes()["security"]
+	if security != nil && helpers.IsKnown(security) {
+		if err := convertFromEnvironmentSecuritySettings(ctx, environmentSettingsModel, environmentSettings.OrgSettings); err != nil {
+			return nil, err
+		}
 	}
 	return environmentSettings, nil
 }

--- a/internal/services/environment_settings/resource_environment_settings_test.go
+++ b/internal/services/environment_settings/resource_environment_settings_test.go
@@ -4,6 +4,7 @@
 package environment_settings_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -14,6 +15,185 @@ import (
 	"github.com/jarcoal/httpmock"
 	"github.com/microsoft/terraform-provider-power-platform/internal/mocks"
 )
+
+func registerStandardEnvironmentSettingsResponders(t *testing.T) *int {
+	t.Helper()
+	var organizations struct {
+		Value []map[string]any `json:"value"`
+	}
+	if err := json.Unmarshal([]byte(httpmock.File("tests/resources/Validate_Create_Empty_Settings/get_organisations_1.json").String()), &organizations); err != nil {
+		t.Fatal(err)
+	}
+	if len(organizations.Value) != 1 {
+		t.Fatal("expected one organization in the fixture")
+	}
+	organization := organizations.Value[0]
+	organization["powerappsmakerbotenabled"] = false
+	organization["bounddashboarddefaultcardexpanded"] = false
+
+	type backendSetting struct {
+		Name     string
+		Value    string
+		DataType int
+	}
+	var backend struct {
+		SettingDetailCollection []backendSetting
+	}
+	if err := json.Unmarshal([]byte(httpmock.File("tests/resources/Validate_Create_Empty_Settings/get_retrievesettinglist.json").String()), &backend); err != nil {
+		t.Fatal(err)
+	}
+
+	httpmock.RegisterResponder("GET", "https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/00000000-0000-0000-0000-000000000001?api-version=2023-06-01",
+		httpmock.NewStringResponder(http.StatusOK, httpmock.File("tests/resources/Validate_Create_Empty_Settings/get_environment_00000000-0000-0000-0000-000000000001.json").String()))
+	httpmock.RegisterResponder("GET", "https://00000000-0000-0000-0000-000000000001.crm4.dynamics.com/api/data/v9.0/organizations",
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewJsonResponse(http.StatusOK, organizations)
+		})
+	httpmock.RegisterResponder("GET", "https://00000000-0000-0000-0000-000000000001.crm4.dynamics.com/api/data/v9.0/RetrieveSettingList%28%29",
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewJsonResponse(http.StatusOK, backend)
+		})
+	httpmock.RegisterResponder("POST", "https://00000000-0000-0000-0000-000000000001.crm4.dynamics.com/api/data/v9.0/SaveSettingValue%28%29",
+		func(req *http.Request) (*http.Response, error) {
+			var setting struct {
+				SettingName string
+				Value       string
+			}
+			if err := json.NewDecoder(req.Body).Decode(&setting); err != nil {
+				return nil, err
+			}
+			for index := range backend.SettingDetailCollection {
+				detail := &backend.SettingDetailCollection[index]
+				if detail.Name == setting.SettingName {
+					detail.Value = setting.Value
+				}
+			}
+			return httpmock.NewStringResponse(http.StatusNoContent, ""), nil
+		})
+	patchCount := 0
+	httpmock.RegisterResponder("PATCH", "https://00000000-0000-0000-0000-000000000001.crm4.dynamics.com/api/data/v9.0/organizations%2843f51247-aee6-ee11-9048-000d3a688755%29",
+		func(req *http.Request) (*http.Response, error) {
+			var payload map[string]any
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				return nil, err
+			}
+			for _, field := range []string{
+				"enableipbasedcookiebinding", "enableipbasedfirewallrule", "allowediprangeforfirewall",
+				"allowedservicetagsforfirewall", "allowapplicationuseraccess", "allowmicrosofttrustedservicetags",
+				"enableipbasedfirewallruleinauditmode", "reverseproxyipaddresses",
+			} {
+				if _, exists := payload[field]; exists {
+					return nil, fmt.Errorf("unexpected security field %s in Standard Environment PATCH", field)
+				}
+			}
+			for field, value := range payload {
+				organization[field] = value
+			}
+			patchCount++
+			return httpmock.NewStringResponse(http.StatusNoContent, ""), nil
+		})
+	return &patchCount
+}
+
+func TestUnitTestEnvironmentSettingsResource_StandardEnvironment_ProductUpdates(t *testing.T) {
+	for _, testCase := range []struct {
+		name      string
+		security  string
+		lifecycle string
+	}{
+		{name: "omitted"},
+		{name: "null", security: "security = null"},
+		{name: "ignored", security: "security = null", lifecycle: "lifecycle { ignore_changes = [product.security] }"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			httpmock.Activate()
+			defer httpmock.DeactivateAndReset()
+			patchCount := registerStandardEnvironmentSettingsResponders(t)
+
+			steps := []resource.TestStep{}
+			for _, enabled := range []bool{false, true} {
+				steps = append(steps, resource.TestStep{
+					Config: fmt.Sprintf(`
+						resource "powerplatform_environment_settings" "settings" {
+							environment_id = "00000000-0000-0000-0000-000000000001"
+							product = {
+								features = { enable_powerapps_maker_bot = %t }
+								behavior_settings = { show_dashboard_cards_in_expanded_state = %t }
+								%s
+							}
+							%s
+						}`, enabled, enabled, testCase.security, testCase.lifecycle),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "product.features.enable_powerapps_maker_bot", fmt.Sprint(enabled)),
+						resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "product.behavior_settings.show_dashboard_cards_in_expanded_state", fmt.Sprint(enabled)),
+					),
+				})
+			}
+			resource.Test(t, resource.TestCase{
+				IsUnitTest:               true,
+				ProtoV6ProviderFactories: mocks.TestUnitTestProtoV6ProviderFactories,
+				Steps:                    steps,
+			})
+			if *patchCount != 2 {
+				t.Errorf("expected create and update PATCH requests, got %d", *patchCount)
+			}
+		})
+	}
+}
+
+func TestAccTestEnvironmentSettingsResource_StandardEnvironment_ProductUpdates(t *testing.T) {
+	baseConfig := fmt.Sprintf(`
+		resource "powerplatform_environment" "example_environment_settings" {
+			display_name = "%s"
+			location = "unitedstates"
+			environment_type = "Sandbox"
+			dataverse = {
+				language_code = "1033"
+				currency_code = "USD"
+				security_group_id = "00000000-0000-0000-0000-000000000000"
+			}
+		}
+		resource "time_sleep" "wait_for_dataverse" {
+			create_duration = "120s"
+			depends_on = [powerplatform_environment.example_environment_settings]
+		}
+	`, mocks.TestName())
+	steps := []resource.TestStep{}
+	for _, testCase := range []struct {
+		enabled   bool
+		security  string
+		lifecycle string
+	}{
+		{enabled: false},
+		{enabled: true, security: "security = null"},
+		{enabled: false, security: "security = null", lifecycle: "lifecycle { ignore_changes = [product.security] }"},
+	} {
+		steps = append(steps, resource.TestStep{
+			Config: baseConfig + fmt.Sprintf(`
+				resource "powerplatform_environment_settings" "settings" {
+					environment_id = powerplatform_environment.example_environment_settings.id
+					depends_on = [time_sleep.wait_for_dataverse]
+					product = {
+						features = { enable_powerapps_maker_bot = %t }
+						behavior_settings = { show_dashboard_cards_in_expanded_state = %t }
+						%s
+					}
+					%s
+				}`, testCase.enabled, testCase.enabled, testCase.security, testCase.lifecycle),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "product.features.enable_powerapps_maker_bot", fmt.Sprint(testCase.enabled)),
+				resource.TestCheckResourceAttr("powerplatform_environment_settings.settings", "product.behavior_settings.show_dashboard_cards_in_expanded_state", fmt.Sprint(testCase.enabled)),
+			),
+		})
+	}
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: mocks.TestAccProtoV6ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {Source: "hashicorp/time"},
+		},
+		Steps: steps,
+	})
+}
 
 func TestUnitTestEnvironmentSettingsResource_Validate_Create_Empty_Settings(t *testing.T) {
 	httpmock.Activate()

--- a/internal/services/environment_settings/resources_environment_settings.go
+++ b/internal/services/environment_settings/resources_environment_settings.go
@@ -360,9 +360,12 @@ func (r *EnvironmentSettingsResource) Schema(ctx context.Context, req resource.S
 						},
 					},
 					"security": schema.SingleNestedAttribute{
-						MarkdownDescription: "Security. See [Security Overview](https://learn.microsoft.com/en-us/power-platform/admin/settings-privacy-security) for more details.",
+						MarkdownDescription: "Security. When omitted or set to null, existing security settings are read but are not sent in updates. Omit this block when configuring product features on a non-managed environment, as IP firewall settings require a Managed Environment. See [Security Overview](https://learn.microsoft.com/en-us/power-platform/admin/settings-privacy-security) for more details.",
 						Optional:            true,
 						Computed:            true,
+						PlanModifiers: []planmodifier.Object{
+							objectplanmodifier.UseStateForUnknown(),
+						},
 						Attributes: map[string]schema.Attribute{
 							"enable_ip_based_cookie_binding": schema.BoolAttribute{
 								MarkdownDescription: "Enable IP based cookie binding",
@@ -514,12 +517,14 @@ func (r *EnvironmentSettingsResource) Create(ctx context.Context, req resource.C
 	defer exitContext()
 
 	var plan EnvironmentSettingsResourceModel
+	var config EnvironmentSettingsResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	settingsToUpdate, err := convertFromEnvironmentSettingsModel(ctx, plan)
+	settingsToUpdate, err := convertFromEnvironmentSettingsModel(ctx, plan, config)
 	if err != nil {
 		resp.Diagnostics.AddError("Error converting environment settings model", err.Error())
 		return
@@ -598,7 +603,9 @@ func (r *EnvironmentSettingsResource) Update(ctx context.Context, req resource.U
 
 	var plan EnvironmentSettingsResourceModel
 	var state EnvironmentSettingsResourceModel
+	var config EnvironmentSettingsResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -613,7 +620,7 @@ func (r *EnvironmentSettingsResource) Update(ctx context.Context, req resource.U
 		return
 	}
 
-	envSettingsToUpdate, err := convertFromEnvironmentSettingsModel(ctx, plan)
+	envSettingsToUpdate, err := convertFromEnvironmentSettingsModel(ctx, plan, config)
 	if err != nil {
 		resp.Diagnostics.AddError("Error converting environment settings model", err.Error())
 		return


### PR DESCRIPTION
## Summary
Prevent product-only environment-settings updates from sending computed security/IP firewall values to non-managed environments.

Fixes #1113.

## Changes
- Check whether `product.security` is configured before including security fields in create/update requests. Continue using planned values when the block is configured.
- Preserve computed security state during planning to avoid recurring diffs when the block is omitted.
- Add lifecycle regression tests for omitted security, `security = null`, and `ignore_changes = [product.security]`.
- Add a dedicated acceptance test, update generated resource documentation, and include a changelog entry.

## Reproduction
Before the fix, the mocked lifecycle regression detected an unintended security field in the update PATCH with `ignore_changes`. Omitted/null security also produced a non-empty post-apply plan. All three cases pass after the fix.

## Validation
- `make unittest TEST='(TestEnvironmentSettings|ConvertFromEnvironmentPrivacyAndSecuritySettings|ConvertBlockedAttachments)'` passed, including existing explicit-security tests; environment-settings service coverage was 78.4%.
- Final focused product-update regression passed after mock cleanup.
- `POWER_PLATFORM_USE_CLI=true make acctest TEST='TestEnvironmentSettingsResource_StandardEnvironment_ProductUpdates$'` passed against real infrastructure in 401.94 seconds. The test created a disposable non-managed Dataverse sandbox, applied product-setting changes with omitted/null/ignored security, and completed Terraform cleanup.
- `make lint`: 0 issues.
- `make userdocs` and `git diff --check` completed successfully.